### PR TITLE
chore: remove auto-import override

### DIFF
--- a/.nuxtrc
+++ b/.nuxtrc
@@ -1,2 +1,1 @@
-imports.autoImport=false
 typescript.includeWorkspace=true


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

https://github.com/nuxt/ecosystem-ci/actions/runs/8210272012/job/22462705680

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since https://github.com/unjs/nitro/pull/2226, new nitropack version will throw an error when type checking because we explicitly disable autoImports for all packages (including docs) in the workspace.

However, this should be safe to disable as the module uses new module-builder prepare mode which generates a `.nuxt/tsconfig.json` with autoImports already disabled (for root package) but doesn't affect playground + docs.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
