### PR TITLE
feat(Slideover): add `resize` prop to support width adjustment

### DIFF
--- a/docs/components/content/examples/SlideoverExampleEnableResize.vue
+++ b/docs/components/content/examples/SlideoverExampleEnableResize.vue
@@ -1,0 +1,24 @@
+<script setup lang="ts">
+const isOpen = ref(false)
+</script>
+
+<template>
+  <div>
+    <UButton label="Open" @click="isOpen = true" />
+
+    <USlideover v-model="isOpen" :resize="{ enable: true }">
+      <UCard class="flex flex-col flex-1" :ui="{ body: { base: 'flex-1' }, ring: '', divide: 'divide-y divide-gray-100 dark:divide-gray-800' }">
+        <template #header>
+          <div class="flex items-center justify-between">
+            <h3 class="text-base font-semibold leading-6 text-gray-900 dark:text-white">
+              Slideover enable resize
+            </h3>
+            <UButton color="gray" variant="ghost" icon="i-heroicons-x-mark-20-solid" class="-my-1" @click="isOpen = false" />
+          </div>
+        </template>
+
+        <Placeholder class="h-full" />
+      </UCard>
+    </USlideover>
+  </div>
+</template>

--- a/docs/components/content/examples/SlideoverExampleEnableResizeOptions.vue
+++ b/docs/components/content/examples/SlideoverExampleEnableResizeOptions.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+const isOpen = ref(false)
+</script>
+
+<template>
+  <div>
+    <UButton label="Open" @click="isOpen = true" />
+
+    <USlideover v-model="isOpen" :resize="{ enable: true, width: 'lg', icon: 'i-heroicons-arrow-left-20-solid', size: 'lg' }" />
+  </div>
+</template>

--- a/docs/content/2.components/slideover.md
+++ b/docs/content/2.components/slideover.md
@@ -71,6 +71,21 @@ First of all, add the `USlideovers` component to your app, preferably inside `ap
 Then, you can use the `useSlideover` composable to control your slideovers within your app.
 
 :component-example{component="slideover-example-composable"}
+
+### Enable resize :u-badge{label="New" class="align-middle ml-2 !rounded-full" variant="subtle"}
+
+**Drag** or **click** (automatically decide whether to reach 50% or 100% of the screen according to the current width) to change the prop of the slideover body width
+
+Set the `resize` prop to enable it. Similarly, the aforementioned props can be employed in conjunction.
+
+:component-example{component="slideover-example-enable-resize"}
+
+Set the `resize.width` prop to establish the initial width of the Slideover's main section. Moreover, you can customize the drag icon and its size by set `resize.icon` and `resize.size` respectively.
+
+:component-example{component="slideover-example-enable-resize-options"}
+
+By adjusting the `resize.duration` and `resize.transition` props, you can modify the transition effects (Please refer to the [`@vueuse/core: useTransition()`](https://vueuse.org/core/useTransition/#usetransition) for further details). Additionally, setting `resize.percentage` allows you to change the proportion at which the width automatically snaps while adjusting, aligning it seamlessly to full screen.
+
 ## Props
 
 :component-props

--- a/src/runtime/composables/useSlideover.ts
+++ b/src/runtime/composables/useSlideover.ts
@@ -1,8 +1,8 @@
-import { ref, inject } from 'vue'
-import type { ShallowRef, Component, InjectionKey } from 'vue'
-import { createSharedComposable } from '@vueuse/core'
+import { ref, inject, computed, reactive } from 'vue'
+import type { ShallowRef, Component, InjectionKey, Ref, WritableComputedRef, ComputedRef } from 'vue'
+import { createSharedComposable, useWindowSize, useTransition, useTimeoutFn, useEventListener } from '@vueuse/core'
 import type { ComponentProps } from '../types/component'
-import type { Slideover, SlideoverState } from '../types/slideover'
+import type { Slideover, SlideoverState, Arguments } from '../types/slideover'
 
 export const slidOverInjectionKey: InjectionKey<ShallowRef<SlideoverState>> = Symbol('nuxt-ui.slideover')
 
@@ -61,4 +61,138 @@ function _useSlideover () {
   }
 }
 
+function _useResizeSlideover (A: Arguments) {
+
+  if (!A._enable) return
+
+  const resize: {
+    initWidth: number,
+    isResizing: boolean,
+    isClick: boolean,
+    newWidth: number | null,
+    _resizedWidth: number
+  } = reactive({
+    initWidth: A._width,
+    isResizing: false,
+    isClick: true,
+    newWidth: null,
+    _resizedWidth: A._width
+  })
+  const { width } = useWindowSize()
+  const isMagnetic: ComputedRef<boolean> = computed(() => {
+    return resize.newWidth > width.value * (A._percentage)
+  })
+
+  const resizedWidth: WritableComputedRef<number> = computed({
+    get: () => {
+      if (resize._resizedWidth > width.value) {
+        resize.initWidth = width.value
+        return width.value
+      } else {
+        return resize._resizedWidth
+      }
+    },
+    set: (value: number) => {
+      if (!resize.isClick) {
+        if (value > width.value) {
+          value = width.value
+          resize.initWidth = width.value
+        }
+        if (value <= A._width) {
+          value = A._width
+        }
+        resize._resizedWidth = isMagnetic.value ? width.value : value
+      } else {
+        resize._resizedWidth = value
+      }
+    }
+  })
+
+  /**
+   * see @vueuse/core useTransition()
+   * https://vueuse.org/core/useTransition/#usetransition
+   */
+  const transition: ComputedRef<number> = useTransition(resizedWidth, {
+    duration: A._duration,
+    transition: A._transition,
+    disabled: !A.transitionP.value
+  })
+
+  const rotateTarget: Ref<number> = ref(0)
+
+  const styleWidth: ComputedRef<string> = computed(() => {
+    return (isMagnetic.value || resize.isClick) && A.transitionP.value ? `${transition.value}px` : `${resizedWidth.value}px`
+  })
+
+  const handleResize = (e: MouseEvent) => {
+    // Recording the initial position
+    const initPosX: number = e.clientX
+
+    /**
+     * PointMove
+     */
+    const onDocumentPointerMove = (e: PointerEvent) => {
+      /**
+       * Employing two ref() to differentiate between
+       * a click and a drag for the purpose of modification
+       * might be excessively verbose
+       */
+      resize.isClick = false
+      resize.isResizing = true
+
+      /**
+       * The direction of the arrow is determined based on
+       * the initial mouse click position,
+       * rather than the direction of mouse movement.
+       */
+      rotateTarget.value = -Math.sign(e.clientX - initPosX)
+
+      resize.newWidth = A._side.value === 'left'
+        ? resize.initWidth + (e.clientX - initPosX)
+        : resize.initWidth - (e.clientX - initPosX)
+
+      if (resize.newWidth >= width.value) return
+      resizedWidth.value = resize.newWidth
+    }
+    const cleanupPointerMove = useEventListener('pointermove', onDocumentPointerMove)
+
+    /**
+     * PointUp
+     */
+    const onDocumentPointerUp = () => {
+      resize.isResizing = false
+      resize.initWidth = resizedWidth.value
+      cleanupPointerMove()
+      rotateTarget.value = 0
+      useTimeoutFn(() => {
+        resize.isClick = true
+      }, A._duration)
+    }
+    useEventListener('pointerup', onDocumentPointerUp, { once: true })
+  }
+
+  /**
+   * Click
+   */
+  const handleClick = () => {
+    if (resize.isClick) {
+      if (resizedWidth.value >= width.value / 2) {
+        resizedWidth.value = resizedWidth.value === width.value ? A._width : width.value
+      } else {
+        resizedWidth.value = width.value / 2
+      }
+      resize.initWidth = resizedWidth.value
+    }
+  }
+
+  return {
+    handleClick,
+    handleResize,
+    styleWidth,
+    rotateTarget,
+    resize
+  }
+}
+
 export const useSlideover = createSharedComposable(_useSlideover)
+export const useResizeSlideover = createSharedComposable(_useResizeSlideover)

--- a/src/runtime/composables/useSlideover.ts
+++ b/src/runtime/composables/useSlideover.ts
@@ -61,7 +61,7 @@ function _useSlideover () {
   }
 }
 
-function _useResizeSlideover (A: Arguments) {
+export function useResizeSlideover (A: Arguments) {
 
   if (!A._enable) return
 
@@ -195,4 +195,3 @@ function _useResizeSlideover (A: Arguments) {
 }
 
 export const useSlideover = createSharedComposable(_useSlideover)
-export const useResizeSlideover = createSharedComposable(_useResizeSlideover)

--- a/src/runtime/types/slideover.d.ts
+++ b/src/runtime/types/slideover.d.ts
@@ -1,4 +1,39 @@
 import type { Component } from 'vue'
+import { slideover } from '../ui.config'
+import type { EasingFunction, CubicBezierPoints } from '@vueuse/core'
+export type SlideoverInitSize = keyof typeof slideover.resize.width.init
+export type ResizeIconSize = keyof typeof slideover.resize.icon.size
+
+interface ResizeOptions {
+  enable: boolean;
+  /**
+   * The initial width of HDialogPanel
+   */
+  width?: SlideoverInitSize;
+  /**
+   * see `@vueuse/core` useTransition()
+   */
+  duration?: number;
+  /**
+   * see `@vueuse/core` useTransition()
+   */
+  transition?: EasingFunction | CubicBezierPoints;
+  /**
+   * Screen aspect ratio:
+   * determines the ratio to which the width
+   * automatically snaps when adjusting,
+   * aligning it to the full screen
+   */
+  percentage?: number;
+  /**
+   * Custom icons
+   */
+  icon?: string | null;
+  /**
+   * Adjust the size of custom icons
+   */
+  size?: ResizeIconSize;
+}
 
 interface Slideover {
     ui?: any;
@@ -8,6 +43,7 @@ interface Slideover {
     overlay?: boolean;
     preventClose?: boolean;
     modelValue?: boolean;
+    resize?: ResizeOptions;
 }
 
 interface SlideoverState {
@@ -15,3 +51,12 @@ interface SlideoverState {
     props: Slideover;
 }
 
+interface Arguments {
+  _enable: boolean;
+  _width: number;
+  _duration: number;
+  _transition: EasingFunction | CubicBezierPoints;
+  _percentage: number;
+  _side: Ref<'left' | 'right'>;
+  transitionP: Ref<boolean>;
+}

--- a/src/runtime/ui.config/overlays/slideover.ts
+++ b/src/runtime/ui.config/overlays/slideover.ts
@@ -29,5 +29,41 @@ export default {
   transition: {
     enter: 'transform transition ease-in-out duration-300',
     leave: 'transform transition ease-in-out duration-200'
+  },
+  resize: {
+    wrapper: 'absolute top-0 cursor-col-resize h-full flex z-50 w-4 justify-center flex-col group',
+    base: 'flex h-8 w-4 flex-col items-center justify-center opacity-30 dark:opacity-40 group-hover:dark:opacity-80 group-hover:opacity-80',
+    shield: 'w-full h-full absolute z-50 opacity-0 bg-transparent cursor-col-resize',
+    width: {
+      class: 'w-screen max-w-[var(--width)]',
+      init: {
+        xs: 320,
+        sm: 384,
+        md: 448,
+        lg: 512,
+        xl: 576,
+        '2xl': 672
+      }
+    },
+    icon: {
+      base: 'flex-shrink-0',
+      defaultIconBase: 'h-12 w-1 rounded-full transform rotate-0 group-hover:transform bg-gray-500 dark:bg-gray-400',
+      defaultIconRotatePos: 'group-hover:rotate-[15deg]',
+      defaultIconRotateNeg: 'group-hover:rotate-[-15deg]',
+      size: {
+        '2xs': 'h-4 w-4',
+        xs: 'h-4 w-4',
+        sm: 'h-5 w-5',
+        md: 'h-5 w-5',
+        lg: 'h-5 w-5',
+        xl: 'h-6 w-6'
+      }
+    }
+  },
+  default: {
+    resize: {
+      width: 'md',
+      size: 'xs'
+    }
   }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Let the Slideover be resizable by dragging or clicking, but please forgive me for my poor coding skills as a beginner. I apologize if I have caused any inconvenience. 😢 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
