### PR TITLE
chore: expose all types in index.ts

### DIFF
--- a/src/runtime/types/index.d.ts
+++ b/src/runtime/types/index.d.ts
@@ -1,3 +1,5 @@
+export * from './avatar'
 export * from './clipboard'
-export * from './toast'
+export * from './command-palette'
 export * from './popper'
+export * from './toast'


### PR DESCRIPTION
I had to import `Command` type in volta and thought it would be better to have all types properly exposed in the index.