### PR TITLE
docs(releases): Remove get started button on releases page

### DIFF
--- a/docs/components/Banner.vue
+++ b/docs/components/Banner.vue
@@ -1,11 +1,6 @@
 <script setup lang="ts">
-import { isAfter } from 'date-fns'
-
 const id = 'nuxt-ui-banner-1'
 const to = '/pro/pricing'
-const date = new Date('2024-02-25T20:00:00Z')
-
-const timeAgo = useTimeAgo(date)
 
 const hideBanner = () => {
   localStorage.setItem(id, 'true')
@@ -25,20 +20,6 @@ if (process.server) {
     }]
   })
 }
-
-onMounted(() => {
-  if (isAfter(new Date(), date)) {
-    hideBanner()
-    return
-  }
-
-  const interval = setInterval(() => {
-    if (isAfter(new Date(), date)) {
-      hideBanner()
-      clearInterval(interval)
-    }
-  }, 1000)
-})
 </script>
 
 <template>
@@ -52,8 +33,8 @@ onMounted(() => {
         <div class="lg:flex-1 hidden lg:flex items-center" />
 
         <p class="text-sm font-medium text-white dark:text-gray-900">
-          <UIcon name="i-heroicons-gift" class="w-5 h-5 align-top flex-shrink-0 pointer-events-none mr-2" />
-          <span class="font-semibold">Nuxt UI Pro v1.0</span> is out with dashboard components! Discount ends <span class="font-semibold">{{ timeAgo }}</span>.
+          <UIcon name="i-heroicons-rocket-launch" class="w-5 h-5 align-top flex-shrink-0 pointer-events-none mr-2" />
+          <span class="font-semibold">Nuxt UI Pro v1.0</span> is out with dashboard components!
         </p>
 
         <div class="flex items-center justify-end lg:flex-1">

--- a/docs/content/2.components/accordion.md
+++ b/docs/content/2.components/accordion.md
@@ -1,12 +1,12 @@
 ---
 description: Display togglable accordion panels.
 links:
-  - label: GitHub
-    icon: i-simple-icons-github
-    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/elements/Accordion.vue
   - label: Disclosure
     icon: i-simple-icons-headlessui
     to: 'https://headlessui.com/vue/disclosure'
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/elements/Accordion.vue
 ---
 
 ## Usage

--- a/docs/content/2.components/breadcrumb.md
+++ b/docs/content/2.components/breadcrumb.md
@@ -1,6 +1,10 @@
 ---
 title: Breadcrumb
 description: A list of links that indicate the current page's location within a navigational hierarchy.
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/navigation/Breadcrumb.vue
 ---
 
 ## Usage

--- a/docs/content/2.components/command-palette.md
+++ b/docs/content/2.components/command-palette.md
@@ -2,12 +2,12 @@
 title: CommandPalette
 description: Add a customizable command palette to your app.
 links:
-  - label: GitHub
-    icon: i-simple-icons-github
-    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/navigation/CommandPalette.vue
   - label: 'Combobox'
     icon: i-simple-icons-headlessui
     to: 'https://headlessui.com/vue/combobox'
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/navigation/CommandPalette.vue
 ---
 
 ## Usage

--- a/docs/content/2.components/dropdown.md
+++ b/docs/content/2.components/dropdown.md
@@ -1,12 +1,12 @@
 ---
 description: Display a list of actions in a dropdown menu.
 links:
-  - label: GitHub
-    icon: i-simple-icons-github
-    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/elements/Dropdown.vue
   - label: Menu
     icon: i-simple-icons-headlessui
     to: https://headlessui.com/vue/menu
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/elements/Dropdown.vue
 ---
 
 ## Usage

--- a/docs/content/2.components/input-menu.md
+++ b/docs/content/2.components/input-menu.md
@@ -2,12 +2,12 @@
 title: InputMenu
 description: Display an autocomplete input with real-time suggestions.
 links:
-  - label: GitHub
-    icon: i-simple-icons-github
-    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/forms/InputMenu.vue
   - label: 'Combobox'
     icon: i-simple-icons-headlessui
     to: 'https://headlessui.com/vue/combobox'
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/forms/InputMenu.vue
 ---
 
 ## Usage

--- a/docs/content/2.components/modal.md
+++ b/docs/content/2.components/modal.md
@@ -1,12 +1,12 @@
 ---
 description: Display a modal within your application.
 links:
-  - label: GitHub
-    icon: i-simple-icons-github
-    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/overlays/Modal.vue
   - label: 'Dialog'
     icon: i-simple-icons-headlessui
     to: 'https://headlessui.com/vue/dialog'
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/overlays/Modal.vue
 ---
 
 ## Usage

--- a/docs/content/2.components/popover.md
+++ b/docs/content/2.components/popover.md
@@ -1,12 +1,12 @@
 ---
 description: Display a non-modal dialog that floats around a trigger element.
 links:
-  - label: GitHub
-    icon: i-simple-icons-github
-    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/overlays/Popover.vue
   - label: 'Popover'
     icon: i-simple-icons-headlessui
     to: 'https://headlessui.com/vue/popover'
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/overlays/Popover.vue
 ---
 
 ## Usage

--- a/docs/content/2.components/select-menu.md
+++ b/docs/content/2.components/select-menu.md
@@ -2,12 +2,12 @@
 title: SelectMenu
 description: Display a select menu with advanced features.
 links:
-  - label: GitHub
-    icon: i-simple-icons-github
-    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/forms/SelectMenu.vue
   - label: 'Listbox'
     icon: i-simple-icons-headlessui
     to: 'https://headlessui.com/vue/listbox'
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/forms/SelectMenu.vue
 ---
 
 ## Usage

--- a/docs/content/2.components/slideover.md
+++ b/docs/content/2.components/slideover.md
@@ -1,12 +1,12 @@
 ---
 description: Display a dialog that slides in from the edge of the screen.
 links:
-  - label: GitHub
-    icon: i-simple-icons-github
-    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/overlays/Slideover.vue
   - label: 'Dialog'
     icon: i-simple-icons-headlessui
     to: 'https://headlessui.com/vue/dialog'
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/overlays/Slideover.vue
 ---
 
 ## Usage

--- a/docs/content/2.components/toggle.md
+++ b/docs/content/2.components/toggle.md
@@ -1,12 +1,12 @@
 ---
 description: Display a toggle field.
 links:
-  - label: GitHub
-    icon: i-simple-icons-github
-    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/forms/Toggle.vue
   - label: 'Switch'
     icon: i-simple-icons-headlessui
     to: 'https://headlessui.com/vue/switch'
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/dev/src/runtime/components/forms/Toggle.vue
 ---
 
 ## Usage

--- a/docs/content/releases.yml
+++ b/docs/content/releases.yml
@@ -3,11 +3,6 @@ title: '<span class="text-primary">Nuxt UI</span> Releases'
 head.title: Releases
 description: Follow the latest releases and updates happening on the nuxt/ui repository.
 links:
-  - label: Get Started
-    trailingIcon: i-heroicons-arrow-right-20-solid
-    to: /getting-started
-    size: md
-    color: black
   - label: View on GitHub
     icon: i-simple-icons-github
     to: https://github.com/nuxt/ui/releases

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "@nuxt/devtools": "^1.0.8",
     "@nuxt/eslint-config": "^0.2.0",
     "@nuxt/image": "^1.3.0",
-    "@nuxt/ui-pro": "npm:@nuxt/ui-pro-edge@1.0.0-28478433.ed477f1",
+    "@nuxt/ui-pro": "npm:@nuxt/ui-pro-edge@1.0.1-28480256.227c7d5",
     "@nuxtjs/fontaine": "^0.4.1",
     "@nuxtjs/google-fonts": "^3.1.3",
     "@nuxtjs/plausible": "^0.2.4",

--- a/docs/package.json
+++ b/docs/package.json
@@ -12,7 +12,7 @@
     "@nuxt/devtools": "^1.0.8",
     "@nuxt/eslint-config": "^0.2.0",
     "@nuxt/image": "^1.3.0",
-    "@nuxt/ui-pro": "npm:@nuxt/ui-pro-edge@1.0.0-28476869.809f447",
+    "@nuxt/ui-pro": "npm:@nuxt/ui-pro-edge@1.0.0-28478433.ed477f1",
     "@nuxtjs/fontaine": "^0.4.1",
     "@nuxtjs/google-fonts": "^3.1.3",
     "@nuxtjs/plausible": "^0.2.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0(rollup@3.29.4)
       '@nuxt/ui-pro':
-        specifier: npm:@nuxt/ui-pro-edge@1.0.0-28476869.809f447
-        version: /@nuxt/ui-pro-edge@1.0.0-28476869.809f447(nuxt@3.10.3)(rollup@3.29.4)(vite@5.1.4)(vue@3.4.19)
+        specifier: npm:@nuxt/ui-pro-edge@1.0.0-28478433.ed477f1
+        version: /@nuxt/ui-pro-edge@1.0.0-28478433.ed477f1(nuxt@3.10.3)(rollup@3.29.4)(vite@5.1.4)(vue@3.4.19)
       '@nuxtjs/fontaine':
         specifier: ^0.4.1
         version: 0.4.1(rollup@3.29.4)
@@ -1979,10 +1979,10 @@ packages:
       - supports-color
     dev: true
 
-  /@nuxt/ui-pro-edge@1.0.0-28476869.809f447(nuxt@3.10.3)(rollup@3.29.4)(vite@5.1.4)(vue@3.4.19):
-    resolution: {integrity: sha512-AAJ8FVVtcYbSBoGdu/di5g/L6nxSxssaSK9eZkvW0z58WumghzRX+7cOzNvogN7acaR0YCj3NNbe7JHFhEjLXQ==}
+  /@nuxt/ui-pro-edge@1.0.0-28478433.ed477f1(nuxt@3.10.3)(rollup@3.29.4)(vite@5.1.4)(vue@3.4.19):
+    resolution: {integrity: sha512-bDpIhCwPzQQ7l2J+lPzJ3a7IK509/fJUOhLERZDP0UiNMU8e1aA8Q1VaC8yOIc54/LT7tVFh9k2mjDm0qrjdpg==}
     dependencies:
-      '@nuxt/ui': 2.14.0(nuxt@3.10.3)(rollup@3.29.4)(vite@5.1.4)(vue@3.4.19)
+      '@nuxt/ui': 2.14.1(nuxt@3.10.3)(rollup@3.29.4)(vite@5.1.4)(vue@3.4.19)
       '@vueuse/core': 10.8.0(vue@3.4.19)
       defu: 6.1.4
       git-url-parse: 14.0.0
@@ -2016,8 +2016,8 @@ packages:
   /@nuxt/ui-templates@1.3.1:
     resolution: {integrity: sha512-5gc02Pu1HycOVUWJ8aYsWeeXcSTPe8iX8+KIrhyEtEoOSkY0eMBuo0ssljB8wALuEmepv31DlYe5gpiRwkjESA==}
 
-  /@nuxt/ui@2.14.0(nuxt@3.10.3)(rollup@3.29.4)(vite@5.1.4)(vue@3.4.19):
-    resolution: {integrity: sha512-WLjHv1zdJCmSU//wiigMXz7C4k0sroL8tCSNXnBRJAD5UIQiZ70gN+RFV9YRv4Ofv/soeYUgXZoiYTu4u3NHbA==}
+  /@nuxt/ui@2.14.1(nuxt@3.10.3)(rollup@3.29.4)(vite@5.1.4)(vue@3.4.19):
+    resolution: {integrity: sha512-yz6S05a37Q5PRskw1eXtRet4q8C463WMJFSu1Lw7zpKSl2yCyPJYegzwXqQV/fLo/NvM9j62XTuEy7+Xe7j0Kw==}
     engines: {node: '>=v16.20.2'}
     dependencies:
       '@egoist/tailwindcss-icons': 1.7.4(tailwindcss@3.4.1)
@@ -3132,6 +3132,7 @@ packages:
   /@trysound/sax@0.2.0:
     resolution: {integrity: sha512-L7z9BgrNEcYyUYtF+HaEfiS5ebkh9jXqbszz7pC0hRBPaatV0XjSD3+eHrpqFemQfgwiFF0QPIarnIihIDn7OA==}
     engines: {node: '>=10.13.0'}
+    requiresBuild: true
 
   /@tufjs/canonical-json@2.0.0:
     resolution: {integrity: sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA==}
@@ -4979,6 +4980,7 @@ packages:
   /commander@7.2.0:
     resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
     engines: {node: '>= 10'}
+    requiresBuild: true
 
   /commander@8.3.0:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
@@ -5288,6 +5290,7 @@ packages:
 
   /css-select@5.1.0:
     resolution: {integrity: sha512-nwoRF1rvRRnnCqqY7updORDsuqKzqYJ28+oSMaJMMgOauh3fvwHqMS7EZpIPqK8GL+g9mKxF1vP/ZjSeNjEVHg==}
+    requiresBuild: true
     dependencies:
       boolbase: 1.0.0
       css-what: 6.1.0
@@ -5321,6 +5324,7 @@ packages:
   /css-what@6.1.0:
     resolution: {integrity: sha512-HTUrgRJ7r4dsZKU6GjmpfRK1O76h97Z8MfS1G0FozR+oF2kG6Vfe8JE6zwrkbxigziPHinCJ+gCPjA9EaBDtRw==}
     engines: {node: '>= 6'}
+    requiresBuild: true
 
   /cssesc@3.0.0:
     resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
@@ -5391,6 +5395,7 @@ packages:
   /csso@5.0.5:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
+    requiresBuild: true
     dependencies:
       css-tree: 2.2.1
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -165,8 +165,8 @@ importers:
         specifier: ^1.3.0
         version: 1.3.0(rollup@3.29.4)
       '@nuxt/ui-pro':
-        specifier: npm:@nuxt/ui-pro-edge@1.0.0-28478433.ed477f1
-        version: /@nuxt/ui-pro-edge@1.0.0-28478433.ed477f1(nuxt@3.10.3)(rollup@3.29.4)(vite@5.1.4)(vue@3.4.19)
+        specifier: npm:@nuxt/ui-pro-edge@1.0.1-28480256.227c7d5
+        version: /@nuxt/ui-pro-edge@1.0.1-28480256.227c7d5(nuxt@3.10.3)(rollup@3.29.4)(vite@5.1.4)(vue@3.4.19)
       '@nuxtjs/fontaine':
         specifier: ^0.4.1
         version: 0.4.1(rollup@3.29.4)
@@ -1979,8 +1979,8 @@ packages:
       - supports-color
     dev: true
 
-  /@nuxt/ui-pro-edge@1.0.0-28478433.ed477f1(nuxt@3.10.3)(rollup@3.29.4)(vite@5.1.4)(vue@3.4.19):
-    resolution: {integrity: sha512-bDpIhCwPzQQ7l2J+lPzJ3a7IK509/fJUOhLERZDP0UiNMU8e1aA8Q1VaC8yOIc54/LT7tVFh9k2mjDm0qrjdpg==}
+  /@nuxt/ui-pro-edge@1.0.1-28480256.227c7d5(nuxt@3.10.3)(rollup@3.29.4)(vite@5.1.4)(vue@3.4.19):
+    resolution: {integrity: sha512-geKXY1Z28eRvKnJwGwnZLl+bJVNyXxWot+vCAwBJ3zIDX4hifGGU1KqSdO3okfoA6nKUyvz2J9GF0n1Zt/E86w==}
     dependencies:
       '@nuxt/ui': 2.14.1(nuxt@3.10.3)(rollup@3.29.4)(vite@5.1.4)(vue@3.4.19)
       '@vueuse/core': 10.8.0(vue@3.4.19)

--- a/renovate.json
+++ b/renovate.json
@@ -1,5 +1,5 @@
 {
   "extends": [
-    "@nuxtjs"
+    "github>nuxt/renovate-config-nuxt"
   ]
 }


### PR DESCRIPTION

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
Seems out of place to have a get started button on releases page, especially since user will normally be coming from nuxt ui docs IMHO.
Thanks for your work!
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
