### PR TITLE
fix(useShortcuts): include `contenteditable="plaintext-only"` elements in `usingInput`

### DIFF
--- a/src/runtime/composables/useShortcuts.ts
+++ b/src/runtime/composables/useShortcuts.ts
@@ -9,7 +9,9 @@ export const _useShortcuts = () => {
 
   const activeElement = useActiveElement()
   const usingInput = computed(() => {
-    const usingInput = !!(activeElement.value?.tagName === 'INPUT' || activeElement.value?.tagName === 'TEXTAREA' || activeElement.value?.contentEditable === 'true')
+    const contentEditable = activeElement.value?.contentEditable
+
+		return !!(activeElement.value?.tagName === 'INPUT' || activeElement.value?.tagName === 'TEXTAREA' || contentEditable === 'true' || contentEditable === 'plaintext-only')
 
     if (usingInput) {
       return ((activeElement.value as any)?.name as string) || true


### PR DESCRIPTION
### 🔗 Linked issue
No

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed that shortcuts can be used when a `contenteditable="plaintext-only"` element is focused.
[MDN Docs for contenteditable](https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/contenteditable)

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
