### PR TITLE
fix(Avatar): truncate placeholder if too long

### DIFF
--- a/src/runtime/presets/default.ts
+++ b/src/runtime/presets/default.ts
@@ -322,7 +322,7 @@ const pills = {
 const avatar = {
   wrapper: 'relative inline-flex items-center justify-center',
   background: 'u-bg-gray-100',
-  placeholder: 'text-xs font-medium leading-none u-text-black',
+  placeholder: 'text-xs font-medium leading-none u-text-black truncate',
   size: {
     xxxs: 'h-4 w-4 text-xs',
     xxs: 'h-5 w-5 text-xs',


### PR DESCRIPTION
Before
![Screenshot 2022-06-07 at 13 34 13](https://user-images.githubusercontent.com/7547335/172369753-0e992c46-f7b0-4bd0-b9af-09812bb7464a.png)

After
![Screenshot 2022-06-07 at 13 33 44](https://user-images.githubusercontent.com/7547335/172369778-74d83d9e-e14d-4cd8-b018-ecacda37ad7c.png)

