### PR TITLE
fix(Divider): add `w-full` only on horizontal wrapper

### DIFF
--- a/src/runtime/ui.config/layout/divider.ts
+++ b/src/runtime/ui.config/layout/divider.ts
@@ -1,7 +1,7 @@
 export default {
   wrapper: {
     base: 'flex items-center align-center text-center',
-    horizontal: 'flex-row',
+    horizontal: 'w-full flex-row',
     vertical: 'flex-col'
   },
   container: {

--- a/src/runtime/ui.config/layout/divider.ts
+++ b/src/runtime/ui.config/layout/divider.ts
@@ -1,6 +1,6 @@
 export default {
   wrapper: {
-    base: 'flex items-center align-center text-center w-full',
+    base: 'flex items-center align-center text-center',
     horizontal: 'flex-row',
     vertical: 'flex-col'
   },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The existence of the w-full class in the wrapper base causes the divider to create extra spaces in vertical mode and in flex

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
