### PR TITLE
fix(Dropdown): better handle item click to preventDefault

### DIFF
--- a/src/runtime/components/elements/Dropdown.vue
+++ b/src/runtime/components/elements/Dropdown.vue
@@ -10,8 +10,13 @@
       <transition appear v-bind="transitionClass">
         <MenuItems :class="baseClass" static>
           <div v-for="(subItems, index) of items" :key="index" :class="groupClass">
-            <MenuItem v-for="(item, subIndex) of subItems" :key="subIndex" v-slot="{ active, disabled }" :disabled="item.disabled" @click="e => item.click?.(e)">
-              <Component v-bind="item" :is="(item.to && NuxtLink) || (item.click && 'button') || 'div'" :class="resolveItemClass({ active, disabled })">
+            <MenuItem v-for="(item, subIndex) of subItems" :key="subIndex" v-slot="{ active, disabled }" :disabled="item.disabled">
+              <Component
+                v-bind="omit(item, ['click'])"
+                :is="(item.to && NuxtLink) || (item.click && 'button') || 'div'"
+                :class="resolveItemClass({ active, disabled })"
+                @click="item.click"
+              >
                 <slot :name="item.slot" :item="item">
                   <Icon v-if="item.icon" :name="item.icon" :class="[itemIconClass, item.iconClass]" />
                   <Avatar v-if="item.avatar" v-bind="{ size: 'xxs', ...item.avatar }" :class="itemAvatarClass" />
@@ -45,7 +50,7 @@ import { defu } from 'defu'
 import NuxtLink from '#app/components/nuxt-link'
 import Icon from '../elements/Icon.vue'
 import Avatar from '../elements/Avatar.vue'
-import { classNames } from '../../utils'
+import { classNames, omit } from '../../utils'
 import { usePopper } from '../../composables/usePopper'
 import type { Avatar as AvatarType } from '../../types/avatar'
 import type { PopperOptions } from '../../types'


### PR DESCRIPTION
Fixes nuxtlabs/volta-app#1932

Now the mouse click can properly `preventDefault` to avoid closing the Dropdown.
Now the `enter` keyboard hit sends an `Event`, but as `trusted: false` so `preventDefault` has no effect.