### PR TITLE
fix(Slideover): handle translate in RTL mode

### DIFF
--- a/src/runtime/ui.config/overlays/slideover.ts
+++ b/src/runtime/ui.config/overlays/slideover.ts
@@ -22,8 +22,8 @@ export default {
   width: 'w-screen max-w-md',
   translate: {
     base: 'translate-x-0',
-    left: '-translate-x-full',
-    right: 'translate-x-full'
+    left: '-translate-x-full rtl:translate-x-full',
+    right: 'translate-x-full rtl:-translate-x-full'
   },
   // Syntax for `<TransitionRoot>` component https://headlessui.com/vue/transition#basic-example
   transition: {


### PR DESCRIPTION
Update the Slideover translate config to solve the translate animation directions in RTL.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #1258 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added RTL translate styles for the Slideover component to handle translation in rtl direction
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
