### PR TITLE
docs: update `ui.notifications` position configuration

### DIFF
--- a/docs/content/6.overlays/6.notification.md
+++ b/docs/content/6.overlays/6.notification.md
@@ -29,7 +29,7 @@ export default defineAppConfig({
   ui: {
     notifications: {
       // Show toasts at the top right of the screen
-      position: 'top-0 right-0'
+      position: 'top-0 right-0 bottom-auto'
     }
   }
 })

--- a/docs/content/6.overlays/6.notification.md
+++ b/docs/content/6.overlays/6.notification.md
@@ -29,7 +29,7 @@ export default defineAppConfig({
   ui: {
     notifications: {
       // Show toasts at the top right of the screen
-      position: 'top-0 right-0 bottom-auto'
+      position: 'top-0 bottom-auto'
     }
   }
 })


### PR DESCRIPTION
Resolves #785

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)

### 📚 Description

- Due to tailwind merge strategy introduced in #692, this caused `bottom-0` to be unexpectedly 'merged' in, following the use of the suggested `position: 'top-0 right-0'` ui configuration in the current doc.
