### PR TITLE
docs: add a hint about tailwind intellisense support

### DIFF
--- a/docs/content/1.getting-started/2.installation.md
+++ b/docs/content/1.getting-started/2.installation.md
@@ -57,6 +57,23 @@ export default defineNuxtConfig({
 
 ::
 
+## IDE Intellisense
+
+The [Tailwind CSS IntelliSense](https://marketplace.visualstudio.com/items?itemName=bradlc.vscode-tailwindcss) VSCode extension looks for a `tailwind.config` file for its intellisense to work by default.
+Since Tailwind v4 relies on a css file to work and doesn't require a config file, the extension may not work as expected.
+For the extension to continue to work properly, you need to update your `.vscode/settings.json` to inform the extension where to look for the config.
+
+```json [.vscode/settings.json]
+{
+  "tailwindCSS.experimental.configFile": "./app/assets/css/main.css", // Path to your css file where you're importing `tailwind` and `@nuxt/ui`
+}
+```
+
+::note
+This only works for `css` files. It doesn't work if you import in your `app.vue`
+::
+
+
 ## Options
 
 You can customize Nuxt UI by providing options in your `nuxt.config.ts`:


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The VSCode extension for tailwind CSS looks by default for a config file for the intellisense to work properly. 
Because nuxt/ui v3 builds on top of tailwind v4 which doesn't require a config file and uses the CSS approach, the extension doesn't work as expected. I added a hint on how to solve that by telling the extension the path of the CSS file.

Note that this works only with CSS files. If you import in your app.vue and use its path, it won't work. I added that too.

Unrelated to this PR but I think the module should add a CSS file by default with the tailwind and @nuxt/ui imports and adds it to `css` in nuxt.config. Less boilerplate for the user to do.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
