### PR TITLE
fix(useFormGroup): app config default input size

### DIFF
--- a/src/runtime/composables/useFormGroup.ts
+++ b/src/runtime/composables/useFormGroup.ts
@@ -4,6 +4,7 @@ import type { FormEvent, FormEventType, InjectedFormGroupValue } from '../types/
 import { mergeConfig } from '../utils'
 // @ts-expect-error
 import appConfig from '#build/app.config'
+
 import { formGroup } from '#ui/ui.config'
 
 type InputProps = {
@@ -62,7 +63,8 @@ export const useFormGroup = (inputProps?: InputProps, config?: any) => {
     name: computed(() => inputProps?.name ?? formGroup?.name.value),
     size: computed(() => {
       const formGroupSize = config.size[formGroup?.size.value as string] ? formGroup?.size.value : null
-      return inputProps?.size ?? formGroupSize ?? formGroupConfig?.default?.size
+      const defaultSize = config.default?.size ?? formGroupConfig?.default?.size
+      return inputProps?.size ?? formGroupSize ?? defaultSize
     }),
     color: computed(() => formGroup?.error?.value ? 'red' : inputProps?.color),
     emitFormBlur,

--- a/src/runtime/composables/useFormGroup.ts
+++ b/src/runtime/composables/useFormGroup.ts
@@ -1,11 +1,6 @@
 import { inject, ref, computed } from 'vue'
 import { type UseEventBusReturn, useDebounceFn } from '@vueuse/core'
 import type { FormEvent, FormEventType, InjectedFormGroupValue } from '../types/form'
-import { mergeConfig } from '../utils'
-// @ts-expect-error
-import appConfig from '#build/app.config'
-
-import { formGroup } from '#ui/ui.config'
 
 type InputProps = {
   id?: string
@@ -16,8 +11,6 @@ type InputProps = {
   legend?: string | null
 }
 
-
-const formGroupConfig = mergeConfig<typeof formGroup>(appConfig.ui.strategy, appConfig.ui.formGroup, formGroup)
 
 export const useFormGroup = (inputProps?: InputProps, config?: any) => {
   const formBus = inject<UseEventBusReturn<FormEvent, string> | undefined>('form-events', undefined)
@@ -63,8 +56,7 @@ export const useFormGroup = (inputProps?: InputProps, config?: any) => {
     name: computed(() => inputProps?.name ?? formGroup?.name.value),
     size: computed(() => {
       const formGroupSize = config.size[formGroup?.size.value as string] ? formGroup?.size.value : null
-      const defaultSize = config.default?.size ?? formGroupConfig?.default?.size
-      return inputProps?.size ?? formGroupSize ?? defaultSize
+      return inputProps?.size ?? formGroupSize ?? config.default?.size
     }),
     color: computed(() => formGroup?.error?.value ? 'red' : inputProps?.color),
     emitFormBlur,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
Resolves #1990 

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change
Fixes an issue with the default size configuration of inputs when not used with a FormField introduced in this PR: [https://github.com/nuxt/ui/pull/1875](https://github.com/nuxt/ui/pull/1875/files#diff-657252430036764202d3bd37120dde2069d89c3bcfb3a4c951bc9dc917f47241R65).

In short, we were always using the FormGroup's default size instead of prioritising the input's default size configuration.

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
