### PR TITLE
docs: add examples link in header

### DIFF
--- a/docs/components/Header.vue
+++ b/docs/components/Header.vue
@@ -52,6 +52,10 @@ const links = computed(() => {
     icon: 'i-heroicons-book-open-solid',
     to: '/getting-started'
   }, {
+    label: 'Examples',
+    icon: 'i-heroicons-square-3-stack-3d',
+    to: '/getting-started/examples'
+  }, {
     label: 'Playground',
     icon: 'i-simple-icons-stackblitz',
     to: 'https://stackblitz.com/edit/nuxt-ui?file=app.config.ts,app.vue',


### PR DESCRIPTION
## Add examples page to the header of the home page


<img width="1493" alt="image" src="https://github.com/nuxt/ui/assets/37311945/c7590a2f-7005-431c-be5c-080aecb47bef">


@benjamincanac 
