### PR TITLE
docs: enable `crawlLinks` with exclude patterns 

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -90,8 +90,22 @@ export default defineNuxtConfig({
         '/getting-started'
         // '/api/releases.json',
         // '/api/pulls.json'
-      ]
+      ],
+      crawlLinks: true
       // ignore: !process.env.NUXT_GITHUB_TOKEN ? ['/pro'] : []
+    },
+    cloudflare: {
+      pages: {
+        routes: {
+          exclude: [
+            '/components/*',
+            '/getting-started/',
+            '/composables/',
+            '/api/*',
+            '/__og-image__/*'
+          ]
+        }
+      }
     }
   },
 

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -99,8 +99,8 @@ export default defineNuxtConfig({
         routes: {
           exclude: [
             '/components/*',
-            '/getting-started/',
-            '/composables/',
+            '/getting-started/*',
+            '/composables/*',
             '/api/*',
             '/__og-image__/*'
           ]


### PR DESCRIPTION
Manually adding pages exclude patterns to avoid 100 rules limit. 

