### PR TITLE
fix: default props for command palette

### DIFF
--- a/src/runtime/components/navigation/CommandPalette.vue
+++ b/src/runtime/components/navigation/CommandPalette.vue
@@ -104,7 +104,7 @@ const props = defineProps({
   },
   options: {
     type: Object as PropType<Partial<UseFuseOptions<Command>>>,
-    default: () => {}
+    default: () => ({})
   },
   autoselect: {
     type: Boolean,


### PR DESCRIPTION
`() => {}` actually returns `void` 😅