### PR TITLE
fix(Range): fix track pseudo-elements for mozilla

### DIFF
--- a/src/runtime/app.config.ts
+++ b/src/runtime/app.config.ts
@@ -654,13 +654,13 @@ const range = {
     }
   },
   track: {
-    base: '[&::-webkit-slider-runnable-track]:group-disabled:bg-opacity-50 [&::-moz-slider-runnable-track]:group-disabled:bg-opacity-50',
-    background: '[&::-webkit-slider-runnable-track]:bg-gray-200 [&::-moz-slider-runnable-track]:bg-gray-200 [&::-webkit-slider-runnable-track]:dark:bg-gray-700 [&::-moz-slider-runnable-track]:dark:bg-gray-700',
-    rounded: '[&::-webkit-slider-runnable-track]:rounded-lg [&::-moz-slider-runnable-track]:rounded-lg',
+    base: '[&::-webkit-slider-runnable-track]:group-disabled:bg-opacity-50 [&::-moz-range-track]:group-disabled:bg-opacity-50',
+    background: '[&::-webkit-slider-runnable-track]:bg-gray-200 [&::-moz-range-track]:bg-gray-200 [&::-webkit-slider-runnable-track]:dark:bg-gray-700 [&::-moz-range-track]:dark:bg-gray-700',
+    rounded: '[&::-webkit-slider-runnable-track]:rounded-lg [&::-moz-range-track]:rounded-lg',
     size: {
-      sm: '[&::-webkit-slider-runnable-track]:h-1 [&::-moz-slider-runnable-track]:h-1',
-      md: '[&::-webkit-slider-runnable-track]:h-2 [&::-moz-slider-runnable-track]:h-2',
-      lg: '[&::-webkit-slider-runnable-track]:h-3 [&::-moz-slider-runnable-track]:h-3'
+      sm: '[&::-webkit-slider-runnable-track]:h-1 [&::-moz-range-track]:h-1',
+      md: '[&::-webkit-slider-runnable-track]:h-2 [&::-moz-range-track]:h-2',
+      lg: '[&::-webkit-slider-runnable-track]:h-3 [&::-moz-range-track]:h-3'
     }
   },
   size: {


### PR DESCRIPTION
The `::-moz-slider-runnable-track` pseudo-element is not valid, so it should be replaced with [`::-moz-range-track`](https://developer.mozilla.org/en-US/docs/Web/CSS/::-moz-range-track).

This solves the issue with the track background in Firefox:

| **Before** | **After** |
|--------|--------|
| <img width="527" alt="Screen Shot 2023-09-09 at 01 58 07@2x" src="https://github.com/nuxt/ui/assets/6909744/cbd45a74-3061-480d-87b8-4b90dd9f2029"> | <img width="520" alt="Screen Shot 2023-09-09 at 02 06 26@2x" src="https://github.com/nuxt/ui/assets/6909744/612ba3fb-db7e-4244-b4d2-7a8efac85318"> |