### PR TITLE
fix(Accordion): improve `items` type

### DIFF
--- a/src/runtime/types/accordion.d.ts
+++ b/src/runtime/types/accordion.d.ts
@@ -3,7 +3,7 @@ import type { Button } from './button'
 export interface AccordionItem extends Button {
   slot?: string
   disabled?: boolean
-  content?: string
+  content?: string | string[] | object | object[]
   defaultOpen?: boolean
   closeOthers?: boolean
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [X] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hello, this is my first change here, I just added more typing to the Accordion content so I can add objects, string arrays, or arrays of objects. In the second image for example in the content part, this usability allows us to use varied content not just restricted to a string, resolving the typing error that appears.
![image](https://github.com/user-attachments/assets/3df2b093-0811-480c-b011-d6113609e365)
![image](https://github.com/user-attachments/assets/556cc0df-8bad-4799-95c4-566724e4da15)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
