### PR TITLE
feat(Tabs): add `content` prop to avoid the render of the HTML markup

### DIFF
--- a/docs/content/2.components/tabs.md
+++ b/docs/content/2.components/tabs.md
@@ -63,7 +63,7 @@ componentProps:
 ---
 ::
 
-You can use the `contentless` prop to avoid the rendering of the HTML content if you don't need it.
+You can use the `content` prop and set it to `false` to avoid the rendering of the HTML content if you don't need it.
 
 ### Control the selected index
 

--- a/docs/content/2.components/tabs.md
+++ b/docs/content/2.components/tabs.md
@@ -63,6 +63,8 @@ componentProps:
 ---
 ::
 
+You can use the `contentless` prop to avoid the rendering of the HTML content if you don't need it.
+
 ### Control the selected index
 
 Use a `v-model` to control the selected index.

--- a/src/runtime/components/navigation/Tabs.vue
+++ b/src/runtime/components/navigation/Tabs.vue
@@ -32,7 +32,7 @@
       </HTab>
     </HTabList>
 
-    <HTabPanels :class="ui.container">
+    <HTabPanels v-if="!$props.contentless" :class="ui.container">
       <HTabPanel v-for="(item, index) of items" :key="index" v-slot="{ selected }" :class="ui.base" :unmount="unmount">
         <slot :name="item.slot || 'item'" :item="item" :index="index" :selected="selected">
           {{ item.content }}
@@ -85,6 +85,10 @@ export default defineComponent({
       default: () => []
     },
     unmount: {
+      type: Boolean,
+      default: false
+    },
+    contentless: {
       type: Boolean,
       default: false
     },

--- a/src/runtime/components/navigation/Tabs.vue
+++ b/src/runtime/components/navigation/Tabs.vue
@@ -32,7 +32,7 @@
       </HTab>
     </HTabList>
 
-    <HTabPanels v-if="!$props.contentless" :class="ui.container">
+    <HTabPanels v-if="!contentless" :class="ui.container">
       <HTabPanel v-for="(item, index) of items" :key="index" v-slot="{ selected }" :class="ui.base" :unmount="unmount">
         <slot :name="item.slot || 'item'" :item="item" :index="index" :selected="selected">
           {{ item.content }}

--- a/src/runtime/components/navigation/Tabs.vue
+++ b/src/runtime/components/navigation/Tabs.vue
@@ -32,7 +32,7 @@
       </HTab>
     </HTabList>
 
-    <HTabPanels v-if="!contentless" :class="ui.container">
+    <HTabPanels v-if="content" :class="ui.container">
       <HTabPanel v-for="(item, index) of items" :key="index" v-slot="{ selected }" :class="ui.base" :unmount="unmount">
         <slot :name="item.slot || 'item'" :item="item" :index="index" :selected="selected">
           {{ item.content }}
@@ -88,9 +88,9 @@ export default defineComponent({
       type: Boolean,
       default: false
     },
-    contentless: {
+    content: {
       type: Boolean,
-      default: false
+      default: true
     },
     class: {
       type: [String, Object, Array] as PropType<any>,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #1709 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This prop give tha ability to the user to remove the render markup of the content completely. It may be useful in certain cases, where the user is using the `@change` event, because is changing something else, and using the tab just as a switcher component.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
