### PR TITLE
fix(Table): select all rows without select listener

### DIFF
--- a/src/runtime/components/data/Table.vue
+++ b/src/runtime/components/data/Table.vue
@@ -239,7 +239,8 @@ export default defineComponent({
           return
         }
 
-        attrs.onSelect ? onSelect(row) : selected.value.push(row)
+        // @ts-ignore
+        attrs.onSelect ? attrs.onSelect(row) : selected.value.push(row)
       })
     }
 

--- a/src/runtime/components/data/Table.vue
+++ b/src/runtime/components/data/Table.vue
@@ -239,7 +239,7 @@ export default defineComponent({
           return
         }
 
-        onSelect(row)
+        selected.value.push(row)
       })
     }
 

--- a/src/runtime/components/data/Table.vue
+++ b/src/runtime/components/data/Table.vue
@@ -239,7 +239,7 @@ export default defineComponent({
           return
         }
 
-        selected.value.push(row)
+        attrs.onSelect ? onSelect(row) : selected.value.push(row)
       })
     }
 


### PR DESCRIPTION
resolve #646 
If the table doesn't add select listener, `onSelect` will return. So just select all manually.