### PR TITLE
fix(SelectMenu): `filteredOptions` might be undefined

### DIFF
--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -105,12 +105,12 @@
                 </div>
               </li>
             </component>
-            <p v-else-if="searchable && query && !filteredOptions.length" :class="uiMenu.option.empty">
+            <p v-else-if="searchable && query && !filteredOptions?.length" :class="uiMenu.option.empty">
               <slot name="option-empty" :query="query">
                 No results for "{{ query }}".
               </slot>
             </p>
-            <p v-else-if="!filteredOptions.length" :class="uiMenu.empty">
+            <p v-else-if="!filteredOptions?.length" :class="uiMenu.empty">
               <slot name="empty" :query="query">
                 No options.
               </slot>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #1540 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In the `SelectMenu.vue` file, there's this snippet where it checks for `filteredOptions.length`

```vue
<p v-else-if="searchable && query && !filteredOptions.length" :class="uiMenu.option.empty">
  <slot name="option-empty" :query="query">
    No results for "{{ query }}".
  </slot>
</p>
<p v-else-if="!filteredOptions.length" :class="uiMenu.empty">
  <slot name="empty" :query="query">
    No options.
  </slot>
</p>
```

But because `filteredOptions` is a `computedAsync`, there's a possibility that the object itself is still undefined, thus checking for `.length` will not be possible.

```
SelectMenu.vue:652 Uncaught (in promise) TypeError: Cannot read properties of undefined (reading 'length')
    at SelectMenu.vue:652:52
    at Proxy.renderFnWithContext (vue.js?v=74953c0b:2286:13)
    at y (render.js?v=5a63436d:1:810)
    at A (render.js?v=5a63436d:1:517)
    at Proxy.<anonymous> (combobox.js?v=5a63436d:1:18470)
    at renderComponentRoot (vue.js?v=74953c0b:2345:17)
    at ReactiveEffect.componentUpdateFn [as fn] (vue.js?v=74953c0b:7457:46)
    at ReactiveEffect.run (vue.js?v=74953c0b:432:19)
    at instance.update (vue.js?v=74953c0b:7588:17)
    at setupRenderEffect (vue.js?v=74953c0b:7598:5)
```

To solve this issue we can check whether `filteredOptions` is undefined or not by using optional chaining.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
