### PR TITLE
feat(InputMenu/SelectMenu): allow lazy search

### DIFF
--- a/docs/content/2.components/input-menu.md
+++ b/docs/content/2.components/input-menu.md
@@ -130,7 +130,7 @@ Pass a function to the `search` prop to customize the search behavior and filter
 
 Use the `debounce` prop to adjust the delay of the function.
 
-Use the `searchLazy` prop to control the immediacy of data requests.
+Use the `searchLazy` prop to control the immediacy of data requests. :u-badge{label="New" class="!rounded-full" variant="subtle"}
 
 ::component-example
 ---

--- a/docs/content/2.components/input-menu.md
+++ b/docs/content/2.components/input-menu.md
@@ -130,6 +130,8 @@ Pass a function to the `search` prop to customize the search behavior and filter
 
 Use the `debounce` prop to adjust the delay of the function.
 
+Use the `searchableLazy` prop to control the immediacy of data requests.
+
 ::component-example
 ---
 component: 'input-menu-example-search-async'

--- a/docs/content/2.components/input-menu.md
+++ b/docs/content/2.components/input-menu.md
@@ -130,7 +130,7 @@ Pass a function to the `search` prop to customize the search behavior and filter
 
 Use the `debounce` prop to adjust the delay of the function.
 
-Use the `searchableLazy` prop to control the immediacy of data requests.
+Use the `searchLazy` prop to control the immediacy of data requests.
 
 ::component-example
 ---

--- a/docs/content/2.components/select-menu.md
+++ b/docs/content/2.components/select-menu.md
@@ -150,7 +150,7 @@ Pass a function to the `searchable` prop to customize the search behavior and fi
 
 Use the `debounce` prop to adjust the delay of the function.
 
-Use the `searchLazy` prop to control the immediacy of data requests.
+Use the `searchableLazy` prop to control the immediacy of data requests.
 
 ::component-example
 ---

--- a/docs/content/2.components/select-menu.md
+++ b/docs/content/2.components/select-menu.md
@@ -150,7 +150,7 @@ Pass a function to the `searchable` prop to customize the search behavior and fi
 
 Use the `debounce` prop to adjust the delay of the function.
 
-Use the `searchableLazy` prop to control the immediacy of data requests.
+Use the `searchLazy` prop to control the immediacy of data requests.
 
 ::component-example
 ---

--- a/docs/content/2.components/select-menu.md
+++ b/docs/content/2.components/select-menu.md
@@ -150,6 +150,8 @@ Pass a function to the `searchable` prop to customize the search behavior and fi
 
 Use the `debounce` prop to adjust the delay of the function.
 
+Use the `searchableLazy` prop to control the immediacy of data requests.
+
 ::component-example
 ---
 component: 'select-menu-example-search-async'

--- a/docs/content/2.components/select-menu.md
+++ b/docs/content/2.components/select-menu.md
@@ -150,7 +150,7 @@ Pass a function to the `searchable` prop to customize the search behavior and fi
 
 Use the `debounce` prop to adjust the delay of the function.
 
-Use the `searchableLazy` prop to control the immediacy of data requests.
+Use the `searchableLazy` prop to control the immediacy of data requests. :u-badge{label="New" class="!rounded-full" variant="subtle"}
 
 ::component-example
 ---

--- a/src/runtime/components/forms/InputMenu.vue
+++ b/src/runtime/components/forms/InputMenu.vue
@@ -273,7 +273,7 @@ export default defineComponent({
       type: Object as PropType<Partial<typeof configMenu> & { strategy?: Strategy }>,
       default: () => ({})
     },
-    searchableLazy: {
+    searchLazy: {
       type: Boolean,
       default: false
     }
@@ -412,7 +412,7 @@ export default defineComponent({
         })
       })
     }, [], {
-      lazy: props.searchableLazy
+      lazy: props.searchLazy
     })
 
     watch(container, (value) => {

--- a/src/runtime/components/forms/InputMenu.vue
+++ b/src/runtime/components/forms/InputMenu.vue
@@ -272,6 +272,10 @@ export default defineComponent({
     uiMenu: {
       type: Object as PropType<Partial<typeof configMenu> & { strategy?: Strategy }>,
       default: () => ({})
+    },
+    searchableLazy: {
+      type: Boolean,
+      default: false
     }
   },
   emits: ['update:modelValue', 'update:query', 'open', 'close', 'change'],
@@ -407,6 +411,8 @@ export default defineComponent({
           return child !== null && child !== undefined && String(child).search(new RegExp(query.value, 'i')) !== -1
         })
       })
+    }, [], {
+      lazy: props.searchableLazy
     })
 
     watch(container, (value) => {

--- a/src/runtime/components/forms/InputMenu.vue
+++ b/src/runtime/components/forms/InputMenu.vue
@@ -249,6 +249,10 @@ export default defineComponent({
       type: Array,
       default: null
     },
+    searchLazy: {
+      type: Boolean,
+      default: false
+    },
     debounce: {
       type: Number,
       default: 200
@@ -272,10 +276,6 @@ export default defineComponent({
     uiMenu: {
       type: Object as PropType<Partial<typeof configMenu> & { strategy?: Strategy }>,
       default: () => ({})
-    },
-    searchLazy: {
-      type: Boolean,
-      default: false
     }
   },
   emits: ['update:modelValue', 'update:query', 'open', 'close', 'change'],

--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -249,6 +249,10 @@ export default defineComponent({
       type: String,
       default: 'Search...'
     },
+    searchableLazy: {
+      type: Boolean,
+      default: false
+    },
     clearSearchOnClose: {
       type: Boolean,
       default: () => configMenu.default.clearSearchOnClose
@@ -470,6 +474,8 @@ export default defineComponent({
           return child !== null && child !== undefined && String(child).search(new RegExp(query.value, 'i')) !== -1
         })
       })
+    }, [], {
+      lazy: props.searchableLazy
     })
 
     const createOption = computed(() => {

--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -249,7 +249,7 @@ export default defineComponent({
       type: String,
       default: 'Search...'
     },
-    searchLazy: {
+    searchableLazy: {
       type: Boolean,
       default: false
     },
@@ -475,7 +475,7 @@ export default defineComponent({
         })
       })
     }, [], {
-      lazy: props.searchLazy
+      lazy: props.searchableLazy
     })
 
     const createOption = computed(() => {

--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -249,7 +249,7 @@ export default defineComponent({
       type: String,
       default: 'Search...'
     },
-    searchableLazy: {
+    searchLazy: {
       type: Boolean,
       default: false
     },
@@ -475,7 +475,7 @@ export default defineComponent({
         })
       })
     }, [], {
-      lazy: props.searchableLazy
+      lazy: props.searchLazy
     })
 
     const createOption = computed(() => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #1686 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Maybe we need a  `searchableLazy` switch to achieve optimization goals.

Use the `searchableLazy` prop to control the immediacy of data requests.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
