### PR TITLE
docs(slideover): add close button in some examples for mobile

### DIFF
--- a/docs/components/content/examples/SlideoverExampleBasic.vue
+++ b/docs/components/content/examples/SlideoverExampleBasic.vue
@@ -8,6 +8,8 @@ const isOpen = ref(false)
 
     <USlideover v-model="isOpen">
       <div class="p-4 flex-1">
+        <UButton color="gray" variant="ghost" size="sm" icon="i-heroicons-x-mark-20-solid"
+          class="flex sm:hidden absolute end-5 top-5 z-10" @click="isOpen = false" square padded />
         <Placeholder class="h-full" />
       </div>
     </USlideover>

--- a/docs/components/content/examples/SlideoverExampleBasic.vue
+++ b/docs/components/content/examples/SlideoverExampleBasic.vue
@@ -8,8 +8,16 @@ const isOpen = ref(false)
 
     <USlideover v-model="isOpen">
       <div class="p-4 flex-1">
-        <UButton color="gray" variant="ghost" size="sm" icon="i-heroicons-x-mark-20-solid"
-          class="flex sm:hidden absolute end-5 top-5 z-10" @click="isOpen = false" square padded />
+        <UButton
+          color="gray"
+          variant="ghost"
+          size="sm"
+          icon="i-heroicons-x-mark-20-solid"
+          class="flex sm:hidden absolute end-5 top-5 z-10"
+          square
+          padded
+          @click="isOpen = false"
+        />
         <Placeholder class="h-full" />
       </div>
     </USlideover>

--- a/docs/components/content/examples/SlideoverExampleCard.vue
+++ b/docs/components/content/examples/SlideoverExampleCard.vue
@@ -7,11 +7,21 @@ const isOpen = ref(false)
     <UButton label="Open" @click="isOpen = true" />
 
     <USlideover v-model="isOpen">
-      <UCard class="flex flex-col flex-1"
-        :ui="{ body: { base: 'flex-1' }, ring: '', divide: 'divide-y divide-gray-100 dark:divide-gray-800' }">
+      <UCard
+        class="flex flex-col flex-1"
+        :ui="{ body: { base: 'flex-1' }, ring: '', divide: 'divide-y divide-gray-100 dark:divide-gray-800' }"
+      >
         <template #header>
-          <UButton color="gray" variant="ghost" size="sm" icon="i-heroicons-x-mark-20-solid"
-            class="flex sm:hidden absolute end-5 top-5 z-10" @click="isOpen = false" square padded />
+          <UButton
+            color="gray"
+            variant="ghost"
+            size="sm"
+            icon="i-heroicons-x-mark-20-solid"
+            class="flex sm:hidden absolute end-5 top-5 z-10"
+            square
+            padded
+            @click="isOpen = false"
+          />
 
           <Placeholder class="h-8" />
         </template>

--- a/docs/components/content/examples/SlideoverExampleCard.vue
+++ b/docs/components/content/examples/SlideoverExampleCard.vue
@@ -7,8 +7,12 @@ const isOpen = ref(false)
     <UButton label="Open" @click="isOpen = true" />
 
     <USlideover v-model="isOpen">
-      <UCard class="flex flex-col flex-1" :ui="{ body: { base: 'flex-1' }, ring: '', divide: 'divide-y divide-gray-100 dark:divide-gray-800' }">
+      <UCard class="flex flex-col flex-1"
+        :ui="{ body: { base: 'flex-1' }, ring: '', divide: 'divide-y divide-gray-100 dark:divide-gray-800' }">
         <template #header>
+          <UButton color="gray" variant="ghost" size="sm" icon="i-heroicons-x-mark-20-solid"
+            class="flex sm:hidden absolute end-5 top-5 z-10" @click="isOpen = false" square padded />
+
           <Placeholder class="h-8" />
         </template>
 

--- a/docs/components/content/examples/SlideoverExampleDisableOverlay.vue
+++ b/docs/components/content/examples/SlideoverExampleDisableOverlay.vue
@@ -8,6 +8,9 @@ const isOpen = ref(false)
 
     <USlideover v-model="isOpen" :overlay="false">
       <div class="p-4 flex-1">
+        <UButton color="gray" variant="ghost" size="sm" icon="i-heroicons-x-mark-20-solid"
+          class="flex sm:hidden absolute end-5 top-5 z-10" @click="isOpen = false" square padded />
+
         <Placeholder class="h-full" />
       </div>
     </USlideover>

--- a/docs/components/content/examples/SlideoverExampleDisableOverlay.vue
+++ b/docs/components/content/examples/SlideoverExampleDisableOverlay.vue
@@ -8,8 +8,16 @@ const isOpen = ref(false)
 
     <USlideover v-model="isOpen" :overlay="false">
       <div class="p-4 flex-1">
-        <UButton color="gray" variant="ghost" size="sm" icon="i-heroicons-x-mark-20-solid"
-          class="flex sm:hidden absolute end-5 top-5 z-10" @click="isOpen = false" square padded />
+        <UButton
+          color="gray"
+          variant="ghost"
+          size="sm"
+          icon="i-heroicons-x-mark-20-solid"
+          class="flex sm:hidden absolute end-5 top-5 z-10"
+          square
+          padded
+          @click="isOpen = false"
+        />
 
         <Placeholder class="h-full" />
       </div>

--- a/docs/components/content/examples/SlideoverExampleDisableTransition.vue
+++ b/docs/components/content/examples/SlideoverExampleDisableTransition.vue
@@ -8,8 +8,16 @@ const isOpen = ref(false)
 
     <USlideover v-model="isOpen" :transition="false">
       <div class="p-4 flex-1">
-        <UButton color="gray" variant="ghost" size="sm" icon="i-heroicons-x-mark-20-solid"
-          class="flex sm:hidden absolute end-5 top-5 z-10" @click="isOpen = false" square padded />
+        <UButton
+          color="gray"
+          variant="ghost"
+          size="sm"
+          icon="i-heroicons-x-mark-20-solid"
+          class="flex sm:hidden absolute end-5 top-5 z-10"
+          square
+          padded
+          @click="isOpen = false"
+        />
 
         <Placeholder class="h-full" />
       </div>

--- a/docs/components/content/examples/SlideoverExampleDisableTransition.vue
+++ b/docs/components/content/examples/SlideoverExampleDisableTransition.vue
@@ -8,6 +8,9 @@ const isOpen = ref(false)
 
     <USlideover v-model="isOpen" :transition="false">
       <div class="p-4 flex-1">
+        <UButton color="gray" variant="ghost" size="sm" icon="i-heroicons-x-mark-20-solid"
+          class="flex sm:hidden absolute end-5 top-5 z-10" @click="isOpen = false" square padded />
+
         <Placeholder class="h-full" />
       </div>
     </USlideover>


### PR DESCRIPTION
### Problem
In the SlideOver component documentation, the component couldn't be closed on mobile devices, requiring a page refresh.

### Solution
Added a button that is visible only on mobile devices to close the SlideOver component on the documentation page.

### Changes Made
- Added a close button to the SlideOver component.
- Made the button visible only on mobile devices.