### PR TITLE
feat(InputMenu): allows to customize labels

### DIFF
--- a/docs/content/2.components/input-menu.md
+++ b/docs/content/2.components/input-menu.md
@@ -174,6 +174,8 @@ componentProps:
 
 Use the `#option-empty` slot to customize the content displayed when the `searchable` prop is `true` and there is no options. You will have access to the `query` property in the slot scope.
 
+You can also configure this globally through the `ui.inputMenu.default.optionEmpty.label` config. The token `{query}` will be replaced by `query` property. Defaults to `No results for "{query}".`.
+
 ::component-example
 ---
 component: 'input-menu-example-option-empty-slot'
@@ -185,6 +187,8 @@ componentProps:
 ### `empty`
 
 Use the `#empty` slot to customize the content displayed when there is no options. Defaults to `No options.`.
+
+You can also configure this globally through the `ui.inputMenu.default.empty.label` config. Defaults to `No options.`.
 
 ::component-example
 ---

--- a/src/runtime/components/forms/InputMenu.vue
+++ b/src/runtime/components/forms/InputMenu.vue
@@ -75,7 +75,7 @@
 
             <p v-if="query && !filteredOptions.length" :class="uiMenu.option.empty">
               <slot name="option-empty" :query="query">
-                No results for "{{ query }}".
+                {{ uiMenu.default.optionEmpty.label.replace('{query}', query) }}
               </slot>
             </p>
             <p v-else-if="!filteredOptions.length" :class="uiMenu.empty">

--- a/src/runtime/components/forms/InputMenu.vue
+++ b/src/runtime/components/forms/InputMenu.vue
@@ -80,7 +80,7 @@
             </p>
             <p v-else-if="!filteredOptions.length" :class="uiMenu.empty">
               <slot name="empty" :query="query">
-                No options.
+                {{ uiMenu.default.empty.label }}
               </slot>
             </p>
           </HComboboxOptions>

--- a/src/runtime/ui.config/forms/inputMenu.ts
+++ b/src/runtime/ui.config/forms/inputMenu.ts
@@ -56,6 +56,9 @@ export default {
     trailingIcon: 'i-heroicons-chevron-down-20-solid',
     empty: {
       label: 'No options.'
+    },
+    optionEmpty: {
+      label: 'No results for "{query}".'
     }
   },
   arrow: {

--- a/src/runtime/ui.config/forms/inputMenu.ts
+++ b/src/runtime/ui.config/forms/inputMenu.ts
@@ -53,7 +53,10 @@ export default {
   },
   default: {
     selectedIcon: 'i-heroicons-check-20-solid',
-    trailingIcon: 'i-heroicons-chevron-down-20-solid'
+    trailingIcon: 'i-heroicons-chevron-down-20-solid',
+    empty: {
+      label: 'No options.'
+    }
   },
   arrow: {
     ...arrow,


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Avoids to use `slots` or `props` to customize labels in InputMenu.

Request  https://github.com/nuxt/ui/pull/2266#issuecomment-2388017320.
