### PR TITLE
feat(SelectMenu): allow creating option despite search

### DIFF
--- a/docs/content/3.forms/4.select-menu.md
+++ b/docs/content/3.forms/4.select-menu.md
@@ -148,7 +148,7 @@ componentProps:
 
 ### Create option
 
-Use the `creatable` prop to enable the creation of new options when the search doesn't return any results (only works with `searchable`).
+Use the `creatable` prop to enable the creation of new options when the search doesn't return any results (only works with `searchable`). However, if you want to create options despite search query (apart from exact match), you can set `creatable` as `'always'`.
 
 Try to search for something that doesn't exist in the example below.
 

--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -98,7 +98,7 @@
               </li>
             </component>
 
-            <component :is="searchable ? 'HComboboxOption' : 'HListboxOption'" v-if="creatable && queryOption && !filteredOptions.length" v-slot="{ active, selected }" :value="queryOption" as="template">
+            <component :is="searchable ? 'HComboboxOption' : 'HListboxOption'" v-if="showCreateOption" v-slot="{ active, selected }" :value="queryOption" as="template">
               <li :class="[uiMenu.option.base, uiMenu.option.rounded, uiMenu.option.padding, uiMenu.option.size, uiMenu.option.color, active ? uiMenu.option.active : uiMenu.option.inactive]">
                 <div :class="uiMenu.option.container">
                   <slot name="option-create" :option="queryOption" :active="active" :selected="selected">
@@ -249,7 +249,7 @@ export default defineComponent({
       default: 200
     },
     creatable: {
-      type: Boolean,
+      type: [Boolean, String] as PropType<boolean | 'always'>,
       default: false
     },
     placeholder: {
@@ -437,6 +437,31 @@ export default defineComponent({
       return query.value === '' ? null : { [props.optionAttribute]: query.value }
     })
 
+    const showCreateOption = computed(() =>
+      props.creatable
+      && queryOption.value
+      && (
+        props.creatable !== 'always'
+          ? !filteredOptions.value.length
+          : (
+            filteredOptions.value.length === 1
+              ? query.value !== (['string', 'number'].includes(typeof filteredOptions.value[0])
+                ? String(filteredOptions.value[0])
+                : (
+                  props.searchAttributes?.length
+                    ? props.searchAttributes
+                    : [props.optionAttribute]
+                ).some((searchAttribute: any) => {
+                  const child = get(filteredOptions.value[0], searchAttribute)
+
+                  return child !== null && child !== undefined && String(child) !== query.value
+                })
+              )
+              : true
+          )
+      )
+    )
+
     function clearOnClose () {
       if (props.clearSearchOnClose) {
         query.value = ''
@@ -490,6 +515,7 @@ export default defineComponent({
       trailingWrapperIconClass,
       filteredOptions,
       queryOption,
+      showCreateOption,
       query,
       onUpdate
     }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Say I want to create an option with the name `"enhance"`; the menu won't show it as a option as we do have a search result, though its a subset, not an exact.

![image](https://github.com/nuxt/ui/assets/56732164/eb7ca869-c69c-4cb6-90dc-1b0ffc1b868a)

This should allow creating such options.

(Will add preview)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
