### PR TITLE
docs(FormGroup): wrong icon name in `#help` slot

### DIFF
--- a/docs/content/2.components/form-group.md
+++ b/docs/content/2.components/form-group.md
@@ -236,7 +236,7 @@ Use the `#help` slot to set the custom content for help.
 ::component-card
 ---
 slots:
-  help: Here are some examples <UIcon name="i-heroicons-arrow-right-20-solid" />
+  help: Here are some examples <UIcon name="i-heroicons-information-circle" />
   default: <UInput model-value="benjamincanac" placeholder="you@example.com" />
 props:
   label: 'Email'


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
<img width="700" alt="image" src="https://github.com/nuxt/ui/assets/47675540/5c875677-a045-48a8-9228-2c69c86f4854">
the icon does not match the code example

### 📝 Checklist



- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
