### PR TITLE
fix(Breadcrumb): handle divider in rtl

### DIFF
--- a/src/runtime/ui.config/navigation/breadcrumb.ts
+++ b/src/runtime/ui.config/navigation/breadcrumb.ts
@@ -14,6 +14,6 @@ export default {
   active: 'text-primary-500 dark:text-primary-400',
   inactive: ' hover:text-gray-700 dark:hover:text-gray-200',
   default: {
-    divider: 'i-heroicons-chevron-right-20-solid'
+    divider: 'i-heroicons-chevron-right-20-solid rtl:i-heroicons-chevron-left-20-solid'
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds the left variant of the default divider icon in rtl 

**Before**
![before](https://github.com/nuxt/ui/assets/86230182/ef48d706-652f-4b38-aa8e-0250c4ae2c3d) 

**After**
![after](https://github.com/nuxt/ui/assets/86230182/eee5de6f-bf86-471b-bb97-2535ce0bd2f7)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
