### PR TITLE
feat(SelectMenu): allows to clear search query on close

### DIFF
--- a/docs/content/3.forms/4.select-menu.md
+++ b/docs/content/3.forms/4.select-menu.md
@@ -99,7 +99,7 @@ props:
 ---
 ::
 
-#### Clear on close
+#### Clear on close :u-badge{label="New" class="align-middle ml-2 !rounded-full" variant="subtle"}
 
 By default, the search query will be kept after the menu is closed. To clear it on close, set the `clear-search-on-close` prop.
 

--- a/docs/content/3.forms/4.select-menu.md
+++ b/docs/content/3.forms/4.select-menu.md
@@ -101,7 +101,7 @@ props:
 
 #### Clear on close
 
-The search query is not cleared when the menu is closed. You can clear it by setting `clear-search-on-close` to `true`.
+By default, the search query will be kept after the menu is closed. To clear it on close, set the `clear-search-on-close` prop.
 
 ::component-card
 ---
@@ -113,23 +113,6 @@ baseProps:
   options: ['Wade Cooper', 'Arlene Mccoy', 'Devon Webb', 'Tom Cook', 'Tanya Fox', 'Hellen Schmidt', 'Caroline Schultz', 'Mason Heaney', 'Claudie Smitham', 'Emil Schaefer']
 props:
   clearSearchOnClose: true
----
-::
-
-#### Clear on update
-
-The search query is not cleared when an option is selected. You can clear it by setting `clear-search-on-update` to `true`.
-
-::component-card
----
-baseProps:
-  class: 'w-full lg:w-40'
-  placeholder: 'Select a person'
-  searchable: true
-  searchablePlaceholder: 'Search a person...'
-  options: ['Wade Cooper', 'Arlene Mccoy', 'Devon Webb', 'Tom Cook', 'Tanya Fox', 'Hellen Schmidt', 'Caroline Schultz', 'Mason Heaney', 'Claudie Smitham', 'Emil Schaefer']
-props:
-  clearSearchOnUpdate: true
 ---
 ::
 

--- a/docs/content/3.forms/4.select-menu.md
+++ b/docs/content/3.forms/4.select-menu.md
@@ -99,6 +99,40 @@ props:
 ---
 ::
 
+#### Clear on close
+
+The search query is not cleared when the menu is closed. You can clear it by setting `clear-search-on-close` to `true`.
+
+::component-card
+---
+baseProps:
+  class: 'w-full lg:w-40'
+  placeholder: 'Select a person'
+  searchable: true
+  searchablePlaceholder: 'Search a person...'
+  options: ['Wade Cooper', 'Arlene Mccoy', 'Devon Webb', 'Tom Cook', 'Tanya Fox', 'Hellen Schmidt', 'Caroline Schultz', 'Mason Heaney', 'Claudie Smitham', 'Emil Schaefer']
+props:
+  clearSearchOnClose: true
+---
+::
+
+#### Clear on update
+
+The search query is not cleared when an option is selected. You can clear it by setting `clear-search-on-update` to `true`.
+
+::component-card
+---
+baseProps:
+  class: 'w-full lg:w-40'
+  placeholder: 'Select a person'
+  searchable: true
+  searchablePlaceholder: 'Search a person...'
+  options: ['Wade Cooper', 'Arlene Mccoy', 'Devon Webb', 'Tom Cook', 'Tanya Fox', 'Hellen Schmidt', 'Caroline Schultz', 'Mason Heaney', 'Claudie Smitham', 'Emil Schaefer']
+props:
+  clearSearchOnUpdate: true
+---
+::
+
 ### Async search
 
 Pass a function to the `searchable` prop to customize the search behavior and filter options according to your needs. The function will receive the query as its first argument and should return an array.

--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -239,6 +239,10 @@ export default defineComponent({
       type: String,
       default: 'Search...'
     },
+    clearSearchOnClose: {
+      type: Boolean,
+      default: () => configMenu.default.clearOnClose
+    },
     debounce: {
       type: Number,
       default: 200
@@ -290,10 +294,6 @@ export default defineComponent({
     searchAttributes: {
       type: Array,
       default: null
-    },
-    clearSearchOnClose: {
-      type: Boolean,
-      default: false
     },
     popper: {
       type: Object as PropType<PopperOptions>,

--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -295,10 +295,6 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
-    clearSearchOnUpdate: {
-      type: Boolean,
-      default: false
-    },
     popper: {
       type: Object as PropType<PopperOptions>,
       default: () => ({})
@@ -437,12 +433,6 @@ export default defineComponent({
       }
     }
 
-    function clearOnChange () {
-      if (props.clearSearchOnUpdate) {
-        query.value = ''
-      }
-    }
-
     watch(container, (value) => {
       if (value) {
         emit('open')
@@ -454,8 +444,6 @@ export default defineComponent({
     })
 
     function onUpdate (event: any) {
-      clearOnChange()
-
       if (query.value && searchInput.value?.$el) {
         query.value = ''
         // explicitly set input text because `ComboboxInput` `displayValue` is not reactive

--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -86,17 +86,17 @@
                       aria-hidden="true"
                     />
                     <span v-else-if="option.chip" :class="uiMenu.option.chip.base" :style="{ background: `#${option.chip}` }" />
-  
+
                     <span class="truncate">{{ ['string', 'number'].includes(typeof option) ? option : option[optionAttribute] }}</span>
                   </slot>
                 </div>
-  
+
                 <span v-if="selected" :class="[uiMenu.option.selectedIcon.wrapper, uiMenu.option.selectedIcon.padding]">
                   <UIcon :name="selectedIcon" :class="uiMenu.option.selectedIcon.base" aria-hidden="true" />
                 </span>
               </li>
             </component>
-  
+
             <component :is="searchable ? 'HComboboxOption' : 'HListboxOption'" v-if="creatable && queryOption && !filteredOptions.length" v-slot="{ active, selected }" :value="queryOption" as="template">
               <li :class="[uiMenu.option.base, uiMenu.option.rounded, uiMenu.option.padding, uiMenu.option.size, uiMenu.option.color, active ? uiMenu.option.active : uiMenu.option.inactive]">
                 <div :class="uiMenu.option.container">
@@ -291,6 +291,14 @@ export default defineComponent({
       type: Array,
       default: null
     },
+    clearSearchOnClose: {
+      type: Boolean,
+      default: false
+    },
+    clearSearchOnUpdate: {
+      type: Boolean,
+      default: false
+    },
     popper: {
       type: Object as PropType<PopperOptions>,
       default: () => ({})
@@ -423,21 +431,37 @@ export default defineComponent({
       return query.value === '' ? null : { [props.optionAttribute]: query.value }
     })
 
+    function clearOnClose () {
+      if (props.clearSearchOnClose) {
+        query.value = ''
+      }
+    }
+
+    function clearOnChange () {
+      if (props.clearSearchOnUpdate) {
+        query.value = ''
+      }
+    }
+
     watch(container, (value) => {
       if (value) {
         emit('open')
       } else {
+        clearOnClose()
         emit('close')
         emitFormBlur()
       }
     })
 
     function onUpdate (event: any) {
+      clearOnChange()
+
       if (query.value && searchInput.value?.$el) {
         query.value = ''
         // explicitly set input text because `ComboboxInput` `displayValue` is not reactive
         searchInput.value.$el.value = ''
       }
+
       emit('update:modelValue', event)
       emit('change', event)
       emitFormChange()

--- a/src/runtime/ui.config.ts
+++ b/src/runtime/ui.config.ts
@@ -755,7 +755,8 @@ export const selectMenu = {
     placement: 'bottom-end'
   },
   default: {
-    selectedIcon: 'i-heroicons-check-20-solid'
+    selectedIcon: 'i-heroicons-check-20-solid',
+    clearOnClose: false
   },
   arrow: {
     ..._popperArrow,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #883

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [X] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, `<USelectMenu>` doesn't clear the search query when an option is selected, or when the menu is closed by selection.

This allows to clear it when the menu is closed, by either manually closing it or selecting an option, by using the attribute `clear-search-on-close`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
