### PR TITLE
fix(defineShortcuts): shift + alphabetic character handling

### DIFF
--- a/src/runtime/composables/defineShortcuts.ts
+++ b/src/runtime/composables/defineShortcuts.ts
@@ -32,7 +32,7 @@ export const defineShortcuts = (config: ShortcutsConfig) => {
   let shortcuts: Shortcut[] = []
 
   const onKeyDown = (e: KeyboardEvent) => {
-    const alphabeticalKey = /^[a-z]{1}$/.test(e.key)
+    const alphabeticalKey = /^[a-z]{1}$/i.test(e.key)
 
     for (const shortcut of shortcuts) {
       if (e.key.toLowerCase() !== shortcut.key) { continue }


### PR DESCRIPTION
There was an issue on checking if `shift` + an `alphabetic character key` was down.
The regex that checks the character wasn't ignoring case.
Should fix your issue.