### PR TITLE
fix(FormGroup): remove inputId if the input is a fieldset

### DIFF
--- a/src/runtime/components/forms/RadioGroup.vue
+++ b/src/runtime/components/forms/RadioGroup.vue
@@ -99,7 +99,7 @@ export default defineComponent({
     const { ui, attrs } = useUI('radioGroup', toRef(props, 'ui'), config, toRef(props, 'class'))
     const { ui: uiRadio } = useUI('radio', toRef(props, 'uiRadio'), configRadio)
 
-    const { emitFormChange, color, name } = useFormGroup({ ...props, isFieldset: true } , config)
+    const { emitFormChange, color, name } = useFormGroup({ ...props, isFieldset: true }, config)
     provide('radio-group', { color, name })
 
     const onUpdate = (value: any) => {

--- a/src/runtime/components/forms/RadioGroup.vue
+++ b/src/runtime/components/forms/RadioGroup.vue
@@ -99,7 +99,7 @@ export default defineComponent({
     const { ui, attrs } = useUI('radioGroup', toRef(props, 'ui'), config, toRef(props, 'class'))
     const { ui: uiRadio } = useUI('radio', toRef(props, 'uiRadio'), configRadio)
 
-    const { emitFormChange, color, name } = useFormGroup(props, config)
+    const { emitFormChange, color, name } = useFormGroup({ ...props, isFieldset: true } , config)
     provide('radio-group', { color, name })
 
     const onUpdate = (value: any) => {

--- a/src/runtime/composables/useFormGroup.ts
+++ b/src/runtime/composables/useFormGroup.ts
@@ -3,10 +3,11 @@ import { type UseEventBusReturn, useDebounceFn } from '@vueuse/core'
 import type { FormEvent, FormEventType, InjectedFormGroupValue } from '../types/form'
 
 type InputProps = {
-  id?: string
+  id?: string | null
   size?: string | number | symbol
   color?: string
   name?: string
+  isFieldset?: boolean
 }
 
 export const useFormGroup = (inputProps?: InputProps, config?: any) => {
@@ -17,7 +18,7 @@ export const useFormGroup = (inputProps?: InputProps, config?: any) => {
     const inputId = ref(inputProps?.id)
 
     onMounted(() => {
-      inputId.value = inputProps?.id ?? formGroup?.inputId.value
+      inputId.value = inputProps?.isFieldset ? null : inputProps?.id ?? formGroup?.inputId.value
       if (formGroup) {
         // Updates for="..." attribute on label if inputProps.id is provided
         formGroup.inputId.value = inputId.value


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#906 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This removes the auto-generated ID on the FormGroup element for Inputs containing a fieldset (e.g. RadioGroup) since they introduce their own labels and don't bind to the one provided by the FormGroup.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
