### PR TITLE
fix(module): skip devtools renderer page injection if router integration is disabled

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -176,16 +176,18 @@ export default defineNuxtModule<ModuleOptions>({
 
       nuxt.options.routeRules = defu(nuxt.options.routeRules, { '/__nuxt_ui__/**': { ssr: false } })
       extendPages((pages) => {
-        pages.unshift({
-          name: 'ui-devtools',
-          path: '/__nuxt_ui__/components/:slug',
-          file: resolve('./devtools/runtime/DevtoolsRenderer.vue'),
-          meta: {
-            // https://github.com/nuxt/nuxt/pull/29366
-            //   isolate: true
-            layout: false
-          }
-        })
+        if (pages.length) {
+          pages.unshift({
+            name: 'ui-devtools',
+            path: '/__nuxt_ui__/components/:slug',
+            file: resolve('./devtools/runtime/DevtoolsRenderer.vue'),
+            meta: {
+              // https://github.com/nuxt/nuxt/pull/29366
+              // isolate: true
+              layout: false
+            }
+          })
+        }
       })
 
       addCustomTab({


### PR DESCRIPTION

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
Resolves #2558 
<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Avoid injecting the Devtools page for rendering components if the router integration is not enabled in the user's application. In the previous implementation, injecting this page would enable the router integration on the user's behalf and result in 404 errors when the index page is not defined.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
