### PR TITLE
fix(SelectCustom): avoid submitting to form when closing

### DIFF
--- a/src/runtime/components/forms/SelectCustom.vue
+++ b/src/runtime/components/forms/SelectCustom.vue
@@ -13,7 +13,7 @@
 
     <ComboboxButton ref="trigger" v-slot="{ disabled }" as="div">
       <slot :open="open" :disabled="disabled">
-        <button :class="selectCustomClass" :disabled="disabled">
+        <button :class="selectCustomClass" :disabled="disabled" type="button">
           <slot name="label">
             <span v-if="modelValue" class="block truncate">{{ modelValue[textAttribute] }}</span>
             <span v-else class="block truncate u-text-gray-400">{{ placeholder }}</span>


### PR DESCRIPTION
Fixes nuxtlabs/volta-app#1620

Make sure trigger button is of type `button` and not `submit`, avoiding to submit to parent form.

