### PR TITLE
fix: avoid referring to complex types in props

### DIFF
--- a/src/runtime/components/overlays/ContextMenu.vue
+++ b/src/runtime/components/overlays/ContextMenu.vue
@@ -9,7 +9,7 @@
 </template>
 
 <script setup lang="ts">
-import type { Ref } from 'vue'
+import type { PropType, Ref } from 'vue'
 import { computed, toRef } from 'vue'
 import { defu } from 'defu'
 import type { VirtualElement } from '@popperjs/core'
@@ -47,7 +47,7 @@ const props = defineProps({
     default: () => $ui.contextMenu.transition
   },
   popperOptions: {
-    type: Object,
+    type: Object as PropType<PopperOptions>,
     default: () => ({})
   }
 })


### PR DESCRIPTION
to workaround the compatibility with nuxt-component-meta

Resolves nuxtlabs/studio-app#289

This is because `nuxt-component-meta` expanded the type entirely in the schema, creating 150MB of objects that have been duplicated a few times, causing the memory overflow.

The root fix should be done on the `nuxt-component-meta` side, but it takes some research. Workaround here to make it non-blocking.