### PR TITLE
fix(defineShortcuts): support minus `-` key

### DIFF
--- a/src/runtime/composables/defineShortcuts.ts
+++ b/src/runtime/composables/defineShortcuts.ts
@@ -32,6 +32,9 @@ interface Shortcut {
   // keyCode?: number
 }
 
+const chainedShortcutRegex = /^[^-]+.*-.*[^-]+$/
+const combinedShortcutRegex = /^[^_]+.*_.*[^_]+$/
+
 export const defineShortcuts = (config: ShortcutsConfig, options: ShortcutsOptions = {}) => {
   const { macOS, usingInput } = useShortcuts()
 
@@ -98,12 +101,15 @@ export const defineShortcuts = (config: ShortcutsConfig, options: ShortcutsOptio
     // Parse key and modifiers
     let shortcut: Partial<Shortcut>
 
-    if (key.includes('-') && key.includes('_')) {
-      console.trace('[Shortcut] Invalid key')
-      return null
+    if (key.includes('-') && key !== '-' && !key.match(chainedShortcutRegex)?.length) {
+      console.trace(`[Shortcut] Invalid key: "${key}"`)
     }
 
-    const chained = key.includes('-')
+    if (key.includes('_') && key !== '_' && !key.match(combinedShortcutRegex)?.length) {
+      console.trace(`[Shortcut] Invalid key: "${key}"`)
+    }
+
+    const chained = key.includes('-') && key !== '-'
     if (chained) {
       shortcut = {
         key: key.toLowerCase(),


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
Fixes #954 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Here is a fix to the `-` shortcut using `defineShortcuts`, which has been broken when chained shortcuts were introduced.

Though, it fixes a bug but leverages some issues on more advanced usecases (complex keys).
The current separators for combined and chained shortcuts are `_` and `-`. And their combination in the same key is quite complex.
We could image being able to handle `_-_` (two hits on `_`), or `e_-` (combination of `e` and `-`). A non-exhaustive list of shortcuts that should work IMO: `['e_-', 'e__', '_-_', '---', '_--']`.

But let's fix this current issue and potentially create a new one for advanced shortcuts, or wait to see if the demand actually exists.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
