### PR TITLE
feat(Textarea): add char counter

### DIFF
--- a/docs/components/content/examples/TextareaExampleSlotCounter.vue
+++ b/docs/components/content/examples/TextareaExampleSlotCounter.vue
@@ -1,0 +1,24 @@
+<script setup>
+const input = ref('I love NuxtUI!')
+
+const badgeColor = (remaining)=>{
+  switch (true) {
+    case remaining < 5: return 'red';
+    case remaining < 10: return 'amber';
+    case remaining < 15: return 'orange';
+    default: return 'green';
+  }
+}
+</script>
+
+<template>
+  <UTextarea v-model="input" :counter="15">
+    <template #counter="{focused, letterCount, maxValue}">
+      <UBadge :color="badgeColor(maxValue - letterCount)">
+      {{ maxValue - letterCount  }} Characters remaining!
+      
+      <UIcon class="ml-1" v-if="focused" name="i-heroicons-eye" />
+      </UBadge>
+    </template>
+  </UTextarea>
+</template>

--- a/docs/content/3.forms/2.textarea.md
+++ b/docs/content/3.forms/2.textarea.md
@@ -132,6 +132,31 @@ props:
 ---
 ::
 
+### Counter
+
+Use the `counter` prop to enable the counter and to set a maximum value. The counter will show if you are focusing the textarea or when setting `persistent-counter`. This is only visual and not validating the input.
+
+::component-card
+---
+baseProps:
+  modelValue: 'This is an example of the counter prop'
+props:
+  counter: '540'
+  persistentCounter: false
+excludedProps:
+  - counter
+
+---
+::
+
+## Slots
+
+### `counter`
+
+You can use the `#counter` slot to show a custom counter. It receives `focused` `letterCount` and `maxValue` of the textarea.
+
+:component-example{component="textarea-example-slot-counter"}
+
 ## Props
 
 :component-props

--- a/src/runtime/ui.config.ts
+++ b/src/runtime/ui.config.ts
@@ -685,6 +685,9 @@ export const formGroup = {
 
 export const textarea = {
   ...input,
+  counter: {
+    wrapper: 'absolute right-0'
+  },
   default: {
     size: 'sm',
     color: 'white',
@@ -1124,7 +1127,7 @@ export const pagination = {
     nextButton: {
       color: 'white',
       class: 'rtl:[&_span:last-child]:rotate-180',
-      icon: 'i-heroicons-chevron-right-20-solid'
+      icon: 'i-heroicons-chevron-right-20-solid '
     }
   }
 }
@@ -1160,26 +1163,6 @@ export const tabs = {
       rounded: 'rounded-md',
       shadow: ''
     }
-  }
-}
-
-export const breadcrumb = {
-  wrapper: 'relative',
-  ol: 'flex items-center gap-x-1.5',
-  li: 'flex items-center gap-x-1.5 text-gray-500 dark:text-gray-400 text-sm',
-  base: 'flex items-center gap-x-1.5 group font-semibold',
-  icon: {
-    base: 'flex-shrink-0 w-4 h-4',
-    active: '',
-    inactive: ''
-  },
-  divider: {
-    base: 'flex-shrink-0 w-5 h-5'
-  },
-  active: 'text-primary-500 dark:text-primary-400',
-  inactive: ' hover:text-gray-700 dark:hover:text-gray-200',
-  default: {
-    divider: 'i-heroicons-chevron-right-20-solid'
   }
 }
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #971 

### ❓ Type of change

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [X] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds a `counter` and `persistent-counter` property to the textarea to show the amount of typed chars. The `counter` prop can be a Boolean, Number or String. If set to a number or String the value will be parsed into the maxValue and displayed. The counter will show if the user is focusing the Textarea ([VueUse useFocus](https://vueuse.org/core/usefocus/)) or the `persistent-counter` Boolean is set to true. 

It also adds a slot for the counter passing the `focused, letterCount and maxValue` variables so that the user can fully customize the looks.

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [X] I have updated the documentation accordingly.
