### PR TITLE
docs(table): ensure scroll and pagination visibility on mobile

### DIFF
--- a/docs/content/2.components/table.md
+++ b/docs/content/2.components/table.md
@@ -49,7 +49,7 @@ extraClass: 'overflow-hidden'
 padding: false
 component: 'table-example-columns-selectable'
 componentProps:
-  class: 'flex-1'
+  class: 'flex-1 flex-col overflow-hidden'
 ---
 ::
 
@@ -282,7 +282,7 @@ extraClass: 'overflow-hidden'
 padding: false
 component: 'table-example-searchable'
 componentProps:
-  class: 'flex-1'
+  class: 'flex-1 flex-col overflow-hidden'
 ---
 ::
 
@@ -296,7 +296,7 @@ extraClass: 'overflow-hidden'
 padding: false
 component: 'table-example-paginable'
 componentProps:
-  class: 'flex-1'
+  class: 'flex-1 flex-col overflow-hidden'
 ---
 ::
 


### PR DESCRIPTION
### Description
This pull request addresses the visibility issues for table examples on mobile devices. Previously, the tables were not scrollable, causing pagination to be hidden and rendering the tables unusable on mobile screens. 

### Changes Made
- Added `flex-col` and `overflow-hidden` classes to the parent element of `table-example-columns-selectable`.
- Added `flex-col` and `overflow-hidden` classes to the parent element of `table-example-searchable`.
- Added `flex-col` and `overflow-hidden` classes to the parent element of `table-example-paginable`.

### Impact
These changes will allow users to scroll horizontally and view the pagination on mobile devices.

Before:
<img width="549" alt="Screenshot 2024-06-02 at 1 48 05 PM" src="https://github.com/nuxt/ui/assets/65956317/ede31d5f-98de-4b1f-8084-f56cb0f851d0">

After:
<img width="562" alt="Screenshot 2024-06-02 at 1 48 34 PM" src="https://github.com/nuxt/ui/assets/65956317/c0925360-5b61-48c1-b20c-92df14bab88c">
