### PR TITLE
docs(form): typo

### DIFF
--- a/docs/content/2.components/form.md
+++ b/docs/content/2.components/form.md
@@ -105,7 +105,7 @@ defineExpose({
 </script>
 
 <template>
-  <UForm ref="form" :model="model" :validate="validateWithVuelidate">
+  <UForm ref="form" :state="model" :validate="validateWithVuelidate">
     <slot />
   </UForm>
 </template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes a typo in UForm's page on the docs, more specifically on the Vuelidate example, where the `state` prop was mistaken with `model`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
