### PR TITLE
 fix(Popover): remove full width on trigger 

### DIFF
--- a/src/runtime/ui.config/overlays/popover.ts
+++ b/src/runtime/ui.config/overlays/popover.ts
@@ -3,7 +3,7 @@ import { arrow } from '../popper'
 export default {
   wrapper: 'relative',
   container: 'z-50 group',
-  trigger: 'inline-flex w-full',
+  trigger: 'inline-flex',
   width: '',
   background: 'bg-white dark:bg-gray-900',
   shadow: 'shadow-lg',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

#1662

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR removes the `w-full` of the popover trigger's configuration. The wrapper is a div (block element) and the relative container of the popover will in this situation take as much space as it can.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
