### PR TITLE
fix(Popover/Dropdown): prevent unintended closure on touchstart in mobile devices

### DIFF
--- a/src/runtime/components/elements/Dropdown.vue
+++ b/src/runtime/components/elements/Dropdown.vue
@@ -182,8 +182,8 @@ export default defineComponent({
       }
     })
 
-    function onTouchStart () {
-      if (!menuApi.value) {
+    function onTouchStart (event: TouchEvent) {
+      if (!event.cancelable || !menuApi.value) {
         return
       }
 

--- a/src/runtime/components/overlays/Popover.vue
+++ b/src/runtime/components/overlays/Popover.vue
@@ -154,8 +154,8 @@ export default defineComponent({
       }
     })
 
-    function onTouchStart () {
-      if (!popoverApi.value) {
+    function onTouchStart (event: TouchEvent) {
+      if (!event.cancelable || !popoverApi.value) {
         return
       }
 


### PR DESCRIPTION
### 🔗 Linked issue

A previous PR #1520 changed the event listener from @touchstart.prevent to @touchstart.passive to improve performance on mobile devices. This change introduced an unintended side effect where popovers and dropdowns unintentionally close on touch interaction.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull request addresses a bug where both popover and dropdown components would unintentionally close on touch interaction (specifically the @touchstart.passive event) on mobile devices. This behavior did not occur on desktops.

While a previous change aimed to improve mobile performance by switching to @touchstart.passive, it caused this unintended side effect.

The fix introduces a check for the event.cancelable property before closing the component. This ensures the component only closes on intentional touch interactions.

Benefits:
Maintains the performance improvement introduced by the previous change.
Improves user experience on touch devices by preventing accidental closure of popovers and dropdowns.

Resource:
[Easy fix for: '[Intervention] Ignored attempt to cancel a touchmove event with cancelable=false'](https://www.uriports.com/blog/easy-fix-for-intervention-ignored-attempt-to-cancel-a-touchmove-event-with-cancelable-false/)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
