### PR TITLE
fix(Carousel): prevent mouse click when dragging

### DIFF
--- a/src/runtime/composables/useCarouselScroll.ts
+++ b/src/runtime/composables/useCarouselScroll.ts
@@ -16,7 +16,7 @@ export const useCarouselScroll = (el: Ref<HTMLElement>) => {
   function onMouseUp () {
     el.value.style.removeProperty('scroll-behavior')
     el.value.style.removeProperty('scroll-snap-type')
-    el.value.style.removeProperty("pointer-events")
+    el.value.style.removeProperty('pointer-events')
 
     window.removeEventListener('mousemove', onMouseMove)
     window.removeEventListener('mouseup', onMouseUp)
@@ -25,7 +25,7 @@ export const useCarouselScroll = (el: Ref<HTMLElement>) => {
   function onMouseMove (e) {
     e.preventDefault()
 
-    el.value.style.pointerEvents = "none"
+    el.value.style.pointerEvents = 'none'
 
     const delta = e.pageX - x.value
 

--- a/src/runtime/composables/useCarouselScroll.ts
+++ b/src/runtime/composables/useCarouselScroll.ts
@@ -16,6 +16,7 @@ export const useCarouselScroll = (el: Ref<HTMLElement>) => {
   function onMouseUp () {
     el.value.style.removeProperty('scroll-behavior')
     el.value.style.removeProperty('scroll-snap-type')
+    el.value.style.removeProperty("pointer-events")
 
     window.removeEventListener('mousemove', onMouseMove)
     window.removeEventListener('mouseup', onMouseUp)
@@ -23,6 +24,8 @@ export const useCarouselScroll = (el: Ref<HTMLElement>) => {
 
   function onMouseMove (e) {
     e.preventDefault()
+
+    el.value.style.pointerEvents = "none"
 
     const delta = e.pageX - x.value
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
If `<NuxtLink>` is used inside the carousel, dragging will cause the link to be clicked. Now onwards, `onMouseMove` will add `'pointer-events': "none"` to the `carouselEl` and will be removed `onMouseUp`, thereby preventing click to be propagated. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
