### PR TITLE
feat(Pagination): add first and last page buttons

### DIFF
--- a/docs/components/content/examples/PaginationExampleFirstLastSlots.vue
+++ b/docs/components/content/examples/PaginationExampleFirstLastSlots.vue
@@ -1,0 +1,20 @@
+<script setup>
+const page = ref(1)
+const items = ref(Array(55))
+</script>
+
+<template>
+  <UPagination v-model="page" :total="items.length" :ui="{ rounded: 'first-of-type:rounded-s-md last-of-type:rounded-e-md' }">
+    <template #first="{ onClick }">
+      <UTooltip text="First page">
+        <UButton icon="i-heroicons-arrow-uturn-left" color="primary" :ui="{ rounded: 'rounded-full' }" class="rtl:[&_span:first-child]:rotate-180 me-2" @click="onClick" />
+      </UTooltip>
+    </template>
+
+    <template #last="{ onClick }">
+      <UTooltip text="Last page">
+        <UButton icon="i-heroicons-arrow-uturn-right-20-solid" color="primary" :ui="{ rounded: 'rounded-full' }" class="rtl:[&_span:last-child]:rotate-180 ms-2" @click="onClick" />
+      </UTooltip>
+    </template>
+  </UPagination>
+</template>

--- a/docs/content/5.navigation/3.pagination.md
+++ b/docs/content/5.navigation/3.pagination.md
@@ -91,7 +91,7 @@ excludedProps:
 ---
 ::
 
-### First / Last
+### First / Last :u-badge{label="New" class="align-middle ml-2 !rounded-full" variant="subtle"}
 
 Use the `first-button` and `last-button` props to customize the first and last buttons of the Pagination.
 

--- a/docs/content/5.navigation/3.pagination.md
+++ b/docs/content/5.navigation/3.pagination.md
@@ -126,7 +126,7 @@ Use the `#prev` and `#next` slots to set the content of the previous and next bu
 
 :component-example{component="pagination-example-prev-next-slots"}
 
-### `first` / `last`
+### `first` / `last` :u-badge{label="New" class="align-middle ml-2 !rounded-full" variant="subtle"}
 
 Use the `#first` and `#last` slots to set the content of the first and last buttons.
 

--- a/docs/content/5.navigation/3.pagination.md
+++ b/docs/content/5.navigation/3.pagination.md
@@ -39,6 +39,8 @@ Use the `size` prop to change the size of the buttons.
 baseProps:
   modelValue: 1
   total: 100
+  showLast: true
+  showFirst: true
 props:
   size: 'sm'
 ---
@@ -89,6 +91,33 @@ excludedProps:
 ---
 ::
 
+### First / Last
+
+Use the `first-button` and `last-button` props to customize the first and last buttons of the Pagination.
+
+::component-card
+---
+baseProps:
+  modelValue: 1
+  total: 100
+  showFirst: true
+  showLast: true
+props:
+  firstButton:
+    icon: 'i-heroicons-arrow-small-left-20-solid'
+    label: First
+    color: 'gray'
+  lastButton:
+    icon: 'i-heroicons-arrow-small-right-20-solid'
+    trailing: true
+    label: Last
+    color: 'gray'
+excludedProps:
+  - firstButton
+  - lastButton
+---
+::
+
 ## Slots
 
 ### `prev` / `next`
@@ -96,6 +125,12 @@ excludedProps:
 Use the `#prev` and `#next` slots to set the content of the previous and next buttons.
 
 :component-example{component="pagination-example-prev-next-slots"}
+
+### `first` / `last`
+
+Use the `#first` and `#last` slots to set the content of the first and last buttons.
+
+:component-example{component="pagination-example-first-last-slots"}
 
 ## Props
 

--- a/src/runtime/components/navigation/Pagination.vue
+++ b/src/runtime/components/navigation/Pagination.vue
@@ -1,10 +1,23 @@
 <template>
   <div :class="ui.wrapper" v-bind="attrs">
+    <slot name="first" :on-click="onClickFirst">
+      <UButton
+        v-if="firstButton && showFirst"
+        :size="size"
+        :disabled="!canGoFirstOrPrev"
+        :class="[ui.base, ui.rounded]"
+        v-bind="{ ...ui.default.firstButton, ...firstButton }"
+        :ui="{ rounded: '' }"
+        aria-label="First"
+        @click="onClickFirst"
+      />
+    </slot>
+
     <slot name="prev" :on-click="onClickPrev">
       <UButton
         v-if="prevButton"
         :size="size"
-        :disabled="!canGoPrev"
+        :disabled="!canGoFirstOrPrev"
         :class="[ui.base, ui.rounded]"
         v-bind="{ ...ui.default.prevButton, ...prevButton }"
         :ui="{ rounded: '' }"
@@ -28,12 +41,25 @@
       <UButton
         v-if="nextButton"
         :size="size"
-        :disabled="!canGoNext"
+        :disabled="!canGoLastOrNext"
         :class="[ui.base, ui.rounded]"
         v-bind="{ ...ui.default.nextButton, ...nextButton }"
         :ui="{ rounded: '' }"
         aria-label="Next"
         @click="onClickNext"
+      />
+    </slot>
+
+    <slot name="last" :on-click="onClickLast">
+      <UButton
+        v-if="firstButton && showLast"
+        :size="size"
+        :disabled="!canGoLastOrNext"
+        :class="[ui.base, ui.rounded]"
+        v-bind="{ ...ui.default.lastButton, ...lastButton }"
+        :ui="{ rounded: '' }"
+        aria-label="Last"
+        @click="onClickLast"
       />
     </slot>
   </div>
@@ -94,6 +120,22 @@ export default defineComponent({
       type: Object as PropType<Button>,
       default: () => config.default.inactiveButton as Button
     },
+    showFirst: {
+      type: Boolean,
+      default: false
+    },
+    showLast: {
+      type: Boolean,
+      default: false
+    },
+    firstButton: {
+      type: Object as PropType<Button>,
+      default: () => config.default.firstButton as Button
+    },
+    lastButton: {
+      type: Object as PropType<Button>,
+      default: () => config.default.lastButton as Button
+    },
     prevButton: {
       type: Object as PropType<Button>,
       default: () => config.default.prevButton as Button
@@ -124,6 +166,7 @@ export default defineComponent({
         return props.modelValue
       },
       set (value) {
+        console.log(value)
         emit('update:modelValue', value)
       }
     })
@@ -192,8 +235,24 @@ export default defineComponent({
       return items
     })
 
-    const canGoPrev = computed(() => currentPage.value > 1)
-    const canGoNext = computed(() => currentPage.value < pages.value.length)
+    const canGoFirstOrPrev = computed(() => currentPage.value > 1)
+    const canGoLastOrNext = computed(() => currentPage.value < pages.value.length)
+
+    function onClickFirst () {
+      if (!canGoFirstOrPrev.value) {
+        return
+      }
+
+      currentPage.value = 1
+    }
+
+    function onClickLast () {
+      if (!canGoLastOrNext.value) {
+        return
+      }
+
+      currentPage.value = pages.value.length
+    }
 
     function onClickPage (page: number | string) {
       if (typeof page === 'string') {
@@ -204,7 +263,7 @@ export default defineComponent({
     }
 
     function onClickPrev () {
-      if (!canGoPrev.value) {
+      if (!canGoFirstOrPrev.value) {
         return
       }
 
@@ -212,7 +271,7 @@ export default defineComponent({
     }
 
     function onClickNext () {
-      if (!canGoNext.value) {
+      if (!canGoLastOrNext.value) {
         return
       }
 
@@ -226,11 +285,13 @@ export default defineComponent({
       currentPage,
       pages,
       displayedPages,
-      canGoPrev,
-      canGoNext,
+      canGoLastOrNext,
+      canGoFirstOrPrev,
       onClickPrev,
       onClickNext,
-      onClickPage
+      onClickPage,
+      onClickFirst,
+      onClickLast
     }
   }
 })

--- a/src/runtime/components/navigation/Pagination.vue
+++ b/src/runtime/components/navigation/Pagination.vue
@@ -52,7 +52,7 @@
 
     <slot name="last" :on-click="onClickLast">
       <UButton
-        v-if="firstButton && showLast"
+        v-if="lastButton && showLast"
         :size="size"
         :disabled="!canGoLastOrNext"
         :class="[ui.base, ui.rounded]"

--- a/src/runtime/components/navigation/Pagination.vue
+++ b/src/runtime/components/navigation/Pagination.vue
@@ -166,7 +166,6 @@ export default defineComponent({
         return props.modelValue
       },
       set (value) {
-        console.log(value)
         emit('update:modelValue', value)
       }
     })

--- a/src/runtime/ui.config.ts
+++ b/src/runtime/ui.config.ts
@@ -861,6 +861,16 @@ export const pagination = {
     inactiveButton: {
       color: 'white'
     },
+    firstButton: {
+      color: 'white',
+      class: 'rtl:[&_span:first-child]:rotate-180',
+      icon: 'i-heroicons-chevron-double-left-20-solid'
+    },
+    lastButton: {
+      color: 'white',
+      class: 'rtl:[&_span:last-child]:rotate-180',
+      icon: 'i-heroicons-chevron-double-right-20-solid'
+    },
     prevButton: {
       color: 'white',
       class: 'rtl:[&_span:first-child]:rotate-180',


### PR DESCRIPTION
### 🔗 Linked issue
Resolves #837 

### ❓ Type of change
- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [X] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Added first and last page buttons to the pagination component to instantly jump to the last or first page. First and last page buttons are hidden by default and can be enabled with a boolean passed to the component.
![pagination](https://github.com/nuxt/ui/assets/57699643/45369322-88d6-4d54-a9ca-04d81c476b6f)

### 📝 Checklist
- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
