### PR TITLE
feat(Textarea): add `maxrows` prop to restrict autoresize

### DIFF
--- a/docs/content/2.components/textarea.md
+++ b/docs/content/2.components/textarea.md
@@ -129,6 +129,7 @@ props:
   autoresize: true
   maxrows: 5
 ---
+::
 
 ### Resize
 

--- a/docs/content/2.components/textarea.md
+++ b/docs/content/2.components/textarea.md
@@ -119,6 +119,17 @@ props:
 ---
 ::
 
+Use the `maxrows` prop to set a maximum number of rows when autoresizing. If set to `0`, the Textarea will infinitely grow up.
+::component-card
+---
+baseProps:
+  placeholder: 'Search...'
+  modelValue: 'Here is an autoresize Textarea, write new lines to make the Textarea grow up at a maximum of 5 rows...'
+props:
+  autoresize: true
+  maxrows: 5
+---
+
 ### Resize
 
 Use the `resize` prop to enable the resize control.

--- a/src/runtime/components/forms/Textarea.vue
+++ b/src/runtime/components/forms/Textarea.vue
@@ -66,6 +66,10 @@ export default defineComponent({
       type: Number,
       default: 3
     },
+    maxrows: {
+      type: Number,
+      default: 0
+    },
     autoresize: {
       type: Boolean,
       default: false
@@ -160,7 +164,7 @@ export default defineComponent({
         const newRows = (scrollHeight - padding) / lineHeight
 
         if (newRows > props.rows) {
-          textarea.value.rows = newRows
+          textarea.value.rows = props.maxrows ? Math.min(newRows, props.maxrows) : newRows
         }
       }
     }


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In the current state, `Textarea` component with the `autoresize` prop will grow infinitely.
This pull request aims to add a new prop letting developers to define a maximum number of rows a `Textarea` can grow.
If set to 0 (which is also the default value), it will preserve the current `autoresize` behavior.

I didn't manage to start the local development environment for the docs because of the required nuxt ui pro license so I didn't check if my changes to `ui/docs/content/2.components/textarea.md` are correct.

https://github.com/nuxt/ui/assets/46727566/3d567605-8421-427b-89f9-993b07ede257


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
