### PR TITLE
docs(table): use `status` instead of deprecated `pending` in `useFetch` and `useAsyncData`

### DIFF
--- a/docs/components/content/examples/TableExampleAdvanced.vue
+++ b/docs/components/content/examples/TableExampleAdvanced.vue
@@ -85,7 +85,7 @@ const pageFrom = computed(() => (page.value - 1) * pageCount.value + 1)
 const pageTo = computed(() => Math.min(page.value * pageCount.value, pageTotal.value))
 
 // Data
-const { data: todos, pending } = await useLazyAsyncData<{
+const { data: todos, status } = await useLazyAsyncData<{
   id: number
   title: string
   completed: string
@@ -181,7 +181,7 @@ const { data: todos, pending } = await useLazyAsyncData<{
       v-model:sort="sort"
       :rows="todos"
       :columns="columnsTable"
-      :loading="pending"
+      :loading="status === 'pending'"
       sort-asc-icon="i-heroicons-arrow-up"
       sort-desc-icon="i-heroicons-arrow-down"
       sort-mode="manual"

--- a/docs/content/2.components/table.md
+++ b/docs/content/2.components/table.md
@@ -148,11 +148,11 @@ const columns = [{
   sortable: true
 }]
 
-const { data, pending } = await useLazyFetch(() => `/api/users?orderBy=${sort.value.column}&order=${sort.value.direction}`)
+const { data, status } = await useLazyFetch(() => `/api/users?orderBy=${sort.value.column}&order=${sort.value.direction}`)
 </script>
 
 <template>
-  <UTable v-model:sort="sort" :loading="pending" :columns="columns" :rows="data" sort-mode="manual" />
+  <UTable v-model:sort="sort" :loading="status === 'pending'" :columns="columns" :rows="data" sort-mode="manual" />
 </template>
 ```
 
@@ -359,11 +359,11 @@ This can be easily used with Nuxt `useAsyncData` composable.
 <script setup lang="ts">
 const columns = [...]
 
-const { pending, data: people } = await useLazyAsyncData('people', () => $fetch('/api/people'))
+const { status, data: people } = await useLazyAsyncData('people', () => $fetch('/api/people'))
 </script>
 
 <template>
-  <UTable :rows="people" :columns="columns" :loading="pending" />
+  <UTable :rows="people" :columns="columns" :loading="status === 'pending'" />
 </template>
 ```
 


### PR DESCRIPTION
### 🔗 Linked issue

No issue linked.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull request change the 'pending' property of AsyncData and Fetch calls in favor of the 'status' property.
The 'pending' prop is deprecated and will likely be removed in future versions, according to the documentation.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
