### PR TITLE
chore: fix typescript errors

### DIFF
--- a/src/runtime/components/elements/Dropdown.vue
+++ b/src/runtime/components/elements/Dropdown.vue
@@ -132,9 +132,9 @@ const props = defineProps({
   }
 })
 
-const popperOptions = computed(() => defu({}, props.popperOptions, $ui.dropdown.popperOptions))
+const popperOptions = computed<PopperOptions>(() => defu({}, props.popperOptions, $ui.dropdown.popperOptions))
 
-const [trigger, container] = usePopper(popperOptions.value as PopperOptions)
+const [trigger, container] = usePopper(popperOptions.value)
 
 function resolveItemClass ({ active, disabled }: { active: boolean, disabled: boolean }) {
   return classNames(

--- a/src/runtime/components/forms/SelectCustom.vue
+++ b/src/runtime/components/forms/SelectCustom.vue
@@ -263,9 +263,9 @@ const props = defineProps({
 
 const emit = defineEmits(['update:modelValue'])
 
-const popperOptions = computed(() => defu({}, props.popperOptions, $ui.selectCustom.popperOptions))
+const popperOptions = computed<PopperOptions>(() => defu({}, props.popperOptions, $ui.selectCustom.popperOptions))
 
-const [trigger, container] = usePopper(popperOptions.value as PopperOptions)
+const [trigger, container] = usePopper(popperOptions.value)
 
 const query = ref('')
 const searchInput = ref<ComponentPublicInstance<HTMLElement>>()

--- a/src/runtime/components/overlays/ContextMenu.vue
+++ b/src/runtime/components/overlays/ContextMenu.vue
@@ -63,9 +63,9 @@ const isOpen = computed({
 
 const virtualElement = toRef(props, 'virtualElement')
 
-const popperOptions = computed(() => defu({}, props.popperOptions, $ui.contextMenu.popperOptions))
+const popperOptions = computed<PopperOptions>(() => defu({}, props.popperOptions, $ui.contextMenu.popperOptions))
 
-const [, container] = usePopper(popperOptions.value as PopperOptions, virtualElement)
+const [, container] = usePopper(popperOptions.value, virtualElement)
 </script>
 
 <script lang="ts">

--- a/src/runtime/components/overlays/Popover.vue
+++ b/src/runtime/components/overlays/Popover.vue
@@ -59,9 +59,9 @@ const props = defineProps({
   }
 })
 
-const popperOptions = computed(() => defu({}, props.popperOptions, $ui.popover.popperOptions))
+const popperOptions = computed<PopperOptions>(() => defu({}, props.popperOptions, $ui.popover.popperOptions))
 
-const [trigger, container] = usePopper(popperOptions.value as PopperOptions)
+const [trigger, container] = usePopper(popperOptions.value)
 
 const popoverApi: Ref<any> = ref(null)
 

--- a/src/runtime/components/overlays/Tooltip.vue
+++ b/src/runtime/components/overlays/Tooltip.vue
@@ -55,9 +55,9 @@ const props = defineProps({
   }
 })
 
-const popperOptions = computed(() => defu({}, props.popperOptions, $ui.tooltip.popperOptions))
+const popperOptions = computed<PopperOptions>(() => defu({}, props.popperOptions, $ui.tooltip.popperOptions))
 
-const [trigger, container] = usePopper(popperOptions.value as PopperOptions)
+const [trigger, container] = usePopper(popperOptions.value)
 
 const open = ref(false)
 </script>

--- a/src/runtime/composables/usePopper.ts
+++ b/src/runtime/composables/usePopper.ts
@@ -8,6 +8,7 @@ import offset from '@popperjs/core/lib/modifiers/offset'
 import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow'
 import computeStyles from '@popperjs/core/lib/modifiers/computeStyles'
 import eventListeners from '@popperjs/core/lib/modifiers/eventListeners'
+import type { PopperOptions } from '../types'
 
 export const createPopper = popperGenerator({
   defaultModifiers: [...defaultModifiers, offset, flip, preventOverflow, computeStyles, eventListeners]
@@ -24,7 +25,7 @@ export function usePopper ({
   resize = true,
   placement,
   strategy
-}, virtualReference: Ref<Object> = null) {
+}: PopperOptions, virtualReference: Ref<Object> = null) {
   const reference: Ref<HTMLElement> = ref(null)
   const popper: Ref<HTMLElement> = ref(null)
   const instance: Ref<Instance> = ref(null)


### PR DESCRIPTION
Fixes TS errors on `usePopper()` usage by filling up param type of the composable