### PR TITLE
fix(FormGroup): prevent input click from propagating to label

### DIFF
--- a/src/runtime/components/forms/FormGroup.vue
+++ b/src/runtime/components/forms/FormGroup.vue
@@ -8,7 +8,7 @@
 
       <p v-if="description" :class="[ui.description, size]">{{ description }}</p>
 
-      <div :class="[label ? ui.container : '']">
+      <div :class="[label ? ui.container : '']" @click="$event.preventDefault()">
         <slot v-bind="{ error }" />
 
         <p v-if="error && typeof error !== 'boolean'" :class="[ui.error, size]">{{ error }}</p>


### PR DESCRIPTION
Fixes #621 

The problem was caused by input click events being handled by the `<label>` which sets focus to the nested input. This creates issues with interactive components like SelectMenu, where selecting a value triggers both the component to close and the label to open it.

Here is a reproduction: https://stackblitz.com/edit/nuxt-ui-xj1xrv?file=app.vue