### PR TITLE
feat(Toggle): add `loading` prop

### DIFF
--- a/docs/content/2.components/toggle.md
+++ b/docs/content/2.components/toggle.md
@@ -52,6 +52,19 @@ excludedProps:
 ---
 ::
 
+### Loading
+
+Use the `loading` prop to show a loading icon and disable the Toggle.
+
+Use the `loading-icon` prop to set a different icon or change it globally in `ui.toggle.default.loadingIcon`. Defaults to `i-heroicons-arrow-path-20-solid`.
+
+::component-card
+---
+props:
+  loading: true
+---
+::
+
 ### Disabled
 
 Use the `disabled` prop to disable the Toggle.

--- a/docs/content/2.components/toggle.md
+++ b/docs/content/2.components/toggle.md
@@ -52,7 +52,7 @@ excludedProps:
 ---
 ::
 
-### Loading
+### Loading :u-badge{label="New" class="align-middle ml-2 !rounded-full" variant="subtle"}
 
 Use the `loading` prop to show a loading icon and disable the Toggle.
 

--- a/src/runtime/components/forms/Toggle.vue
+++ b/src/runtime/components/forms/Toggle.vue
@@ -1,17 +1,16 @@
 <template>
-  <HSwitch
-    :id="inputId"
-    v-model="active"
-    :name="name"
-    :disabled="disabled"
-    :class="switchClass"
-    v-bind="attrs"
-  >
+  <HSwitch :id="inputId" v-model="active" :name="name" :disabled="disabled || loading" :class="switchClass"
+    v-bind="attrs">
     <span :class="containerClass">
-      <span v-if="onIcon" :class="[active ? ui.icon.active : ui.icon.inactive, ui.icon.base]" aria-hidden="true">
+      <span v-if="loading" :class="[ui.icon.active, ui.icon.base]" aria-hidden="true">
+        <UIcon :name="loadingIcon" :class="loadingIconClass" />
+      </span>
+      <span v-if="!loading && onIcon" :class="[active ? ui.icon.active : ui.icon.inactive, ui.icon.base]"
+        aria-hidden="true">
         <UIcon :name="onIcon" :class="onIconClass" />
       </span>
-      <span v-if="offIcon" :class="[active ? ui.icon.inactive : ui.icon.active, ui.icon.base]" aria-hidden="true">
+      <span v-if="!loading && offIcon" :class="[active ? ui.icon.inactive : ui.icon.active, ui.icon.base]"
+        aria-hidden="true">
         <UIcon :name="offIcon" :class="offIconClass" />
       </span>
     </span>
@@ -58,6 +57,10 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
+    loading: {
+      type: Boolean,
+      default: false
+    },
     onIcon: {
       type: String,
       default: () => config.default.onIcon
@@ -66,17 +69,21 @@ export default defineComponent({
       type: String,
       default: () => config.default.offIcon
     },
+    loadingIcon: {
+      type: String,
+      default: () => config.default.loadingIcon
+    },
     color: {
       type: String as PropType<ToggleColor>,
       default: () => config.default.color,
-      validator (value: string) {
+      validator(value: string) {
         return appConfig.ui.colors.includes(value)
       }
     },
     size: {
       type: String as PropType<ToggleSize>,
       default: () => config.default.size,
-      validator (value: string) {
+      validator(value: string) {
         return Object.keys(config.size).includes(value)
       }
     },
@@ -90,16 +97,16 @@ export default defineComponent({
     }
   },
   emits: ['update:modelValue', 'change'],
-  setup (props, { emit }) {
+  setup(props, { emit }) {
     const { ui, attrs } = useUI('toggle', toRef(props, 'ui'), config)
 
     const { emitFormChange, color, inputId, name } = useFormGroup(props)
 
     const active = computed({
-      get () {
+      get() {
         return props.modelValue
       },
-      set (value) {
+      set(value) {
         emit('update:modelValue', value)
         emitFormChange()
       }
@@ -137,6 +144,13 @@ export default defineComponent({
       )
     })
 
+    const loadingIconClass = computed(() => {
+      return twJoin(
+        ui.value.icon.size[props.size],
+        color.value && ui.value.icon.loading.replaceAll('{color}', color.value)
+      )
+    })
+
     provideUseId(() => useId())
 
     return {
@@ -150,7 +164,8 @@ export default defineComponent({
       switchClass,
       containerClass,
       onIconClass,
-      offIconClass
+      offIconClass,
+      loadingIconClass
     }
   }
 })

--- a/src/runtime/components/forms/Toggle.vue
+++ b/src/runtime/components/forms/Toggle.vue
@@ -1,16 +1,28 @@
 <template>
-  <HSwitch :id="inputId" v-model="active" :name="name" :disabled="disabled || loading" :class="switchClass"
-    v-bind="attrs">
+  <HSwitch
+    :id="inputId"
+    v-model="active"
+    :name="name"
+    :disabled="disabled || loading"
+    :class="switchClass"
+    v-bind="attrs"
+  >
     <span :class="containerClass">
       <span v-if="loading" :class="[ui.icon.active, ui.icon.base]" aria-hidden="true">
         <UIcon :name="loadingIcon" :class="loadingIconClass" />
       </span>
-      <span v-if="!loading && onIcon" :class="[active ? ui.icon.active : ui.icon.inactive, ui.icon.base]"
-        aria-hidden="true">
+      <span
+        v-if="!loading && onIcon"
+        :class="[active ? ui.icon.active : ui.icon.inactive, ui.icon.base]"
+        aria-hidden="true"
+      >
         <UIcon :name="onIcon" :class="onIconClass" />
       </span>
-      <span v-if="!loading && offIcon" :class="[active ? ui.icon.inactive : ui.icon.active, ui.icon.base]"
-        aria-hidden="true">
+      <span
+        v-if="!loading && offIcon"
+        :class="[active ? ui.icon.inactive : ui.icon.active, ui.icon.base]"
+        aria-hidden="true"
+      >
         <UIcon :name="offIcon" :class="offIconClass" />
       </span>
     </span>
@@ -76,14 +88,14 @@ export default defineComponent({
     color: {
       type: String as PropType<ToggleColor>,
       default: () => config.default.color,
-      validator(value: string) {
+      validator (value: string) {
         return appConfig.ui.colors.includes(value)
       }
     },
     size: {
       type: String as PropType<ToggleSize>,
       default: () => config.default.size,
-      validator(value: string) {
+      validator (value: string) {
         return Object.keys(config.size).includes(value)
       }
     },
@@ -97,16 +109,16 @@ export default defineComponent({
     }
   },
   emits: ['update:modelValue', 'change'],
-  setup(props, { emit }) {
+  setup (props, { emit }) {
     const { ui, attrs } = useUI('toggle', toRef(props, 'ui'), config)
 
     const { emitFormChange, color, inputId, name } = useFormGroup(props)
 
     const active = computed({
-      get() {
+      get () {
         return props.modelValue
       },
-      set(value) {
+      set (value) {
         emit('update:modelValue', value)
         emitFormChange()
       }

--- a/src/runtime/ui.config/forms/toggle.ts
+++ b/src/runtime/ui.config/forms/toggle.ts
@@ -49,11 +49,13 @@ export default {
       '2xl': 'h-6 w-6'
     },
     on: 'text-{color}-500 dark:text-{color}-400',
-    off: 'text-gray-400 dark:text-gray-500'
+    off: 'text-gray-400 dark:text-gray-500',
+    loading: 'animate-spin text-{color}-500 dark:text-{color}-400'
   },
   default: {
     onIcon: null,
     offIcon: null,
+    loadingIcon: 'i-heroicons-arrow-path-20-solid',
     color: 'primary',
     size: 'md'
   }


### PR DESCRIPTION
Use the loading prop to show a loading icon and disable the Toggle.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I want to change state of toggle by calling api, naive-ui has this one! 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
