### PR TITLE
Allow to use a sorting Function

### DIFF
--- a/src/runtime/components/data/Table.vue
+++ b/src/runtime/components/data/Table.vue
@@ -111,6 +111,10 @@ export default defineComponent({
       type: Object as PropType<Partial<Button>>,
       default: () => appConfig.ui.table.default.sortButton
     },
+    sortingFunction: {
+      type: Function,
+      default: null
+    },
     sortAscIcon: {
       type: String,
       default: () => appConfig.ui.table.default.sortAscIcon
@@ -154,7 +158,11 @@ export default defineComponent({
 
       const { column, direction } = sort.value
 
-      return orderBy(props.rows, column, direction)
+      if(!props.sortingFunction) {
+        return orderBy(props.rows, column, direction)
+      } else {
+        return props.sortingFunction(column, direction)
+      }
     })
 
     const selected = computed({


### PR DESCRIPTION
Related to https://github.com/nuxtlabs/ui/issues/399

My initial problem was the sorting process in the component was applied to the portion of data passed to the component, and not to the whole dataset.
In my own project, I managed to fix this by the updates in the PR, associated to a function I wrote in the parent component : 

```ts
const sortingFunction = (column, direction) => {
  return data.value.toSorted((a,b) => {
    if(direction === 'asc'){
      return (a[column] - b[column])
    } else if(direction === 'desc') {
      return (b[column] - a[column])
    }}).slice((page.value - 1)*pageCount.value, (page.value)*pageCount.value)
}
```
There's one problem I can't fix : the **computed property** used to paginate the table is redundant with the last line of my sortingFunction, which artificially recreates the processing applied by the computed property.
I don't know if it's a huge problem or not.