### PR TITLE
fix(Carousel): pages calculation

### DIFF
--- a/src/runtime/components/elements/Carousel.vue
+++ b/src/runtime/components/elements/Carousel.vue
@@ -142,16 +142,16 @@ export default defineComponent({
 
     const pages = computed(() => {
       if (!itemWidth.value) {
-        return 0;
+        return 0
       }
 
-      const itemDivisions = Math.round(carouselWidth.value / itemWidth.value);
+      const itemDivisions = Math.round(carouselWidth.value / itemWidth.value)
 
       if (props.items.length <= itemDivisions) {
-        return 0;
+        return 0
       }
 
-      return props.items.length - itemDivisions + 1;
+      return props.items.length - itemDivisions + 1
     })
 
     const isFirst = computed(() => currentPage.value <= 1)

--- a/src/runtime/components/elements/Carousel.vue
+++ b/src/runtime/components/elements/Carousel.vue
@@ -142,10 +142,16 @@ export default defineComponent({
 
     const pages = computed(() => {
       if (!itemWidth.value) {
-        return 0
+        return 0;
       }
 
-      return props.items.length - Math.round(carouselWidth.value / itemWidth.value) + 1
+      const itemDivisions = Math.round(carouselWidth.value / itemWidth.value);
+
+      if (props.items.length <= itemDivisions) {
+        return 0;
+      }
+
+      return props.items.length - itemDivisions + 1;
     })
 
     const isFirst = computed(() => currentPage.value <= 1)


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #2045 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixed the carousel pages calculation so that it no longer errors when the number of prop items is less than the number of calculated divisions.

The pages calculation in the carousel component returns a negative value when the number of items is less than the number of carousel divisions (calculated from the width of the carousel divided by the width of an item).

This causes the error `RangeError: Invalid array length` in the indicators template, as it is trying to run `v-for="page in pages"`, where `pages` is negative.

The use case which first produced this issue was a carousel of recently viewed products. Initially, there is only 1 item in the carousel, however the items widths had been setup to display multiple items, as and when the user views more products.

### 📝 Checklist

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
