### PR TITLE
fix(Form): invalid errors when using `clear` by path

### DIFF
--- a/src/runtime/components/forms/Form.vue
+++ b/src/runtime/components/forms/Form.vue
@@ -152,7 +152,7 @@ export default defineComponent({
       },
       clear (path?: string) {
         if (path) {
-          errors.value = errors.value.filter((err) => err.path === path)
+          errors.value = errors.value.filter((err) => err.path !== path)
         } else {
           errors.value = []
         }


### PR DESCRIPTION


<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

[Issue #1164](https://github.com/nuxt/ui/issues/1164)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->
The current implementation of the clear function would set the errors ref to the result of a filter on the errors ref. However the test was checking if the errors path was equal to the path passed to the clear function. This results in all other form errors being cleared except for the error(s) that have the specified path, which is opposite of the docs say: "Clears form errors associated with a specific path. If no path is provided, clears all form errors.".

So I just set the filters test to filter all errors that has a path not equal to the path passed in to the clear function.

```ts

clear (path?: string) {
        if (path) {
          errors.value = errors.value.filter((err) => err.path !== path)
        } else {
          errors.value = []
        }
      }
```
Resolves #1164 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
