### PR TITLE
feat(Skeleton): add syntax support for light mode and dark mode by default

### DIFF
--- a/docs/components/content/examples/SkeletonExample.vue
+++ b/docs/components/content/examples/SkeletonExample.vue
@@ -1,9 +1,15 @@
 <template>
   <div class="flex items-center space-x-4">
-    <USkeleton class="h-12 w-12" :ui="{ rounded: 'rounded-full' }" />
+    <USkeleton
+      class="h-16 w-16"
+      :ui="{
+        rounded: 'rounded-full',
+        background: 'bg-gray-300 dark:bg-slate-300',
+      }"
+    />
     <div class="space-y-2">
-      <USkeleton class="h-4 w-[250px]" />
-      <USkeleton class="h-4 w-[200px]" />
+      <USkeleton class="h-4 w-[200px] bg-gray-300 dark:bg-slate-300" />
+      <USkeleton class="h-4 w-[150px] bg-gray-300 dark:bg-slate-300" />
     </div>
   </div>
 </template>


### PR DESCRIPTION
feat(Skeleton): add syntax support for light mode and dark mode by default

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The current usage example is pretty bare and doesn't reflect any specific element classes to target either light mode or dark mode. In fact, could be said that it is perhaps favoring one of another.

This PR fixes that by adding classes to support both background modes for the default copy-paste example from the documentation.

Attached demo of the change (which shows additional text added but not part of this PR):

![Kapture 2024-07-02 at 14 47 32](https://github.com/nuxt/ui/assets/316371/fd0096cf-4f58-41e2-9a20-a8d02b4f2610)
![Kapture 2024-07-02 at 14 48 58](https://github.com/nuxt/ui/assets/316371/125e3672-31e2-4deb-9bc1-ea6685b4ea9b)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
