### PR TITLE
fix(Accordion): close other items in circular order

### DIFF
--- a/src/runtime/components/elements/Accordion.vue
+++ b/src/runtime/components/elements/Accordion.vue
@@ -111,8 +111,6 @@ export default defineComponent({
         .filter(index => index !== currentIndex)
         .reverse()
 
-      console.log(order)
-
       for (const index of order) {
         const close = buttonRefs.value[index]
         close()

--- a/src/runtime/components/elements/Accordion.vue
+++ b/src/runtime/components/elements/Accordion.vue
@@ -100,16 +100,23 @@ export default defineComponent({
 
     const buttonRefs = ref<Function[]>([])
 
-    function closeOthers (itemIndex: number) {
-      if (!props.items[itemIndex].closeOthers && props.multiple) {
+    function closeOthers (currentIndex: number) {
+      if (!props.items[currentIndex].closeOthers && props.multiple) {
         return
       }
 
-      buttonRefs.value.forEach((close, index) => {
-        if (index === itemIndex) return
+      const totalItems = buttonRefs.value.length
 
+      const order = Array.from({ length: totalItems }, (_, i) => (currentIndex + i) % totalItems)
+        .filter(index => index !== currentIndex)
+        .reverse()
+
+      console.log(order)
+
+      for (const index of order) {
+        const close = buttonRefs.value[index]
         close()
-      })
+      }
     }
 
     function onEnter (el: HTMLElement, done) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#626

### ❓ Type of change


- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)


### 📚 Description

The `closeOther` function, which closes items by index in ascending order (1, 2, 3, 4, etc.), can lead to a bug when users try to close items using the keyboard. To solve this issue, we need to close open items in a circular order. Here's an example:

1. When the `currentIndex` is `0`, close items in the order 2, 3, 4, `1`.
2. When the `currentIndex` is `1`, close items in the order 3, 4, 0, `2`.
3. When the `currentIndex` is `2`, close items in the order 4, 0, 1, `3`.
4. When the `currentIndex` is `3`, close items in the order 0, 1, 2, `4`.
5. When the `currentIndex` is `4`, close items in the order 1, 2, 3, `0`.

**Befor :**

https://github.com/nuxt/ui/assets/37311945/5906d35f-c6b2-455b-a8c1-f2b458cc4b8f

**After:** 

https://github.com/nuxt/ui/assets/37311945/e536d1cd-db05-4780-80be-d70f33f30e93


### 📝 Checklist

- [x] I have linked an issue or discussion.


Resolves #626
