### PR TITLE
fix(Dropdown/Popover): conflict in toggle for touch devices

### DIFF
--- a/src/runtime/components/elements/Dropdown.vue
+++ b/src/runtime/components/elements/Dropdown.vue
@@ -183,7 +183,7 @@ export default defineComponent({
     })
 
     function onTouchStart (event: TouchEvent) {
-      if (!event.cancelable || !menuApi.value) {
+      if (!event.cancelable || !menuApi.value || props.mode === 'click') {
         return
       }
 

--- a/src/runtime/components/overlays/Popover.vue
+++ b/src/runtime/components/overlays/Popover.vue
@@ -155,7 +155,7 @@ export default defineComponent({
     })
 
     function onTouchStart (event: TouchEvent) {
-      if (!event.cancelable || !popoverApi.value) {
+      if (!event.cancelable || !popoverApi.value || props.mode === 'click') {
         return
       }
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2261, resolves #2097, resolves #1823 and resolves #1337

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In the UDropdown & UPopover components, when you are in a touch device, clicking on the trigger button, doesn't do anything. because the "click" event & "touchstart" event conflict with each other. 
so I add a gaurd in "onTouchStart" function to do a check if "props.mode === 'click'", return from the function.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
