### PR TITLE
fix(RadioGroup): rendering empty slots

### DIFF
--- a/src/runtime/components/forms/RadioGroup.vue
+++ b/src/runtime/components/forms/RadioGroup.vue
@@ -17,11 +17,11 @@
         :ui="uiRadio"
         @change="onUpdate(option.value)"
       >
-        <template #label>
+        <template v-if="$slots.label" #label>
           <slot name="label" v-bind="{ option, selected: option.selected }" />
         </template>
 
-        <template #help>
+        <template v-if="$slots.help" #help>
           <slot name="help" v-bind="{ option, selected: option.selected }" />
         </template>
       </URadio>

--- a/test/components/elements/RadioGroup.spec.ts
+++ b/test/components/elements/RadioGroup.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import type { TypeOf } from 'zod'
+import ComponentRender from '../component-render'
+import { URadioGroup } from '#components'
+
+describe('RadioGroup', () => {
+  it.each([
+    ['basic case', { props: { options: [{ value: 'value', label: 'label' }] } }],
+    ['help text', { props: { options: [{ value: 'value', label: 'label', help: 'i need somebody' }] } }]
+    // @ts-ignore
+  ])('renders %s correctly', async (nameOrHtml: string, options: TypeOf<typeof URadioGroup.props>) => {
+    const html = await ComponentRender(nameOrHtml, options, URadioGroup)
+    expect(html).toMatchSnapshot()
+  })
+})

--- a/test/components/elements/__snapshots__/RadioGroup.spec.ts.snap
+++ b/test/components/elements/__snapshots__/RadioGroup.spec.ts.snap
@@ -1,0 +1,33 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`RadioGroup > renders basic case correctly 1`] = `
+"<div class="">
+  <fieldset>
+    <!--v-if-->
+    <div class="relative flex items-start">
+      <div class="flex items-center h-5"><input id="v-0-0-0" type="radio" class="h-4 w-4 dark:checked:bg-current dark:checked:border-transparent disabled:opacity-50 disabled:cursor-not-allowed focus:ring-0 focus:ring-transparent focus:ring-offset-transparent form-radio bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 focus-visible:ring-2 focus-visible:ring-primary-500 dark:focus-visible:ring-primary-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900 text-primary-500 dark:text-primary-400" value="value"></div>
+      <div class="ms-3 flex flex-col"><label for="v-0-0-0" class="text-sm font-medium text-gray-700 dark:text-gray-200">label
+          <!--v-if-->
+        </label>
+        <!--v-if-->
+      </div>
+    </div>
+  </fieldset>
+</div>"
+`;
+
+exports[`RadioGroup > renders help text correctly 1`] = `
+"<div class="">
+  <fieldset>
+    <!--v-if-->
+    <div class="relative flex items-start">
+      <div class="flex items-center h-5"><input id="v-0-0-0" type="radio" class="h-4 w-4 dark:checked:bg-current dark:checked:border-transparent disabled:opacity-50 disabled:cursor-not-allowed focus:ring-0 focus:ring-transparent focus:ring-offset-transparent form-radio bg-white dark:bg-gray-900 border border-gray-300 dark:border-gray-700 focus-visible:ring-2 focus-visible:ring-primary-500 dark:focus-visible:ring-primary-400 focus-visible:ring-offset-2 focus-visible:ring-offset-white dark:focus-visible:ring-offset-gray-900 text-primary-500 dark:text-primary-400" value="value"></div>
+      <div class="ms-3 flex flex-col"><label for="v-0-0-0" class="text-sm font-medium text-gray-700 dark:text-gray-200">label
+          <!--v-if-->
+        </label>
+        <p class="text-sm text-gray-500 dark:text-gray-400">i need somebody</p>
+      </div>
+    </div>
+  </fieldset>
+</div>"
+`;


### PR DESCRIPTION
### 🔗 Linked issue

No issue opened. Easy fix.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`RadioGroup` component was missing a conditional to render its nested `Radio` slots. I also added a test to ensure there are no regressions related to this in the future.

This issue might affect v3 too. I can check and port the changes over there if necessary.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
