### PR TITLE
fix(Table): enable sorting for nested column keys

### DIFF
--- a/src/runtime/components/data/Table.vue
+++ b/src/runtime/components/data/Table.vue
@@ -170,8 +170,8 @@ export default defineComponent({
       const { column, direction } = sort.value
 
       return props.rows.slice().sort((a, b) => {
-        const aValue = a[column]
-        const bValue = b[column]
+        const aValue = get(a, column)
+        const bValue = get(b, column)
 
         if (aValue === bValue) {
           return 0


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

While I was using the Table component I noticed that sorting did not work on nested column keys. I.e. when
defining a column like this:

```ts
{
  key: 'creditor.name',
  label: 'Creditor',
  sortable: true,
}
```
Since the get function is already being imported, I made this small change.


Edit: Forgot to mention performance. This definitely affects performance to some degree but could possibly
be negligible in practice.  

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
