### PR TITLE
docs(shortcuts): mention alternative to usingInput

### DIFF
--- a/docs/content/1.getting-started/4.shortcuts.md
+++ b/docs/content/1.getting-started/4.shortcuts.md
@@ -94,6 +94,10 @@ defineShortcuts({
 ```
 _`enter` shortcut will only trigger when `queryInput` is focused._
 
+::callout{icon="i-heroicons-light-bulb"}
+Alternatively you can use `@keyup.enter` or any other event listener that [Vue provides](https://vuejs.org/guide/essentials/event-handling.html#key-modifiers) on the input itself to achieve the same behavior. 
+::
+
 ### `whenever`
 
 Prop: `whenever?: WatchSource<boolean>[]`


### PR DESCRIPTION
Mention that you can use Vue event listeners on the input itself to achieve the same behavior as `usingInput`.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
