### PR TITLE
fix(Table): prevent `@select` event call when selecting all rows

### DIFF
--- a/src/runtime/components/data/Table.vue
+++ b/src/runtime/components/data/Table.vue
@@ -250,12 +250,12 @@ export default defineComponent({
     function selectAllRows () {
       props.rows.forEach((row) => {
         // If the row is already selected, don't select it again
-        if (selected.value.some((item) => compare(toRaw(item), toRaw(row)))) {
+        if (isSelected(row)) {
           return
         }
 
         // @ts-ignore
-        $attrs.onSelect ? $attrs.onSelect(row) : selected.value.push(row)
+        selected.value.push(row)
       })
     }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

#646 #652

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Reverts some of the changes made in #652.

Currently when checking the table header checkbox while the onSelect listener is used, onSelect is executed for every
row instead of just pushing the values to the selected Ref. This is an issue when onSelect  is used as suggested in the Docs:

`You can use this to navigate to a page, open a modal or even to select the row manually.`

In my use case the modal linked to the last item in the rows array will always open ( or many modals at once if implemented differently) and for navigation this is similar. There is no good way to prevent this as only the row is passed to onSelect. I think the checkbox state should not trigger onSelect. The other way around its fine imo and up to the user.



Edit: May be a breaking change to some existing implementations.



### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
