### PR TITLE
chore(Accordion): match event listener types

### DIFF
--- a/src/runtime/components/elements/Accordion.vue
+++ b/src/runtime/components/elements/Accordion.vue
@@ -119,7 +119,8 @@ export default defineComponent({
       })
     }
 
-    function onEnter (el: HTMLElement, done) {
+    function onEnter (_el: Element, done: () => void) {
+      const el = _el as HTMLElement
       el.style.height = '0'
       el.offsetHeight // Trigger a reflow, flushing the CSS changes
       el.style.height = el.scrollHeight + 'px'
@@ -127,16 +128,19 @@ export default defineComponent({
       el.addEventListener('transitionend', done, { once: true })
     }
 
-    function onBeforeLeave (el: HTMLElement) {
+    function onBeforeLeave (_el: Element) {
+      const el = _el as HTMLElement
       el.style.height = el.scrollHeight + 'px'
       el.offsetHeight // Trigger a reflow, flushing the CSS changes
     }
 
-    function onAfterEnter (el: HTMLElement) {
+    function onAfterEnter (_el: Element) {
+      const el = _el as HTMLElement
       el.style.height = 'auto'
     }
 
-    function onLeave (el: HTMLElement, done) {
+    function onLeave (_el: Element, done: () => void) {
+      const el = _el as HTMLElement
       el.style.height = '0'
 
       el.addEventListener('transitionend', done, { once: true })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as: Fixes #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds type assertions for these event listeners, needed for upgrade to vue 3.4.4. Discovered in https://github.com/nuxt/ecosystem-ci/actions/runs/7395824181/job/20124645666.

I would recommend adding something to confirm that `_el` is in fact an HTML element rather than just asserting it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
