### PR TITLE
feat(Table): add ability to custom style for  `td` and  `tr`

### DIFF
--- a/docs/components/content/examples/TableExampleStyle.vue
+++ b/docs/components/content/examples/TableExampleStyle.vue
@@ -1,0 +1,39 @@
+<script setup>
+const columns = [{
+  key: 'id',
+  label: '#'
+}, {
+  key: 'quantity',
+  label: 'quantity'
+}, {
+  key: 'name',
+  label: 'Name'
+}]
+
+const items = [{
+  id: 1,
+  name: 'Apple',
+  quantity: { value: 100, class: 'bg-green-200' }
+}, {
+  id: 2,
+  name: 'Orange',
+  quantity: { value: 0 },
+  class: 'bg-red-200 animate-pulse'
+}, {
+  id: 3,
+  name: 'Banana',
+  quantity: { value: 30, class: 'bg-green-200' }
+}, {
+  id: 4,
+  name: 'Mango',
+  quantity: { value: 5, class: 'bg-green-200' }
+}]
+</script>
+
+<template>
+  <UTable :rows="items" :columns="columns">
+    <template #quantity-data="{ row }">
+      {{ row.quantity.value }}
+    </template>
+  </UTable>
+</template>

--- a/docs/components/content/examples/TableExampleStyle.vue
+++ b/docs/components/content/examples/TableExampleStyle.vue
@@ -14,20 +14,20 @@ const columns = [{
 const items = [{
   id: 1,
   name: 'Apple',
-  quantity: { value: 100, class: 'bg-green-300 dark:bg-green-900' }
+  quantity: { value: 100, class: 'bg-green-500/50 dark:bg-green-400/50' }
 }, {
   id: 2,
   name: 'Orange',
   quantity: { value: 0 },
-  class: 'bg-red-300 dark:bg-red-900 animate-pulse'
+  class: 'bg-red-500/50 dark:bg-red-400/50 animate-pulse'
 }, {
   id: 3,
   name: 'Banana',
-  quantity: { value: 30, class: 'bg-green-300  dark:bg-green-900' }
+  quantity: { value: 30, class: 'bg-green-500/50 dark:bg-green-400/50' }
 }, {
   id: 4,
   name: 'Mango',
-  quantity: { value: 5, class: 'bg-green-300  dark:bg-green-900' }
+  quantity: { value: 5, class: 'bg-green-500/50 dark:bg-green-400/50' }
 }]
 </script>
 

--- a/docs/components/content/examples/TableExampleStyle.vue
+++ b/docs/components/content/examples/TableExampleStyle.vue
@@ -4,7 +4,8 @@ const columns = [{
   label: '#'
 }, {
   key: 'quantity',
-  label: 'quantity'
+  label: 'Quantity',
+  class: 'italic'
 }, {
   key: 'name',
   label: 'Name'
@@ -13,20 +14,20 @@ const columns = [{
 const items = [{
   id: 1,
   name: 'Apple',
-  quantity: { value: 100, class: 'bg-green-200' }
+  quantity: { value: 100, class: 'bg-green-300 dark:bg-green-900' }
 }, {
   id: 2,
   name: 'Orange',
   quantity: { value: 0 },
-  class: 'bg-red-200 animate-pulse'
+  class: 'bg-red-300 dark:bg-red-900 animate-pulse'
 }, {
   id: 3,
   name: 'Banana',
-  quantity: { value: 30, class: 'bg-green-200' }
+  quantity: { value: 30, class: 'bg-green-300  dark:bg-green-900' }
 }, {
   id: 4,
   name: 'Mango',
-  quantity: { value: 5, class: 'bg-green-200' }
+  quantity: { value: 5, class: 'bg-green-300  dark:bg-green-900' }
 }]
 </script>
 

--- a/docs/content/4.data/1.table.md
+++ b/docs/content/4.data/1.table.md
@@ -547,7 +547,7 @@ const columns = [{
 }, {
   key: 'quantity',
   label: 'Quantity',
-  class: 'italic' // Apply style to column header 
+  class: 'italic' // Apply style to column header
 }, {
   key: 'name',
   label: 'Name'
@@ -571,7 +571,6 @@ const items = [{
   name: 'Mango',
   quantity: { value: 5, class: 'bg-green-300  dark:bg-green-900' }
 }]
-</script>
 </script>
 
 <template>

--- a/docs/content/4.data/1.table.md
+++ b/docs/content/4.data/1.table.md
@@ -528,6 +528,8 @@ excludedProps:
 
 You can apply styles to `tr` and `td` elements by passing a `class` to rows.
 
+Also, you can apply styles to `th` elements by passing a `class` to columns.
+
 ::component-example
 ---
 padding: false
@@ -544,7 +546,8 @@ const columns = [{
   label: '#'
 }, {
   key: 'quantity',
-  label: 'quantity'
+  label: 'Quantity',
+  class: 'italic' // Apply style to column header 
 }, {
   key: 'name',
   label: 'Name'
@@ -553,24 +556,22 @@ const columns = [{
 const items = [{
   id: 1,
   name: 'Apple',
-  quantity: {
-    value: 100,
-    class: 'bg-green-200'  // Apply style to td 
-  }
+  quantity: { value: 100, class: 'bg-green-300 dark:bg-green-900' } // Apply style to td
 }, {
   id: 2,
   name: 'Orange',
   quantity: { value: 0 },
-  class: 'bg-red-200 animate-pulse' // Apply style to tr
+  class: 'bg-red-300 dark:bg-red-900 animate-pulse' // Apply style to tr
 }, {
   id: 3,
   name: 'Banana',
-  quantity: { value: 30, class: 'bg-green-200' }
+  quantity: { value: 30, class: 'bg-green-300  dark:bg-green-900' }
 }, {
   id: 4,
   name: 'Mango',
-  quantity: { value: 5, class: 'bg-green-200' }
+  quantity: { value: 5, class: 'bg-green-300  dark:bg-green-900' }
 }]
+</script>
 </script>
 
 <template>

--- a/docs/content/4.data/1.table.md
+++ b/docs/content/4.data/1.table.md
@@ -524,6 +524,65 @@ excludedProps:
 ---
 ::
 
+## Styling
+
+You can apply styles to `tr` and `td` elements by passing a `class` to rows.
+
+::component-example
+---
+padding: false
+---
+
+#default
+:table-example-style{class="w-full"}
+
+#code
+```vue
+<script setup>
+const columns = [{
+  key: 'id',
+  label: '#'
+}, {
+  key: 'quantity',
+  label: 'quantity'
+}, {
+  key: 'name',
+  label: 'Name'
+}]
+
+const items = [{
+  id: 1,
+  name: 'Apple',
+  quantity: {
+    value: 100,
+    class: 'bg-green-200'  // Apply style to td 
+  }
+}, {
+  id: 2,
+  name: 'Orange',
+  quantity: { value: 0 },
+  class: 'bg-red-200 animate-pulse' // Apply style to tr
+}, {
+  id: 3,
+  name: 'Banana',
+  quantity: { value: 30, class: 'bg-green-200' }
+}, {
+  id: 4,
+  name: 'Mango',
+  quantity: { value: 5, class: 'bg-green-200' }
+}]
+</script>
+
+<template>
+  <UTable :rows="items" :columns="columns">
+    <template #quantity-data="{ row }">
+      {{ row.quantity.value }}
+    </template>
+  </UTable>
+</template>
+```
+::
+
 ## Slots
 
 You can use slots to customize the header and data cells of the table.

--- a/docs/content/4.data/1.table.md
+++ b/docs/content/4.data/1.table.md
@@ -556,20 +556,20 @@ const columns = [{
 const items = [{
   id: 1,
   name: 'Apple',
-  quantity: { value: 100, class: 'bg-green-300 dark:bg-green-900' } // Apply style to td
+  quantity: { value: 100, class: 'bg-green-500/50 dark:bg-green-400/50' } // Apply style to td
 }, {
   id: 2,
   name: 'Orange',
   quantity: { value: 0 },
-  class: 'bg-red-300 dark:bg-red-900 animate-pulse' // Apply style to tr
+  class: 'bg-red-500/50 dark:bg-red-400/50 animate-pulse' // Apply style to tr
 }, {
   id: 3,
   name: 'Banana',
-  quantity: { value: 30, class: 'bg-green-300  dark:bg-green-900' }
+  quantity: { value: 30, class: 'bg-green-500/50 dark:bg-green-400/50' }
 }, {
   id: 4,
   name: 'Mango',
-  quantity: { value: 5, class: 'bg-green-300  dark:bg-green-900' }
+  quantity: { value: 5, class: 'bg-green-500/50 dark:bg-green-400/50' }
 }]
 </script>
 

--- a/src/runtime/components/data/Table.vue
+++ b/src/runtime/components/data/Table.vue
@@ -49,12 +49,12 @@
         </tr>
 
         <template v-else>
-          <tr v-for="(row, index) in rows" :key="index" :class="[ui.tr.base, isSelected(row) && ui.tr.selected, $attrs.onSelect && ui.tr.active]" @click="() => onSelect(row)">
+          <tr v-for="(row, index) in rows" :key="index" :class="[ui.tr.base, isSelected(row) && ui.tr.selected, $attrs.onSelect && ui.tr.active, row?.class]" @click="() => onSelect(row)">
             <td v-if="modelValue" :class="ui.checkbox.padding">
               <UCheckbox v-model="selected" :value="row" aria-label="Select row" @click.stop />
             </td>
 
-            <td v-for="(column, subIndex) in columns" :key="subIndex" :class="[ui.td.base, ui.td.padding, ui.td.color, ui.td.font, ui.td.size]">
+            <td v-for="(column, subIndex) in columns" :key="subIndex" :class="[ui.td.base, ui.td.padding, ui.td.color, ui.td.font, ui.td.size, row[column.key]?.class]">
               <slot :name="`${column.key}-data`" :column="column" :row="row" :index="index" :get-row-data="(defaultValue) => getRowData(row, column.key, defaultValue)">
                 {{ getRowData(row, column.key) }}
               </slot>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #736

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add the ability to apply custom styles to `tr` and `td` elements by passing a `class` to rows.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
