### PR TITLE
docs(Notification): add `Notifications` props and config

### DIFF
--- a/docs/content/2.components/notification.md
+++ b/docs/content/2.components/notification.md
@@ -298,5 +298,5 @@ Slots defined in the `<UNotifications />` component are automatically passed dow
 
 ::tabs
   :component-preset{label="Notification"}
-  :component-preset{label="Notifications" slug="UNotifications"}
+  :component-preset{label="Notifications" slug="Notifications"}
 ::

--- a/docs/content/2.components/notification.md
+++ b/docs/content/2.components/notification.md
@@ -289,8 +289,14 @@ Slots defined in the `<UNotifications />` component are automatically passed dow
 
 ## Props
 
-:component-props
+::tabs
+  :component-props{label="Notification"}
+  :component-props{label="Notifications" slug="UNotifications"}
+::
 
 ## Config
 
-:component-preset
+::tabs
+  :component-preset{label="Notification"}
+  :component-preset{label="Notifications" slug="UNotifications"}
+::


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

[notification](https://ui.nuxt.com/components/notification) mentions about `UNotifications` but doesn't enlist it's props and config which is different than `UNotification`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
