### PR TITLE
fix(Pagination): add props for hiding prev/next button

### DIFF
--- a/src/runtime/components/navigation/Pagination.vue
+++ b/src/runtime/components/navigation/Pagination.vue
@@ -15,7 +15,7 @@
 
     <slot name="prev" :on-click="onClickPrev">
       <UButton
-        v-if="prevButton"
+        v-if="prevButton && showPrev"
         :size="size"
         :disabled="!canGoFirstOrPrev || disabled"
         :class="[ui.base, ui.rounded]"
@@ -41,7 +41,7 @@
 
     <slot name="next" :on-click="onClickNext">
       <UButton
-        v-if="nextButton"
+        v-if="nextButton && showNext"
         :size="size"
         :disabled="!canGoLastOrNext || disabled"
         :class="[ui.base, ui.rounded]"
@@ -138,6 +138,14 @@ export default defineComponent({
     showLast: {
       type: Boolean,
       default: false
+    },
+    showPrev: {
+      type: Boolean,
+      default: true
+    },
+    showNext: {
+      type: Boolean,
+      default: true
     },
     firstButton: {
       type: Object as PropType<Button>,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

This PR adds props for hiding prev/next button, like the one for first/last button.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
