### PR TITLE
feat(card): add CSS vars for bg and text

### DIFF
--- a/src/runtime/index.css
+++ b/src/runtime/index.css
@@ -30,6 +30,9 @@
     --ui-border-inverted: var(--ui-color-neutral-900);
 
     --ui-radius: var(--radius);
+
+    --ui-card-bg: var(--ui-bg);
+    --ui-card-text: var(--ui-text);
   }
 
   .dark {

--- a/src/theme/card.ts
+++ b/src/theme/card.ts
@@ -1,6 +1,6 @@
 export default {
   slots: {
-    root: 'bg-[var(--ui-bg)] ring ring-[var(--ui-border)] divide-y divide-[var(--ui-border)] rounded-[calc(var(--ui-radius)*2)] shadow',
+    root: 'bg-[var(--ui-card-bg)] text-[var(--ui-card-text)] ring ring-[var(--ui-border)] divide-y divide-[var(--ui-border)] rounded-[calc(var(--ui-radius)*2)] shadow',
     header: 'p-4 sm:px-6',
     body: 'p-4 sm:p-6',
     footer: 'p-4 sm:px-6'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
Add the ability to change background color for `<UCard />` using css

```css
.dark {
    --ui-card-bg: var(--ui-bg-elevated);
}

.dark [data-theme="midnight"] {
    --ui-bg: hsl(240 5% 6%);
    --ui-card-bg: hsl(240 4% 10%);
    --ui-card-text: hsl(60 5% 90%);
}
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
