### PR TITLE
chore: put back stop propagation on mode hover

### DIFF
--- a/src/runtime/components/elements/Dropdown.vue
+++ b/src/runtime/components/elements/Dropdown.vue
@@ -172,6 +172,13 @@ onMounted(() => {
     }
     const menuProvidesSymbols = Object.getOwnPropertySymbols(menuProvides)
     menuApi.value = menuProvidesSymbols.length && menuProvides[menuProvidesSymbols[0]]
+    // stop trigger click propagation on hover
+    menuApi.value?.buttonRef?.addEventListener('click', (e: Event) => {
+      // ignore links as it would break navigation
+      if (props.mode === 'hover' && (e.target as Element)?.tagName !== 'A') {
+        e.stopPropagation()
+      }
+    }, true)
   }, 200)
 })
 

--- a/src/runtime/components/overlays/Popover.vue
+++ b/src/runtime/components/overlays/Popover.vue
@@ -86,6 +86,13 @@ onMounted(() => {
     }
     const popoverProvidesSymbols = Object.getOwnPropertySymbols(popoverProvides)
     popoverApi.value = popoverProvidesSymbols.length && popoverProvides[popoverProvidesSymbols[0]]
+    // stop trigger click propagation on hover
+    popoverApi.value?.button?.addEventListener('click', (e: Event) => {
+      // ignore links as it would break navigation
+      if (props.mode === 'hover' && (e.target as Element)?.tagName !== 'A') {
+        e.stopPropagation()
+      }
+    }, true)
   }, 200)
 })
 


### PR DESCRIPTION
Proposal of "fix" for Popover and Dropdown hover mode with links.
We would not `stopPropagation` when the trigger is a link.