### PR TITLE
fix(module): use correct alias for `#ui-colors`

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -1,4 +1,3 @@
-import { dirname } from 'pathe'
 import { useNuxt, addTemplate } from '@nuxt/kit'
 
 export default function createTemplates (nuxt = useNuxt()) {
@@ -13,7 +12,7 @@ export default function createTemplates (nuxt = useNuxt()) {
     write: true
   })
 
-  nuxt.options.alias['#ui-colors'] = dirname(template.dst)
+  nuxt.options.alias['#ui-colors'] = template.dst
 
   nuxt.hook('prepare:types', (opts) => {
     opts.references.push({ path: typesTemplate.dst })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes an error showing up (reproducible in this repo in `docs/` folder along these lines):

```
ERROR  EISDIR: illegal operation on a directory, read /nuxt/ui/docs/.nuxt
```

The issue is that the alias was wrongly set to `buildDir` (`.nuxt`) rather than the actual file.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
