### PR TITLE
feat(Button): loading-auto

### DIFF
--- a/docs/app/components/content/examples/button/ButtonLoadingAutoExample.vue
+++ b/docs/app/components/content/examples/button/ButtonLoadingAutoExample.vue
@@ -1,0 +1,11 @@
+<script setup lang="ts">
+async function onClick() {
+  return new Promise<void>(res => setTimeout(res, 1000))
+}
+</script>
+
+<template>
+  <UButton loading-auto @click="onClick">
+    Button
+  </UButton>
+</template>

--- a/docs/app/components/content/examples/button/ButtonLoadingAutoFormExample.vue
+++ b/docs/app/components/content/examples/button/ButtonLoadingAutoFormExample.vue
@@ -1,0 +1,23 @@
+<script setup lang="ts">
+const state = reactive({ fullName: '' })
+
+async function onSubmit() {
+  return new Promise<void>(res => setTimeout(res, 1000))
+}
+
+async function validate(data: Partial<typeof state>) {
+  if (!data.fullName?.length) return [{ name: 'fullName', message: 'Required' }]
+  return []
+}
+</script>
+
+<template>
+  <UForm :state="state" :validate="validate" @submit="onSubmit">
+    <UFormField name="fullName" label="Full name">
+      <UInput v-model="state.fullName" />
+    </UFormField>
+    <UButton type="submit" class="mt-2" loading-auto>
+      Submit
+    </UButton>
+  </UForm>
+</template>

--- a/docs/app/components/content/examples/form/FormExampleElements.vue
+++ b/docs/app/components/content/examples/form/FormExampleElements.vue
@@ -103,11 +103,11 @@ async function onSubmit(event: FormSubmitEvent<any>) {
     </div>
 
     <div class="flex gap-2 mt-8">
-      <UButton color="gray" type="submit" :disabled="form?.disabled">
+      <UButton color="gray" type="submit">
         Submit
       </UButton>
 
-      <UButton color="gray" variant="outline" :disabled="form?.disabled" @click="form?.clear()">
+      <UButton color="gray" variant="outline" @click="form?.clear()">
         Clear
       </UButton>
     </div>

--- a/docs/app/components/content/examples/form/FormExampleNested.vue
+++ b/docs/app/components/content/examples/form/FormExampleNested.vue
@@ -29,7 +29,7 @@ async function onSubmit(event: FormSubmitEvent<any>) {
     :state="state"
     :schema="schema"
     class="gap-4 flex flex-col w-60"
-    @submit="(event) => onSubmit(event)"
+    @submit="onSubmit"
   >
     <UFormField label="Name" name="name">
       <UInput v-model="state.name" placeholder="John Lennon" />

--- a/docs/app/components/content/examples/form/FormExampleOnError.vue
+++ b/docs/app/components/content/examples/form/FormExampleOnError.vue
@@ -20,9 +20,11 @@ async function onSubmit(event: FormSubmitEvent<any>) {
 }
 
 async function onError(event: FormErrorEvent) {
-  const element = document.getElementById(event.errors[0].id)
-  element?.focus()
-  element?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  if (event?.errors?.[0]?.id) {
+    const element = document.getElementById(event.errors[0].id)
+    element?.focus()
+    element?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  }
 }
 </script>
 

--- a/docs/app/components/content/examples/form/FormExampleZod.vue
+++ b/docs/app/components/content/examples/form/FormExampleZod.vue
@@ -9,7 +9,7 @@ const schema = z.object({
 
 type Schema = z.output<typeof schema>
 
-const state = reactive({
+const state = reactive<Partial<Schema>>({
   email: undefined,
   password: undefined
 })

--- a/docs/content/3.components/button.md
+++ b/docs/content/3.components/button.md
@@ -147,11 +147,11 @@ Button
 You can customize this icon globally in your `app.config.ts` under `ui.icons.loading` key.
 ::
 
-Use the `loading-auto` prop to show the loading icon automatically while the `@click` handler is pending.
+Use the `loading-auto` prop to show the loading icon automatically while the `@click` promise is pending.
 
 :component-example{name="button-loading-auto-example"}
 
-This also works for with the `@submit` handler of the [Form](/components/form) component 
+This also works with the [Form](/components/form) component.
 
 :component-example{name="button-loading-auto-form-example"}
 

--- a/docs/content/3.components/button.md
+++ b/docs/content/3.components/button.md
@@ -140,13 +140,20 @@ props:
 slots:
   default: Button
 ---
-
 Button
 ::
 
 ::tip
 You can customize this icon globally in your `app.config.ts` under `ui.icons.loading` key.
 ::
+
+Use the `loading-auto` prop to show the loading icon automatically while the `@click` handler is pending.
+
+:component-example{name="button-loading-auto-example"}
+
+This also works for with the `@submit` handler of the [Form](/components/form) component 
+
+:component-example{name="button-loading-auto-form-example"}
 
 ### Disabled
 

--- a/playground/app/components/FormNestedExample.vue
+++ b/playground/app/components/FormNestedExample.vue
@@ -35,8 +35,8 @@ function onError(event: any) {
     :state="state"
     :schema="schema"
     class="gap-4 flex flex-col w-60"
-    @submit="(event) => onSubmit(event)"
-    @error="(event) => onError(event)"
+    @submit="onSubmit"
+    @error="onError"
   >
     <UFormField label="Email" name="email">
       <UInput v-model="state.email" placeholder="john@lennon.com" />

--- a/playground/app/pages/components/button.vue
+++ b/playground/app/pages/components/button.vue
@@ -4,6 +4,10 @@ import theme from '#build/ui/button'
 
 const sizes = Object.keys(theme.variants.size) as Array<keyof typeof theme.variants.size>
 const variants = Object.keys(theme.variants.variant) as Array<keyof typeof theme.variants.variant>
+
+function onClick() {
+  return new Promise<void>(res => setTimeout(res, 5000))
+}
 </script>
 
 <template>
@@ -23,7 +27,7 @@ const variants = Object.keys(theme.variants.variant) as Array<keyof typeof theme
       </UButton>
     </div>
     <div class="flex items-center gap-2">
-      <UButton loading>
+      <UButton loading-auto @click="onClick">
         Loading
       </UButton>
     </div>

--- a/playground/app/pages/components/form.vue
+++ b/playground/app/pages/components/form.vue
@@ -25,7 +25,7 @@ function onSubmit(event: FormSubmitEvent<Schema>) {
         :state="state"
         :schema="schema"
         class="gap-4 flex flex-col w-60"
-        @submit="(event) => onSubmit(event)"
+        @submit="onSubmit"
       >
         <UFormField label="Email" name="email">
           <UInput v-model="state.email" placeholder="john@lennon.com" />
@@ -51,7 +51,7 @@ function onSubmit(event: FormSubmitEvent<Schema>) {
         :schema="schema"
         class="gap-4 flex flex-col w-60"
         :validate-on-input-delay="2000"
-        @submit="(event) => onSubmit(event)"
+        @submit="onSubmit"
       >
         <UFormField label="Email" name="email">
           <UInput v-model="state2.email" placeholder="john@lennon.com" />

--- a/src/runtime/composables/useFormField.ts
+++ b/src/runtime/composables/useFormField.ts
@@ -20,6 +20,7 @@ export const formBusInjectionKey: InjectionKey<UseEventBusReturn<FormEvent, stri
 export const formFieldInjectionKey: InjectionKey<ComputedRef<FormFieldInjectedOptions<FormFieldProps>>> = Symbol('nuxt-ui.form-field')
 export const inputIdInjectionKey: InjectionKey<Ref<string | undefined>> = Symbol('nuxt-ui.input-id')
 export const formInputsInjectionKey: InjectionKey<Ref<Record<string, string>>> = Symbol('nuxt-ui.form-inputs')
+export const formLoadingInjectionKey: InjectionKey<Readonly<Ref<boolean>>> = Symbol('nuxt-ui.form-loading')
 
 export function useFormField<T>(props?: Props<T>, opts?: { bind?: boolean }) {
   const formOptions = inject(formOptionsInjectionKey, undefined)

--- a/test/components/Form.spec.ts
+++ b/test/components/Form.spec.ts
@@ -81,8 +81,10 @@ describe('Form', () => {
     }
     ]
   ])('%s validation works', async (_nameOrHtml: string, options: Partial<FormProps<any>>) => {
+    const onSubmit = vi.fn()
+
     const wrapper = await renderForm({
-      props: options,
+      props: { ...options, onSubmit },
       slotTemplate: `
           <UFormField name="email">
             <UInput id="email" v-model="state.email" />
@@ -117,10 +119,9 @@ describe('Form', () => {
     await form.trigger('submit.prevent')
     await flushPromises()
 
-    expect(wrapper.emitted()).toHaveProperty('submit')
-    expect(wrapper.emitted('submit')![0][0]).toMatchObject({
+    expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
       data: { email: 'bob@dylan.com', password: 'validpassword' }
-    })
+    }))
 
     expect(wrapper.html()).toMatchSnapshot('without error')
   })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Adds the `loading-auto` prop to the Button component to automatically set the loading state based on the `@click` promise state. It also works with the Form component `@submit` promise.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
