### PR TITLE
feat(Tooltip): adding option to show popper arrow

### DIFF
--- a/docs/components/content/examples/TooltipExampleArrow.vue
+++ b/docs/components/content/examples/TooltipExampleArrow.vue
@@ -1,0 +1,5 @@
+<template>
+  <UTooltip text="Tooltip example" :shortcuts="['⌘', 'O']" :popper="{ arrow: true }">
+    <UButton color="gray" label="Hover me" />
+  </UTooltip>
+</template>

--- a/docs/components/content/examples/TooltipExampleOffset.vue
+++ b/docs/components/content/examples/TooltipExampleOffset.vue
@@ -1,0 +1,5 @@
+<template>
+  <UTooltip text="Tooltip example" :shortcuts="['⌘', 'O']" :popper="{ offsetDistance: 16 }">
+    <UButton color="gray" label="Hover me" />
+  </UTooltip>
+</template>

--- a/docs/components/content/examples/TooltipExamplePlacement.vue
+++ b/docs/components/content/examples/TooltipExamplePlacement.vue
@@ -1,0 +1,5 @@
+<template>
+  <UTooltip text="Tooltip example" :shortcuts="['⌘', 'O']" :popper="{ placement: 'right' }">
+    <UButton color="gray" label="Hover me" />
+  </UTooltip>
+</template>

--- a/docs/content/6.overlays/4.tooltip.md
+++ b/docs/content/6.overlays/4.tooltip.md
@@ -26,6 +26,20 @@ slots:
   [Hello World!]{.italic}
 ::
 
+## Popper Options
+
+Use the `popper` prop to customize the tootip
+
+### Arrow
+
+:component-example{component="tooltip-example-arrow"}
+
+### Placement
+:component-example{component="tooltip-example-placement"}
+
+### Offset
+:component-example{component="tooltip-example-offset"}
+
 ## Props
 
 :component-props

--- a/docs/content/6.overlays/4.tooltip.md
+++ b/docs/content/6.overlays/4.tooltip.md
@@ -10,6 +10,22 @@ links:
 
 :component-example{component="tooltip-example"}
 
+## Popper
+
+Use the `popper` prop to customize the tootip.
+
+### Arrow
+
+:component-example{component="tooltip-example-arrow"}
+
+### Placement
+
+:component-example{component="tooltip-example-placement"}
+
+### Offset
+
+:component-example{component="tooltip-example-offset"}
+
 ## Slots
 
 ### `text`
@@ -25,20 +41,6 @@ slots:
 #text
   [Hello World!]{.italic}
 ::
-
-## Popper Options
-
-Use the `popper` prop to customize the tootip
-
-### Arrow
-
-:component-example{component="tooltip-example-arrow"}
-
-### Placement
-:component-example{component="tooltip-example-placement"}
-
-### Offset
-:component-example{component="tooltip-example-offset"}
 
 ## Props
 

--- a/src/runtime/components/overlays/Tooltip.vue
+++ b/src/runtime/components/overlays/Tooltip.vue
@@ -6,20 +6,21 @@
 
     <div v-if="open && !prevent" ref="container" :class="[ui.container, ui.width]">
       <Transition appear v-bind="ui.transition">
-        <div v-if="popper.arrow" data-popper-arrow :class="['invisible before:visible before:block before:rotate-45 before:z-[-1]', Object.values(ui.arrow)]" />
-      </Transition>
-      <Transition appear v-bind="ui.transition">
-        <div :class="[ui.base, ui.background, ui.color, ui.rounded, ui.shadow, ui.ring]">
-          <slot name="text">
-            {{ text }}
-          </slot>
+        <div>
+          <div v-if="popper.arrow" data-popper-arrow :class="['invisible before:visible before:block before:rotate-45 before:z-[-1]', Object.values(ui.arrow)]" />
 
-          <span v-if="shortcuts?.length" :class="ui.shortcuts">
-            <span class="mx-1 text-gray-700 dark:text-gray-200">&middot;</span>
-            <UKbd v-for="shortcut of shortcuts" :key="shortcut" size="xs">
-              {{ shortcut }}
-            </Ukbd>
-          </span>
+          <div :class="[ui.base, ui.background, ui.color, ui.rounded, ui.shadow, ui.ring]">
+            <slot name="text">
+              {{ text }}
+            </slot>
+  
+            <span v-if="shortcuts?.length" :class="ui.shortcuts">
+              <span class="mx-1 text-gray-700 dark:text-gray-200">&middot;</span>
+              <UKbd v-for="shortcut of shortcuts" :key="shortcut" size="xs">
+                {{ shortcut }}
+              </Ukbd>
+            </span>
+          </div>
         </div>
       </Transition>
     </div>

--- a/src/runtime/components/overlays/Tooltip.vue
+++ b/src/runtime/components/overlays/Tooltip.vue
@@ -6,6 +6,9 @@
 
     <div v-if="open && !prevent" ref="container" :class="[ui.container, ui.width]">
       <Transition appear v-bind="ui.transition">
+        <div v-if="popper.arrow" data-popper-arrow :class="['invisible before:visible before:block before:rotate-45 before:z-[-1]', Object.values(ui.arrow)]" />
+      </Transition>
+      <Transition appear v-bind="ui.transition">
         <div :class="[ui.base, ui.background, ui.color, ui.rounded, ui.shadow, ui.ring]">
           <slot name="text">
             {{ text }}
@@ -127,6 +130,8 @@ export default defineComponent({
       // eslint-disable-next-line vue/no-dupe-keys
       ui,
       attrs,
+      // eslint-disable-next-line vue/no-dupe-keys
+      popper,
       trigger,
       container,
       open,

--- a/src/runtime/composables/usePopper.ts
+++ b/src/runtime/composables/usePopper.ts
@@ -8,12 +8,13 @@ import offset from '@popperjs/core/lib/modifiers/offset'
 import preventOverflow from '@popperjs/core/lib/modifiers/preventOverflow'
 import computeStyles from '@popperjs/core/lib/modifiers/computeStyles'
 import eventListeners from '@popperjs/core/lib/modifiers/eventListeners'
+import arrowModifier from '@popperjs/core/lib/modifiers/arrow'
 import { unrefElement } from '@vueuse/core'
 import type { MaybeElement } from '@vueuse/core'
 import type { PopperOptions } from '../types/popper'
 
 export const createPopper = popperGenerator({
-  defaultModifiers: [...defaultModifiers, offset, flip, preventOverflow, computeStyles, eventListeners]
+  defaultModifiers: [...defaultModifiers, offset, flip, preventOverflow, computeStyles, eventListeners, arrowModifier]
 })
 
 export function usePopper ({
@@ -25,6 +26,7 @@ export function usePopper ({
   adaptive = true,
   scroll = true,
   resize = true,
+  arrow = false,
   placement,
   strategy
 }: PopperOptions, virtualReference?: Ref<Element | VirtualElement>) {
@@ -75,6 +77,10 @@ export function usePopper ({
               scroll,
               resize
             }
+          },
+          {
+            name: 'arrow',
+            enabled: arrow
           }
         ]
       }

--- a/src/runtime/types/popper.d.ts
+++ b/src/runtime/types/popper.d.ts
@@ -11,4 +11,5 @@ export interface PopperOptions {
   adaptive?: boolean
   scroll?: boolean
   resize?: boolean
+  arrow?: boolean
 }

--- a/src/runtime/ui.config.ts
+++ b/src/runtime/ui.config.ts
@@ -978,14 +978,14 @@ export const slideover = {
 
 export const tooltip = {
   wrapper: 'relative inline-flex',
-  container: 'z-20',
+  container: 'z-20 group',
   width: 'max-w-xs',
   background: 'bg-white dark:bg-gray-900',
   color: 'text-gray-900 dark:text-white',
   shadow: 'shadow',
   rounded: 'rounded',
   ring: 'ring-1 ring-gray-200 dark:ring-gray-800',
-  base: '[@media(pointer:coarse)]:hidden h-6 px-2 py-1 text-xs font-normal truncate',
+  base: '[@media(pointer:coarse)]:hidden h-6 px-2 py-1 text-xs font-normal truncate relative',
   shortcuts: 'hidden md:inline-flex flex-shrink-0 gap-0.5',
   // Syntax for `<Transition>` component https://vuejs.org/guide/built-ins/transition.html#css-based-transitions
   transition: {
@@ -998,6 +998,14 @@ export const tooltip = {
   },
   popper: {
     strategy: 'fixed'
+  },
+  arrow: {
+    base: 'before:w-2 before:h-2',
+    ring: 'before:ring-1 before:ring-gray-200 dark:before:ring-gray-800',
+    rounded: 'before:rounded-sm',
+    background: 'before:bg-white dark:before:bg-gray-900',
+    shadow: 'before:shadow',
+    placement: 'group-data-[popper-placement=right]:-left-1 group-data-[popper-placement=left]:-right-1 group-data-[popper-placement=top]:-bottom-1 group-data-[popper-placement=bottom]:-top-1'
   }
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
#836 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Added the option to include an arrow on the popper instance for the Tooltip component. It's optional, so no breaking changes.

Popper object prop doesn't have any documentation so I added a few examples on the Tooltip page.

Resolves #836 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
