### PR TITLE
fix(Button): duplicate click handlers

### DIFF
--- a/src/runtime/components/Button.vue
+++ b/src/runtime/components/Button.vue
@@ -25,7 +25,7 @@ export interface ButtonProps extends UseComponentIconsProps, Omit<LinkProps, 'ra
   block?: boolean
   /** Set loading state automatically based on the `@click` promise state */
   loadingAuto?: boolean
-  onClick?: (event: Event) => void | Promise<void>
+  onClick?: (event: MouseEvent) => void | Promise<void>
   class?: any
   ui?: PartialString<typeof button.slots>
 }
@@ -56,7 +56,7 @@ const { orientation, size: buttonSize } = useButtonGroup<ButtonProps>(props)
 const loadingAutoState = ref(false)
 const formLoading = inject<Ref<boolean> | undefined>(formLoadingInjectionKey, undefined)
 
-async function onClickWrapper(event: Event) {
+async function onClickWrapper(event: MouseEvent) {
   loadingAutoState.value = true
   try {
     await props.onClick?.(event)

--- a/src/runtime/components/Button.vue
+++ b/src/runtime/components/Button.vue
@@ -25,7 +25,7 @@ export interface ButtonProps extends UseComponentIconsProps, Omit<LinkProps, 'ra
   block?: boolean
   /** Set loading state automatically based on the `@click` promise state */
   loadingAuto?: boolean
-  onClick?: ((event: MouseEvent) => void | Promise<void>) | undefined
+  onClick?: ((event: MouseEvent) => void | Promise<void>) | Array<((event: MouseEvent) => void | Promise<void>)>
   class?: any
   ui?: PartialString<typeof button.slots>
 }
@@ -58,8 +58,9 @@ const formLoading = inject<Ref<boolean> | undefined>(formLoadingInjectionKey, un
 
 async function onClickWrapper(event: MouseEvent) {
   loadingAutoState.value = true
+  const callbacks = Array.isArray(props.onClick) ? props.onClick : [props.onClick]
   try {
-    await props.onClick?.(event)
+    await Promise.all(callbacks.map(fn => fn?.(event)))
   } finally {
     loadingAutoState.value = false
   }

--- a/src/runtime/components/Button.vue
+++ b/src/runtime/components/Button.vue
@@ -25,7 +25,7 @@ export interface ButtonProps extends UseComponentIconsProps, Omit<LinkProps, 'ra
   block?: boolean
   /** Set loading state automatically based on the `@click` promise state */
   loadingAuto?: boolean
-  onClick?: (event: MouseEvent) => void | Promise<void>
+  onClick?: ((event: MouseEvent) => void | Promise<void>) | undefined
   class?: any
   ui?: PartialString<typeof button.slots>
 }

--- a/src/runtime/components/LinkBase.vue
+++ b/src/runtime/components/LinkBase.vue
@@ -3,7 +3,7 @@ export interface LinkBaseProps {
   as?: string
   type?: string
   disabled?: boolean
-  click?: (e: MouseEvent) => void
+  onClick?: (e: MouseEvent) => void | Promise<void>
   href?: string
   navigate?: (e: MouseEvent) => void
   rel?: string
@@ -20,15 +20,15 @@ const props = withDefaults(defineProps<LinkBaseProps>(), {
   type: 'button'
 })
 
-function onClick(e: MouseEvent) {
+function onClickWrapper(e: MouseEvent) {
   if (props.disabled) {
     e.stopPropagation()
     e.preventDefault()
     return
   }
 
-  if (props.click) {
-    props.click(e)
+  if (props.onClick) {
+    props.onClick(e)
   }
 
   if (props.href && props.navigate && !props.isExternal) {
@@ -54,7 +54,7 @@ function onClick(e: MouseEvent) {
     }"
     :rel="rel"
     :target="target"
-    @click="onClick"
+    @click="onClickWrapper"
   >
     <slot />
   </Primitive>


### PR DESCRIPTION
Fixes an issue on the Button component where two events handlers were registered on each buttons because of the inheritance from `ULink`.