### PR TITLE
docs(Carousel): add `draggable="false"` to image elements

### DIFF
--- a/docs/components/content/examples/CarouselExample.vue
+++ b/docs/components/content/examples/CarouselExample.vue
@@ -11,6 +11,6 @@ const items = [
 
 <template>
   <UCarousel v-slot="{ item }" :items="items">
-    <img :src="item" width="300" height="400">
+    <img :src="item" width="300" height="400" draggable="false">
   </UCarousel>
 </template>

--- a/docs/components/content/examples/CarouselExampleArrows.vue
+++ b/docs/components/content/examples/CarouselExampleArrows.vue
@@ -11,6 +11,6 @@ const items = [
 
 <template>
   <UCarousel v-slot="{ item }" :items="items" :ui="{ item: 'basis-full' }" class="rounded-lg overflow-hidden" arrows>
-    <img :src="item" class="w-full">
+    <img :src="item" class="w-full" draggable="false">
   </UCarousel>
 </template>

--- a/docs/components/content/examples/CarouselExampleArrowsCenter.vue
+++ b/docs/components/content/examples/CarouselExampleArrowsCenter.vue
@@ -30,6 +30,6 @@ const items = [
     arrows
     class="w-64 mx-auto"
   >
-    <img :src="item" class="w-full">
+    <img :src="item" class="w-full" draggable="false">
   </UCarousel>
 </template>

--- a/docs/components/content/examples/CarouselExampleIndicators.vue
+++ b/docs/components/content/examples/CarouselExampleIndicators.vue
@@ -11,6 +11,6 @@ const items = [
 
 <template>
   <UCarousel v-slot="{ item }" :items="items" :ui="{ item: 'basis-full' }" class="rounded-lg overflow-hidden" indicators>
-    <img :src="item" class="w-full">
+    <img :src="item" class="w-full" draggable="false">
   </UCarousel>
 </template>

--- a/docs/components/content/examples/CarouselExampleIndicatorsSize.vue
+++ b/docs/components/content/examples/CarouselExampleIndicatorsSize.vue
@@ -11,6 +11,6 @@ const items = [
 
 <template>
   <UCarousel v-slot="{ item }" :items="items" :ui="{ item: 'basis-full md:basis-1/2 lg:basis-1/3' }" indicators class="rounded-lg overflow-hidden">
-    <img :src="item" class="w-full">
+    <img :src="item" class="w-full" draggable="false">
   </UCarousel>
 </template>

--- a/docs/components/content/examples/CarouselExampleSize.vue
+++ b/docs/components/content/examples/CarouselExampleSize.vue
@@ -11,6 +11,6 @@ const items = [
 
 <template>
   <UCarousel v-slot="{ item }" :items="items" :ui="{ item: 'basis-full md:basis-1/2 lg:basis-1/3' }">
-    <img :src="item" class="w-full">
+    <img :src="item" class="w-full" draggable="false">
   </UCarousel>
 </template>

--- a/docs/components/content/examples/CarouselExampleSizeCenter.vue
+++ b/docs/components/content/examples/CarouselExampleSizeCenter.vue
@@ -11,6 +11,6 @@ const items = [
 
 <template>
   <UCarousel v-slot="{ item }" :items="items" :ui="{ item: 'basis-full' }" class="w-64 mx-auto rounded-lg overflow-hidden">
-    <img :src="item" class="w-full">
+    <img :src="item" class="w-full" draggable="false">
   </UCarousel>
 </template>

--- a/docs/components/content/examples/CarouselExampleSizeFull.vue
+++ b/docs/components/content/examples/CarouselExampleSizeFull.vue
@@ -11,6 +11,6 @@ const items = [
 
 <template>
   <UCarousel v-slot="{ item }" :items="items" :ui="{ item: 'basis-full' }" class="rounded-lg overflow-hidden">
-    <img :src="item" class="w-full">
+    <img :src="item" class="w-full" draggable="false">
   </UCarousel>
 </template>

--- a/docs/components/content/examples/CarouselExampleSlotsDefault.vue
+++ b/docs/components/content/examples/CarouselExampleSlotsDefault.vue
@@ -22,7 +22,7 @@ const items = [{
   <UCarousel :items="items" :ui="{ item: 'w-full' }">
     <template #default="{ item, index }">
       <div class="text-center mx-auto">
-        <img :src="item.avatar.src" :alt="item.name" class="rounded-full w-48 h-48 mb-2">
+        <img :src="item.avatar.src" :alt="item.name" class="rounded-full w-48 h-48 mb-2" draggable="false">
 
         <p class="font-semibold">
           {{ index + 1 }}. {{ item.name }}

--- a/docs/components/content/examples/CarouselExampleSlotsIndicator.vue
+++ b/docs/components/content/examples/CarouselExampleSlotsIndicator.vue
@@ -23,7 +23,7 @@ const items = [
     class="w-64 mx-auto"
   >
     <template #default="{ item }">
-      <img :src="item" class="w-full">
+      <img :src="item" class="w-full" draggable="false">
     </template>
 
     <template #indicator="{ onClick, index, active }">

--- a/docs/components/content/examples/CarouselExampleSlotsPrevNext.vue
+++ b/docs/components/content/examples/CarouselExampleSlotsPrevNext.vue
@@ -20,7 +20,7 @@ const items = [
     class="w-64 mx-auto"
   >
     <template #default="{ item }">
-      <img :src="item" class="w-full">
+      <img :src="item" class="w-full" draggable="false">
     </template>
 
     <template #prev="{ onClick, disabled }">

--- a/docs/components/content/examples/CarouselExampleSnapEnd.vue
+++ b/docs/components/content/examples/CarouselExampleSnapEnd.vue
@@ -11,6 +11,6 @@ const items = [
 
 <template>
   <UCarousel v-slot="{ item }" :items="items" :ui="{ item: 'snap-end' }">
-    <img :src="item" width="200" height="300">
+    <img :src="item" width="200" height="300" draggable="false">
   </UCarousel>
 </template>

--- a/docs/components/content/examples/CarouselExampleSnapStart.vue
+++ b/docs/components/content/examples/CarouselExampleSnapStart.vue
@@ -11,6 +11,6 @@ const items = [
 
 <template>
   <UCarousel v-slot="{ item }" :items="items" :ui="{ item: 'snap-start' }">
-    <img :src="item" width="200" height="300">
+    <img :src="item" width="200" height="300" draggable="false">
   </UCarousel>
 </template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
Added `draggable="false"` to the image element to allow dragging the carousel with the mouse.

<!-- Why is this change required? What problem does it solve? -->
https://github.com/nuxt/ui/assets/33054273/f313e7bd-5d3f-4782-88de-99513732cae1

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
