### PR TITLE
feat(RadioGroup): add `selected` to label slot props

### DIFF
--- a/src/runtime/components/forms/RadioGroup.vue
+++ b/src/runtime/components/forms/RadioGroup.vue
@@ -18,7 +18,7 @@
         @change="onUpdate(option.value)"
       >
         <template #label>
-          <slot name="label" v-bind="{ option }" />
+          <slot name="label" v-bind="{ option, selected: option.selected }" />
         </template>
       </URadio>
     </fieldset>
@@ -117,6 +117,10 @@ export default defineComponent({
       return get(option, props.optionAttribute, get(option, props.valueAttribute))
     }
 
+    const guessOptionSelected = (option: any) => {
+      return props.modelValue === guessOptionValue(option)
+    }
+
     const normalizeOption = (option: any) => {
       if (['string', 'number', 'boolean'].includes(typeof option)) {
         return {
@@ -128,7 +132,8 @@ export default defineComponent({
       return {
         ...option,
         value: guessOptionValue(option),
-        label: guessOptionText(option)
+        label: guessOptionText(option),
+        selected: guessOptionSelected(option)
       }
     }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
Resolves #1563 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The idea is to create a binding name 'selected' that returns a boolean if a radio is selected or not.
So I've created a new function named: guessOptionSelected(option: any) and passed it as a value of the key "selected" in the return of normalizeOptions function.
Then I've created a bind 'selected: option.selected' in the slot.

Code example:
![Screenshot 2024-03-29 at 19 09 53](https://github.com/nuxt/ui/assets/105924355/78d556e8-d847-4a21-9bee-b11be34f0be5)
Video example:
https://github.com/nuxt/ui/assets/105924355/e6a07932-a7d7-4fbf-bcba-c415fff1beb8


<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
