### PR TITLE
📝 better notifications position suggestion

### DIFF
--- a/docs/content/6.overlays/6.notification.md
+++ b/docs/content/6.overlays/6.notification.md
@@ -29,7 +29,7 @@ export default defineAppConfig({
   ui: {
     notifications: {
       // Show toasts at the top right of the screen for desktop
-      position: 'lg:justify-start'
+      position: 'lg:top-0 lg:justify-start'
     }
   }
 })

--- a/docs/content/6.overlays/6.notification.md
+++ b/docs/content/6.overlays/6.notification.md
@@ -28,8 +28,8 @@ This component will render the notifications at the bottom right of the screen b
 export default defineAppConfig({
   ui: {
     notifications: {
-      // Show toasts at the top right of the screen
-      position: 'top-0 bottom-auto'
+      // Show toasts at the top right of the screen for desktop
+      position: 'lg:justify-start'
     }
   }
 })


### PR DESCRIPTION
This component will render the notifications at the bottom right of the screen by default. You can configure its behavior in the `app.config.ts` through `ui.notifications`:

```ts [app.config.ts]
export default defineAppConfig({
  ui: {
    notifications: {
      // Show toasts at the top right of the screen for desktop
      position: 'lg:top-0 lg:justify-start'
    }
  }
})
```

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
https://github.com/nuxt/ui/issues/792
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
 better notification position suggestion #792

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
