### PR TITLE
fix: Hover mode on Dropdown & Popover

### DIFF
--- a/src/runtime/components/elements/Dropdown.vue
+++ b/src/runtime/components/elements/Dropdown.vue
@@ -175,6 +175,12 @@ export default {
         const menuProvides = trigger.value?.$.provides
         const menuProvidesSymbols = Object.getOwnPropertySymbols(menuProvides)
         menuApi.value = menuProvidesSymbols.length && menuProvides[menuProvidesSymbols[0]]
+        // stop trigger click propagation on hover
+        menuApi.value.buttonRef.addEventListener('click', (e) => {
+          if (props.mode === 'hover') {
+            e.stopPropagation()
+          }
+        }, true)
       }, 0)
     })
 
@@ -195,7 +201,7 @@ export default {
       openTimeout = openTimeout || setTimeout(() => {
         menuApi.value.openMenu && menuApi.value.openMenu()
         openTimeout = null
-      }, 200)
+      }, 50)
     }
 
     function onMouseLeave () {
@@ -215,7 +221,7 @@ export default {
       closeTimeout = closeTimeout || setTimeout(() => {
         menuApi.value.closeMenu && menuApi.value.closeMenu()
         closeTimeout = null
-      }, 100)
+      }, 200)
     }
 
     return {

--- a/src/runtime/components/overlays/Popover.vue
+++ b/src/runtime/components/overlays/Popover.vue
@@ -100,6 +100,12 @@ export default {
         const popoverProvides = trigger.value?.$.provides
         const popoverProvidesSymbols = Object.getOwnPropertySymbols(popoverProvides)
         popoverApi.value = popoverProvidesSymbols.length && popoverProvides[popoverProvidesSymbols[0]]
+        // stop trigger click propagation on hover
+        popoverApi.value.button.addEventListener('click', (e) => {
+          if (props.mode === 'hover') {
+            e.stopPropagation()
+          }
+        }, true)
       }, 0)
     })
 
@@ -119,7 +125,7 @@ export default {
       openTimeout = openTimeout || setTimeout(() => {
         popoverApi.value.togglePopover && popoverApi.value.togglePopover()
         openTimeout = null
-      }, 200)
+      }, 50)
     }
 
     function onMouseLeave () {
@@ -138,7 +144,7 @@ export default {
       closeTimeout = closeTimeout || setTimeout(() => {
         popoverApi.value.closePopover && popoverApi.value.closePopover()
         closeTimeout = null
-      }, 100)
+      }, 200)
     }
 
     return {


### PR DESCRIPTION
Fixes nuxtlabs/nuxt.com#315

- Click properly stopped when `mode: 'hover'`
- Reduces opening delay to a fair time to still not be frustrating when moving cursor over accidentally
- Increases closing delay to be more forgiving when moving from trigger to container and vice-versa