### PR TITLE
feat(Form): handle multiple paths in `validate`

### DIFF
--- a/docs/content/3.forms/10.form.md
+++ b/docs/content/3.forms/10.form.md
@@ -206,7 +206,7 @@ componentProps:
   ::field{name="submit ()" type="Promise<void>"}
     Triggers form submission.
   ::
-  ::field{name="validate (path?: string, opts: { silent?: boolean })" type="Promise<T>"}
+  ::field{name="validate (path?: string | string[], opts: { silent?: boolean })" type="Promise<T>"}
     Triggers form validation. Will raise any errors unless `opts.silent` is set to true.
   ::
   ::field{name="clear (path?: string)" type="void"}

--- a/src/runtime/components/forms/Form.vue
+++ b/src/runtime/components/forms/Form.vue
@@ -89,13 +89,19 @@ export default defineComponent({
       return errs
     }
 
-    async function validate (path?: string, opts: { silent?: boolean } = { silent: false }) {
-      if (path) {
+    async function validate (path?: string | string[], opts: { silent?: boolean } = { silent: false }) {
+      let paths = path
+
+      if (path && !Array.isArray(path)) {
+        paths = [path]
+      }
+
+      if (paths) {
         const otherErrors = errors.value.filter(
-          (error) => error.path !== path
+          (error) => !paths.includes(error.path)
         )
         const pathErrors = (await getErrors()).filter(
-          (error) => error.path === path
+          (error) => paths.includes(error.path)
         )
         errors.value = otherErrors.concat(pathErrors)
       } else {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The primary motivation behind this change is to address a specific use case where multiple dynamic paths need validation for a multi-step form. In the original implementation, when a user progressed to the next step by clicking "continue," I needed to validate various steps asynchronously. The solution involved using await Promise.all(paths.map(path => form.value.validate(path))).

However, due to the asynchronous nature of the validate function, there was a potential issue where the final state of errors.value might not accurately reflect the expected validation results.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
