### PR TITLE
fix(CommandPalette): Results groups order based on initial groups order

### DIFF
--- a/src/runtime/components/navigation/CommandPalette.vue
+++ b/src/runtime/components/navigation/CommandPalette.vue
@@ -278,7 +278,7 @@ export default defineComponent({
       return [
         ...groups,
         ...searchGroups
-      ]
+      ].sort((a, b) => props.groups.findIndex(item => item.key === a.key) - props.groups.findIndex(item => item.key === b.key))
     })
 
     const debouncedSearch = useDebounceFn(async () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently, in CommandPalette, the order of groups is determined based on the processing type (search or useFuse) rather than maintaining the initial order of groups. This can lead to confusion and inconsistency, especially when users expect groups to remain in the order they were initially arranged.

To address this issue, I propose implementing a fix that ensures the order of groups is preserved based on their initial arrangement. By prioritizing the original order, users will have a more intuitive experience.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
