### PR TITLE
fix(Textarea): autoresize

### DIFF
--- a/src/runtime/components/forms/Textarea.vue
+++ b/src/runtime/components/forms/Textarea.vue
@@ -104,15 +104,19 @@ export default {
 
     const autoResize = () => {
       if (props.autoresize) {
+        textarea.value.rows = props.rows
+
         const styles = window.getComputedStyle(textarea.value)
         const paddingTop = parseInt(styles.paddingTop)
         const paddingBottom = parseInt(styles.paddingBottom)
         const padding = paddingTop + paddingBottom
-        const initialHeight = (parseInt(styles.height) - padding) / textarea.value.rows
-        const scrollHeight = textarea.value.scrollHeight - padding
-        const newRows = Math.ceil(scrollHeight / initialHeight)
+        const lineHeight = parseInt(styles.lineHeight)
+        const { scrollHeight } = textarea.value
+        const newRows = (scrollHeight - padding) / lineHeight
 
-        textarea.value.rows = newRows
+        if (newRows > props.rows) {
+          textarea.value.rows = newRows
+        }
       }
     }
 


### PR DESCRIPTION
Fixes nuxtlabs/nuxt.com#219

The main issue was that we didn't "reset" the height by forcing it to "auto" (or something equivalent) to force the refresh of `scrollHeight`.

The good old way was working but in some ways was breaking the padding a bit.
```js
textarea.style.height = 'auto'
textarea.style.height = `${textarea.scrollHeight}px`
```

So I took the same logic mixed with the current method:
```js
// init to a default height using rows
textarea.value.rows = props.rows

// once the `scrollHeight` is properly refreshed, compute pretty much the same way the needed rows
const styles = window.getComputedStyle(textarea.value)
const paddingTop = parseInt(styles.paddingTop)
const paddingBottom = parseInt(styles.paddingBottom)
const padding = paddingTop + paddingBottom
// use `lineHeight` to avoid unprecise pixel value which was happening with the previous method
const lineHeight = parseInt(styles.lineHeight)
const { scrollHeight } = textarea.value
const newRows = (scrollHeight - padding) / lineHeight

// make sure we don't go below the minimum request amount
if (newRows > props.rows) {
  textarea.value.rows = newRows
}
```