### PR TITLE
feat(SelectMenu): Clear Search on Close

### DIFF
--- a/docs/content/3.forms/4.select-menu.md
+++ b/docs/content/3.forms/4.select-menu.md
@@ -83,6 +83,25 @@ Use the `debounce` prop to adjust the delay of the function.
 
 :component-example{component="select-menu-example-async-search" :componentProps='{"class": "w-full lg:w-40"}'}
 
+### Clear Search
+
+By default, the search query is cleared when the menu is closed. You can disable this behavior by setting the `clearSearchOnClose` prop to `false`.
+
+::component-card
+---
+baseProps:
+  class: 'w-full lg:w-40'
+  placeholder: 'Select a person'
+  options: ['Wade Cooper', 'Arlene Mccoy', 'Devon Webb', 'Tom Cook', 'Tanya Fox', 'Hellen Schmidt', 'Caroline Schultz', 'Mason Heaney', 'Claudie Smitham', 'Emil Schaefer']
+props:
+  searchable: true
+  clearSearchOnClose: false
+excludedProps:
+  searchable
+  clearSearchOnClose
+---
+::
+
 ### Create option
 
 Use the `creatable` prop to enable the creation of new options when the search doesn't return any results (only works with `searchable`).

--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -438,7 +438,7 @@ export default defineComponent({
     })
 
     function onUpdate (event: any) {
-      if (props.multiple || (!props.multple && props.clearSearchOnClose)) {
+      if (props.multiple || (!props.multiple && props.clearSearchOnClose)) {
         query.value = ''
       }
       emit('update:modelValue', event)

--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -438,7 +438,9 @@ export default defineComponent({
     })
 
     function onUpdate (event: any) {
-      query.value = ''
+      if (props.multiple || (!props.multple && props.clearSearchOnClose)) {
+        query.value = ''
+      }
       emit('update:modelValue', event)
       emit('change', event)
       emitFormChange()

--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -57,7 +57,6 @@
           <component :is="searchable ? 'HComboboxOptions' : 'HListboxOptions'" static :class="[uiMenu.base, uiMenu.divide, uiMenu.ring, uiMenu.rounded, uiMenu.shadow, uiMenu.background, uiMenu.padding, uiMenu.height]">
             <HComboboxInput
               v-if="searchable"
-              ref="searchInput"
               :display-value="() => query"
               name="q"
               :placeholder="searchablePlaceholder"
@@ -120,7 +119,7 @@
 
 <script lang="ts">
 import { ref, computed, toRef, watch, defineComponent } from 'vue'
-import type { PropType, ComponentPublicInstance } from 'vue'
+import type { PropType } from 'vue'
 import {
   Combobox as HCombobox,
   ComboboxButton as HComboboxButton,
@@ -310,6 +309,10 @@ export default defineComponent({
     uiMenu: {
       type: Object as PropType<Partial<typeof configMenu & { strategy?: Strategy }>>,
       default: undefined
+    },
+    clearSearchOnClose: {
+      type: Boolean,
+      default: () => configMenu.default.clearSearchOnClose
     }
   },
   emits: ['update:modelValue', 'open', 'close', 'change'],
@@ -324,7 +327,6 @@ export default defineComponent({
     const { emitFormBlur, emitFormChange, inputId, color, size, name } = useFormGroup(props, config)
 
     const query = ref('')
-    const searchInput = ref<ComponentPublicInstance<HTMLElement>>()
 
     const selectClass = computed(() => {
       const variant = ui.value.color?.[color.value as string]?.[props.variant as string] || ui.value.variant[props.variant]
@@ -427,17 +429,16 @@ export default defineComponent({
       if (value) {
         emit('open')
       } else {
+        if (props.clearSearchOnClose) {
+          query.value = ''
+        }
         emit('close')
         emitFormBlur()
       }
     })
 
     function onUpdate (event: any) {
-      if (query.value && searchInput.value?.$el) {
-        query.value = ''
-        // explicitly set input text because `ComboboxInput` `displayValue` is not reactive
-        searchInput.value.$el.value = ''
-      }
+      query.value = ''
       emit('update:modelValue', event)
       emit('change', event)
       emitFormChange()

--- a/src/runtime/ui.config.ts
+++ b/src/runtime/ui.config.ts
@@ -753,7 +753,8 @@ export const selectMenu = {
     placement: 'bottom-end'
   },
   default: {
-    selectedIcon: 'i-heroicons-check-20-solid'
+    selectedIcon: 'i-heroicons-check-20-solid',
+    clearSearchOnClose: true
   },
   arrow: {
     ..._popperArrow,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
#883 

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
Adding the prop `clearSearchOnClose` to the `SelectMenu` component. This removes the annoyance of a end user searching for an item, closing then reopening the select menu, and having their previous query still in the input box, causing them to manually clear the query before searching for something else.

This prop is set to `true` by default, but can disabled per component instance, or by changing the default property in the `app.config`

Resolves #883 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
