### PR TITLE
fix(button): support `RouteLocationRaw` type for `to`

### DIFF
--- a/src/runtime/components/elements/Button.vue
+++ b/src/runtime/components/elements/Button.vue
@@ -15,7 +15,7 @@
 <script setup lang="ts">
 import { ref, computed, useSlots } from 'vue'
 import type { PropType } from 'vue'
-import type { RouteLocationNormalized } from 'vue-router'
+import type { RouteLocationNormalized, RouteLocationRaw } from 'vue-router'
 import NuxtLink from '#app/components/nuxt-link'
 import Icon from '../elements/Icon.vue'
 import { classNames } from '../../utils'
@@ -81,7 +81,7 @@ const props = defineProps({
     default: false
   },
   to: {
-    type: [String, Object] as PropType<string | RouteLocationNormalized>,
+    type: [String, Object] as PropType<string | RouteLocationNormalized | RouteLocationRaw>,
     default: null
   },
   target: {


### PR DESCRIPTION
The `to` prop is passed to NuxtLink and should support `RouteLocationRaw`