### PR TITLE
feat(Table): pagination

### DIFF
--- a/src/runtime/components/data/Table.vue
+++ b/src/runtime/components/data/Table.vue
@@ -136,6 +136,10 @@ export default defineComponent({
       type: String,
       default: 'label'
     },
+    pagination: {
+      type: Object as PropType<{ pageCount: number, page: number }>,
+      default: () => ({})
+    },
     sort: {
       type: Object as PropType<{ column: string, direction: 'asc' | 'desc' }>,
       default: () => ({})
@@ -191,14 +195,20 @@ export default defineComponent({
 
     const savedSort = { column: sort.value.column, direction: null }
 
+    const page = toRef(() => props.pagination?.page ?? 1)
+    const pageCount = toRef(() => props.pagination?.pageCount ?? props.rows.length)
+
+    const start = computed(() => pageCount.value * (page.value - 1))
+    const end = computed(() => pageCount.value * page.value)
+
     const rows = computed(() => {
       if (!sort.value?.column || props.sortMode === 'manual') {
-        return props.rows
+        return props.rows.slice(start.value, end.value)
       }
 
       const { column, direction } = sort.value
-
-      return props.rows.slice().sort((a, b) => {
+      
+      return props.rows.slice(start.value, end.value).sort((a, b) => {
         const aValue = get(a, column)
         const bValue = get(b, column)
 

--- a/src/runtime/components/data/Table.vue
+++ b/src/runtime/components/data/Table.vue
@@ -208,14 +208,14 @@ export default defineComponent({
 
       const { column, direction } = sort.value
       
-      return props.rows.slice(start.value, end.value).sort((a, b) => {
+      return props.rows.toSorted((a, b) => {
         const aValue = get(a, column)
         const bValue = get(b, column)
 
         const sort = columns.value.find((col) => col.key === column)?.sort ?? defaultSort
 
         return sort(aValue, bValue, direction)
-      })
+      }).slice(start.value, end.value)
     })
 
     const selected = computed({


### PR DESCRIPTION
### 🔗 Linked issue
Resolves #399 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Client side pagination for `UTable` component.
Currently it's possible to paginate rows in parent component and passing computed (paginated) `rows` to `UTable`

But if `sort` prop is used alongside - the sorting is applied to already paginated (passed) rows.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
