### PR TITLE
fix(SelectMenu): fixes non-strings and nested searchable attributes

### DIFF
--- a/docs/components/content/examples/SelectMenuExampleSearchAttributes.vue
+++ b/docs/components/content/examples/SelectMenuExampleSearchAttributes.vue
@@ -1,0 +1,30 @@
+<script setup>
+const options = [
+  { id: 1, name: 'Wade Cooper', favoriteColors: ['red', 'yellow'] },
+  { id: 2, name: 'Arlene Mccoy', favoriteColors: ['blue', 'yellow'] },
+  { id: 3, name: 'Devon Webb', favoriteColors: ['black', 'blue'] },
+  { id: 4, name: 'Tom Cook', favoriteColors: ['yellow', 'blue'] },
+  { id: 5, name: 'Tanya Fox', favoriteColors: ['green', 'red'] }
+]
+
+const selected = ref(options[1])
+</script>
+
+<template>
+  <USelectMenu
+    v-model="selected"
+    :options="options"
+    class="w-full lg:w-96"
+    placeholder="Select an user"
+    searchable
+    searchable-placeholder="Search by name or favorite colors"
+    option-attribute="name"
+    by="id"
+    :search-attributes="['name', 'favoriteColors']"
+  >
+    <template #option="{ option: person }">
+      <span v-for="color in person.favoriteColors" :key="color.id" class="h-2 w-2 rounded-full mr-2" :class="`bg-${color}-500`" />
+      <span class="truncate">{{ person.name }}</span>
+    </template>
+  </USelectMenu>
+</template>

--- a/docs/components/content/examples/SelectMenuExampleSearchAttributes.vue
+++ b/docs/components/content/examples/SelectMenuExampleSearchAttributes.vue
@@ -2,9 +2,10 @@
 const options = [
   { id: 1, name: 'Wade Cooper', favoriteColors: ['red', 'yellow'] },
   { id: 2, name: 'Arlene Mccoy', favoriteColors: ['blue', 'yellow'] },
-  { id: 3, name: 'Devon Webb', favoriteColors: ['black', 'blue'] },
-  { id: 4, name: 'Tom Cook', favoriteColors: ['yellow', 'blue'] },
-  { id: 5, name: 'Tanya Fox', favoriteColors: ['green', 'red'] }
+  { id: 3, name: 'Devon Webb', favoriteColors: ['green', 'blue'] },
+  { id: 4, name: 'Tom Cook', favoriteColors: ['blue', 'red'] },
+  { id: 5, name: 'Tanya Fox', favoriteColors: ['green', 'red'] },
+  { id: 5, name: 'Hellen Schmidt', favoriteColors: ['green', 'yellow'] }
 ]
 
 const selected = ref(options[1])
@@ -23,7 +24,7 @@ const selected = ref(options[1])
     :search-attributes="['name', 'favoriteColors']"
   >
     <template #option="{ option: person }">
-      <span v-for="color in person.favoriteColors" :key="color.id" class="h-2 w-2 rounded-full mr-2" :class="`bg-${color}-500`" />
+      <span v-for="color in person.favoriteColors" :key="color.id" class="h-2 w-2 rounded-full" :class="`bg-${color}-500 dark:bg-${color}-400`" />
       <span class="truncate">{{ person.name }}</span>
     </template>
   </USelectMenu>

--- a/docs/content/3.forms/4.select-menu.md
+++ b/docs/content/3.forms/4.select-menu.md
@@ -116,6 +116,14 @@ props:
 ---
 ::
 
+#### Search Attributes
+
+Use the `search-attributes` with an array of property names to search on each option object.
+
+Nested attributes can be accessed using `dot.notation`. When the property value is an arra or object, these are cast to string so these can be searched within.
+
+:component-example{component="select-menu-example-search-attributes" :componentProps='{"class": "w-full lg:w-96"}'}
+
 ### Async search
 
 Pass a function to the `searchable` prop to customize the search behavior and filter options according to your needs. The function will receive the query as its first argument and should return an array.

--- a/docs/content/3.forms/4.select-menu.md
+++ b/docs/content/3.forms/4.select-menu.md
@@ -99,6 +99,20 @@ props:
 ---
 ::
 
+#### Search Attributes
+
+Use the `search-attributes` with an array of property names to search on each option object.
+
+Nested attributes can be accessed using `dot.notation`. When the property value is an array or object, these are cast to string so these can be searched within.
+
+::component-example
+---
+component: 'select-menu-example-search-attributes'
+componentProps:
+  class: 'w-full lg:w-96'
+---
+::
+
 #### Clear on close :u-badge{label="New" class="align-middle ml-2 !rounded-full" variant="subtle"}
 
 By default, the search query will be kept after the menu is closed. To clear it on close, set the `clear-search-on-close` prop.
@@ -116,13 +130,6 @@ props:
 ---
 ::
 
-#### Search Attributes
-
-Use the `search-attributes` with an array of property names to search on each option object.
-
-Nested attributes can be accessed using `dot.notation`. When the property value is an arra or object, these are cast to string so these can be searched within.
-
-:component-example{component="select-menu-example-search-attributes" :componentProps='{"class": "w-full lg:w-96"}'}
 
 ### Async search
 

--- a/docs/content/3.forms/4.select-menu.md
+++ b/docs/content/3.forms/4.select-menu.md
@@ -130,7 +130,6 @@ props:
 ---
 ::
 
-
 ### Async search
 
 Pass a function to the `searchable` prop to customize the search behavior and filter options according to your needs. The function will receive the query as its first argument and should return an array.

--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -140,7 +140,7 @@ import UAvatar from '../elements/Avatar.vue'
 import { useUI } from '../../composables/useUI'
 import { usePopper } from '../../composables/usePopper'
 import { useFormGroup } from '../../composables/useFormGroup'
-import { mergeConfig } from '../../utils'
+import { get, mergeConfig } from '../../utils'
 import { useInjectButtonGroup } from '../../composables/useButtonGroup'
 import type { SelectSize, SelectColor, SelectVariant, PopperOptions, Strategy } from '../../types'
 // @ts-expect-error
@@ -422,7 +422,13 @@ export default defineComponent({
 
       return (props.options as any[]).filter((option: any) => {
         return (props.searchAttributes?.length ? props.searchAttributes : [props.optionAttribute]).some((searchAttribute: any) => {
-          return ['string', 'number'].includes(typeof option) ? option.toString().search(new RegExp(query.value, 'i')) !== -1 : (option[searchAttribute] && option[searchAttribute].search(new RegExp(query.value, 'i')) !== -1)
+          if (['string', 'number'].includes(typeof option)) {
+            return String(option).search(new RegExp(query.value, 'i')) !== -1
+          }
+
+          const child = get(option, searchAttribute)
+
+          return child !== null && child !== undefined && String(child).search(new RegExp(query.value, 'i')) !== -1
         })
       })
     })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, `<USelectMenu>` attribute `search-attributes` doesn't work when the property to search is a non-string, or is nested.

This fixes that behavior:

- The attribute uses the `get` internal utility to find the nested attribute if it's not a string or number.
- It uses the `String` constructor to cast the Object/Array option to a string.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
