### PR TITLE
fix(Carousel): remove `mix-blend-overlay` on indicators

### DIFF
--- a/src/runtime/ui.config/elements/carousel.ts
+++ b/src/runtime/ui.config/elements/carousel.ts
@@ -9,7 +9,7 @@ export default {
     wrapper: 'absolute flex items-center justify-center gap-3 bottom-4 inset-x-0',
     base: 'rounded-full h-3 w-3',
     active: 'bg-primary-500 dark:bg-primary-400',
-    inactive: 'bg-gray-100 dark:bg-gray-800 mix-blend-overlay'
+    inactive: 'bg-gray-100 dark:bg-gray-800'
   },
   default: {
     prevButton: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
Resolves #1713 

### ❓ Type of change

I found that the Carousel uses the 'mix-blend-overlay' CSS style property to enhance the visual effect of the indicators, but after multiple experiments, it was discovered that this property caused the issue.

Can we achieve the desired outcome by removing the use of this property, or if there are other good ideas, I am willing to provide assistance.

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
