### PR TITLE
feat(Input): If input type `Number`, can be set `min` and `max` value.

### DIFF
--- a/src/runtime/components/forms/Input.vue
+++ b/src/runtime/components/forms/Input.vue
@@ -5,6 +5,8 @@
       ref="input"
       :name="name"
       :type="type"
+      :min="inputNumberMin"
+      :max="inputNumberMax"
       :required="required"
       :placeholder="placeholder"
       :disabled="disabled"
@@ -120,6 +122,14 @@ export default defineComponent({
     padded: {
       type: Boolean,
       default: true
+    },
+    inputNumberMin: {
+      type: Number,
+      default: null
+    },
+    inputNumberMax: {
+      type: Number,
+      default: null
     },
     size: {
       type: String as PropType<InputSize>,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #1462

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

When the type of `<UInput />` is `Number`, the `min` and `max` values ​​of `<UInput />` can be set.
like this,

Below video was set to `input-number-min: -20, input-number-max:50`.

https://github.com/user-attachments/assets/50f61cc0-b8be-4c2c-a403-35dbf5f1510c

If not set `min` and `max` values of `<UInput />`, it can adjust values ​​indefinitely as in the current state.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
