### PR TITLE
feat(config): add an option to disable global css styles

### DIFF
--- a/docs/content/1.getting-started/3.theming.md
+++ b/docs/content/1.getting-started/3.theming.md
@@ -438,3 +438,16 @@ export default defineAppConfig({
   }
 })
 ```
+
+## Global CSS styles
+
+By default, the module injects some global CSS styles, which are not specific to any component.
+You can disable these styles in your `nuxt.config.ts`.
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  ui: {
+    disableGlobalStyles: false
+  }
+})
+```

--- a/src/module.ts
+++ b/src/module.ts
@@ -54,6 +54,10 @@ export interface ModuleOptions {
   icons: CollectionNames[] | 'all' | IconsPluginOptions
 
   safelistColors?: string[]
+  /**
+   * Disables the global css styles added by the module.
+   */
+  disableGlobalStyles?: boolean
 }
 
 export default defineNuxtModule<ModuleOptions>({
@@ -68,7 +72,8 @@ export default defineNuxtModule<ModuleOptions>({
   defaults: {
     prefix: 'U',
     icons: ['heroicons'],
-    safelistColors: ['primary']
+    safelistColors: ['primary'],
+    disableGlobalStyles: false
   },
   async setup (options, nuxt) {
     const { resolve } = createResolver(import.meta.url)
@@ -80,7 +85,9 @@ export default defineNuxtModule<ModuleOptions>({
 
     nuxt.options.alias['#ui'] = runtimeDir
 
-    nuxt.options.css.push(resolve(runtimeDir, 'ui.css'))
+    if (!options.disableGlobalStyles) {
+      nuxt.options.css.push(resolve(runtimeDir, 'ui.css'))
+    }
 
     // @ts-ignore
     nuxt.hook('tailwindcss:config', function (tailwindConfig) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
This pull request introduces an option to disable the global CSS styles injected by the module. The primary motivation for this feature is the `::selection` style, which can be quite intrusive on some websites. However, upon considering whether to allow disabling only this specific option, I concluded that it would be more practical to allow the disabling of all styles.

I am of course open to suggestions. 😊

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
