### PR TITLE
feat(Slideover): handle `top` and `bottom` side

### DIFF
--- a/src/runtime/components/overlays/Slideover.vue
+++ b/src/runtime/components/overlays/Slideover.vue
@@ -46,9 +46,9 @@ export default defineComponent({
       default: false
     },
     side: {
-      type: String as PropType<'left' | 'right'>,
+      type: String as PropType<'left' | 'right' | 'top' | 'bottom'>,
       default: 'right',
-      validator: (value: string) => ['left', 'right'].includes(value)
+      validator: (value: string) => ['left', 'right', 'top', 'bottom'].includes(value)
     },
     overlay: {
       type: Boolean,
@@ -89,12 +89,35 @@ export default defineComponent({
         return {}
       }
 
+      let enterFrom, leaveTo
+      switch (props.side) {
+        case 'left':
+          enterFrom = ui.value.translate.left
+          leaveTo = ui.value.translate.left
+          break
+        case 'right':
+          enterFrom = ui.value.translate.right
+          leaveTo = ui.value.translate.right
+          break
+        case 'top':
+          enterFrom = ui.value.translate.top
+          leaveTo = ui.value.translate.top
+          break
+        case 'bottom':
+          enterFrom = ui.value.translate.bottom
+          leaveTo = ui.value.translate.bottom
+          break
+        default:
+          enterFrom = ui.value.translate.right
+          leaveTo = ui.value.translate.right
+      }
+
       return {
         ...ui.value.transition,
-        enterFrom: props.side === 'left' ? ui.value.translate.left : ui.value.translate.right,
+        enterFrom,
         enterTo: ui.value.translate.base,
         leaveFrom: ui.value.translate.base,
-        leaveTo: props.side === 'left' ? ui.value.translate.left : ui.value.translate.right
+        leaveTo
       }
     })
 
@@ -116,7 +139,6 @@ export default defineComponent({
     provideUseId(() => useId())
 
     return {
-      // eslint-disable-next-line vue/no-dupe-keys
       ui,
       attrs,
       isOpen,

--- a/src/runtime/components/overlays/Slideover.vue
+++ b/src/runtime/components/overlays/Slideover.vue
@@ -6,7 +6,7 @@
       </TransitionChild>
 
       <TransitionChild as="template" :appear="appear" v-bind="transitionClass">
-        <HDialogPanel :class="[ui.base, ui.side[sideType].width, ui.side[sideType].height, ui.background, ui.ring, ui.padding]">
+        <HDialogPanel :class="[ui.base, sideType === 'horizontal' ? [ui.width, 'h-full'] : [ui.height, 'w-full'], ui.background, ui.ring, ui.padding]">
           <slot />
         </HDialogPanel>
       </TransitionChild>

--- a/src/runtime/components/overlays/Slideover.vue
+++ b/src/runtime/components/overlays/Slideover.vue
@@ -1,12 +1,12 @@
 <template>
   <TransitionRoot as="template" :appear="appear" :show="isOpen" @after-leave="onAfterLeave">
-    <HDialog :class="[ui.wrapper, { 'justify-end': side === 'right' }]" v-bind="attrs" @close="close">
+    <HDialog :class="[ui.wrapper, { 'justify-end': side === 'right' }, { 'items-end': side === 'bottom' }]" v-bind="attrs" @close="close">
       <TransitionChild v-if="overlay" as="template" :appear="appear" v-bind="ui.overlay.transition">
         <div :class="[ui.overlay.base, ui.overlay.background]" />
       </TransitionChild>
 
       <TransitionChild as="template" :appear="appear" v-bind="transitionClass">
-        <HDialogPanel :class="[ui.base, ui.width, ui.background, ui.ring, ui.padding]">
+        <HDialogPanel :class="[ui.base, ui.side[sideType].width, ui.side[sideType].height, ui.background, ui.ring, ui.padding]">
           <slot />
         </HDialogPanel>
       </TransitionChild>
@@ -91,25 +91,25 @@ export default defineComponent({
 
       let enterFrom, leaveTo
       switch (props.side) {
-        case 'left':
-          enterFrom = ui.value.translate.left
-          leaveTo = ui.value.translate.left
-          break
-        case 'right':
-          enterFrom = ui.value.translate.right
-          leaveTo = ui.value.translate.right
-          break
-        case 'top':
-          enterFrom = ui.value.translate.top
-          leaveTo = ui.value.translate.top
-          break
-        case 'bottom':
-          enterFrom = ui.value.translate.bottom
-          leaveTo = ui.value.translate.bottom
-          break
-        default:
-          enterFrom = ui.value.translate.right
-          leaveTo = ui.value.translate.right
+      case 'left':
+        enterFrom = ui.value.translate.left
+        leaveTo = ui.value.translate.left
+        break
+      case 'right':
+        enterFrom = ui.value.translate.right
+        leaveTo = ui.value.translate.right
+        break
+      case 'top':
+        enterFrom = ui.value.translate.top
+        leaveTo = ui.value.translate.top
+        break
+      case 'bottom':
+        enterFrom = ui.value.translate.bottom
+        leaveTo = ui.value.translate.bottom
+        break
+      default:
+        enterFrom = ui.value.translate.right
+        leaveTo = ui.value.translate.right
       }
 
       return {
@@ -120,6 +120,21 @@ export default defineComponent({
         leaveTo
       }
     })
+    const sideType = computed(() => {
+      switch (props.side) {
+      case 'left':
+        return 'horizontal'
+      case 'right':
+        return 'horizontal'
+      case 'top':
+        return 'vertical'
+      case 'bottom':
+        return 'vertical'
+      default:
+        return 'right'
+      }
+    })
+
 
     function close (value: boolean) {
       if (props.preventClose) {
@@ -139,10 +154,12 @@ export default defineComponent({
     provideUseId(() => useId())
 
     return {
+      // eslint-disable-next-line vue/no-dupe-keys
       ui,
       attrs,
       isOpen,
       transitionClass,
+      sideType,
       onAfterLeave,
       close
     }

--- a/src/runtime/ui.config/overlays/slideover.ts
+++ b/src/runtime/ui.config/overlays/slideover.ts
@@ -20,6 +20,16 @@ export default {
   padding: '',
   shadow: 'shadow-xl',
   width: 'w-screen max-w-md',
+  side: {
+    horizontal: {
+      width: 'w-screen max-w-md',
+      height: 'h-full'
+    },
+    vertical: {
+      height: 'h-screen max-h-96',
+      width: 'w-full'
+    }
+  },  
   translate: {
     base: 'translate-x-0',
     left: '-translate-x-full rtl:translate-x-full',

--- a/src/runtime/ui.config/overlays/slideover.ts
+++ b/src/runtime/ui.config/overlays/slideover.ts
@@ -20,16 +20,7 @@ export default {
   padding: '',
   shadow: 'shadow-xl',
   width: 'w-screen max-w-md',
-  side: {
-    horizontal: {
-      width: 'w-screen max-w-md',
-      height: 'h-full'
-    },
-    vertical: {
-      height: 'h-screen max-h-96',
-      width: 'w-full'
-    }
-  },  
+  height: 'h-screen max-h-96',
   translate: {
     base: 'translate-x-0',
     left: '-translate-x-full rtl:translate-x-full',

--- a/src/runtime/ui.config/overlays/slideover.ts
+++ b/src/runtime/ui.config/overlays/slideover.ts
@@ -23,7 +23,9 @@ export default {
   translate: {
     base: 'translate-x-0',
     left: '-translate-x-full rtl:translate-x-full',
-    right: 'translate-x-full rtl:-translate-x-full'
+    right: 'translate-x-full rtl:-translate-x-full',
+    top: '-translate-y-full',
+    bottom: 'translate-y-full'
   },
   // Syntax for `<TransitionRoot>` component https://headlessui.com/vue/transition#basic-example
   transition: {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #576 
<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pr adds `top` and `bottom` to the side prop. 
It's just a working proof of concepts, meaning i didn't care about the braking changes it involves. Adding new config keys (`side`) forced me to remove the original `width`. I'd like to discuss in this pr how to reconcile my changes in the best way possible. I think the news `side` config (along with the news `sideType` computed property) is a nice way to implement the change, but i'm open to everything. 

Also, not discussed directly in the issue, i'd like to know if could be interesting adding a `fullscreen` reactive option, letting the slideover go fullscreen; this could be usefull in mobile mode, creating the drawer effect and letting the user enlarge the content on an action.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
