### PR TITLE
feat(SelectMenu): add loading state on async search

### DIFF
--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -105,14 +105,14 @@
               </div>
             </li>
           </component>
+          <p v-else-if="searchable && !filteredOptions.length && isSearching" :class="uiMenu.option.empty">
+            <slot name="option-empty-loading" :query="query">
+              {{ query ? `Searching for "${query}"` : "Searching for results..." }}
+            </slot>
+          </p>
           <p v-else-if="searchable && query && !filteredOptions.length" :class="uiMenu.option.empty">
             <slot name="option-empty" :query="query">
               No results for "{{ query }}".
-            </slot>
-          </p>
-          <p v-else-if="searchable && !filteredOptions.length && isSearching" :class="uiMenu.option.empty">
-            <slot name="option-empty-loading" :query="query">
-              Searching for results...
             </slot>
           </p>
         </component>


### PR DESCRIPTION
The SelectMenu component is missing a loading state that informs the user when a process is ongoing. I have added a simple implementation to exhibit this behaviour.

It doesn't use the ﻿`loading` prop since it disables the component and does not truly represent the anticipated state.

I chose to keep this functionality internal to the component and not expose it as a prop, as it seems more natural for the 
﻿`isSearching` state to activate as soon as the user begins typing, rather than at the expiration of the ﻿debounce delay.

Let me know what you think!

<table>
<tr>
 <td>Before</td>
 <td>After</td>
<tr>
 <td>

https://github.com/nuxtlabs/ui/assets/6144489/1fc60fdc-4c0e-431b-bdb9-3186ee3c45d5


</td>
 <td>

https://github.com/nuxtlabs/ui/assets/6144489/8f408488-928a-4bf3-b3f5-3c4f24e909bf



</td>
</table>