### PR TITLE
fix(Tabs): allow custom keys in `TabItem`

### DIFF
--- a/src/runtime/types/tabs.d.ts
+++ b/src/runtime/types/tabs.d.ts
@@ -3,4 +3,5 @@ export interface TabItem {
   slot?: string
   disabled?: boolean
   content?: string
+  [key: string]: any
 }


### PR DESCRIPTION
Docs shows examples with possible custom keys in the items objects, but type actually forbids it, so I've added it. https://ui.nuxt.com/navigation/tabs#slots