### PR TITLE
fix(App): remove `dir` prop

### DIFF
--- a/docs/content/1.getting-started/7.i18n/.navigation.yml
+++ b/docs/content/1.getting-started/7.i18n/.navigation.yml
@@ -1,0 +1,1 @@
+badge: New

--- a/docs/content/1.getting-started/7.i18n/1.nuxt.md
+++ b/docs/content/1.getting-started/7.i18n/1.nuxt.md
@@ -1,7 +1,7 @@
 ---
 navigation.title: Nuxt
 title: Internationalization (i18n) in a Nuxt app
-description: 'Learn how to internationalize your Nuxt app and support multi-directional support (LTR/RTL).'
+description: 'Learn how to internationalize your Nuxt app with multi-directional support (LTR/RTL).'
 select:
   items:
     - label: Nuxt
@@ -34,24 +34,6 @@ import { fr } from '@nuxt/ui/locale'
 </template>
 ```
 
-### Direction
-
-Each locale has a default direction, but you can override it using the `dir` prop if needed.
-
-Use the `dir` prop with `ltr` or `rtl` to set the global reading direction of your app:
-
-```vue [app.vue]
-<script setup lang="ts">
-import { fr } from '@nuxt/ui/locale'
-</script>
-
-<template>
-  <UApp dir="rtl" :locale="fr">
-    <NuxtPage />
-  </UApp>
-</template>
-```
-
 ### Custom locale
 
 You also have the option to add your own locale using `defineLocale`:
@@ -61,6 +43,7 @@ You also have the option to add your own locale using `defineLocale`:
 const locale = defineLocale({
   name: 'My custom locale',
   code: 'en',
+  dir: 'ltr',
   messages: {
     // implement pairs
   }
@@ -148,6 +131,36 @@ const { locale } = useI18n()
 ```
 
 ::
+
+### Dynamic direction
+
+Each locale has a `dir` property which will be used by the `App` component to set the directionality of all components.
+
+In a multilingual application, you might want to set the `lang` and `dir` attributes on the `<html>` element dynamically based on the user's locale, which you can do with the [useHead](https://nuxt.com/docs/api/composables/use-head) composable:
+
+```vue [app.vue]
+<script setup lang="ts">
+import * as locales from '@nuxt/ui/locale'
+
+const { locale } = useI18n()
+
+const lang = computed(() => locales[locale.value].code)
+const dir = computed(() => locales[locale.value].dir)
+
+useHead({
+  htmlAttrs: {
+    lang,
+    dir
+  }
+})
+</script>
+
+<template>
+  <UApp :locale="locales[locale]">
+    <NuxtPage />
+  </UApp>
+</template>
+```
 
 ## Supported languages
 

--- a/docs/content/1.getting-started/7.i18n/2.vue.md
+++ b/docs/content/1.getting-started/7.i18n/2.vue.md
@@ -1,7 +1,7 @@
 ---
 navigation.title: Vue
 title: Internationalization (i18n) in a Vue app
-description: 'Learn how to internationalize your Vue app and support multi-directional support (LTR/RTL).'
+description: 'Learn how to internationalize your Vue app with multi-directional support (LTR/RTL).'
 select:
   items:
     - label: Nuxt
@@ -34,24 +34,6 @@ import { fr } from '@nuxt/ui/locale'
 </template>
 ```
 
-### Direction
-
-Each locale has a default direction, but you can override it using the `dir` prop if needed.
-
-Use the `dir` prop with `ltr` or `rtl` to set the global reading direction of your app:
-
-```vue [App.vue]
-<script setup lang="ts">
-import { fr } from '@nuxt/ui/locale'
-</script>
-
-<template>
-  <UApp dir="rtl" :locale="fr">
-    <RouterView />
-  </UApp>
-</template>
-```
-
 ### Custom locale
 
 You also have the option to add your locale using `defineLocale`:
@@ -63,6 +45,7 @@ import { defineLocale } from '@nuxt/ui/runtime/composables/defineLocale'
 const locale = defineLocale({
   name: 'My custom locale',
   code: 'en',
+  dir: 'ltr',
   messages: {
     // implement pairs
   }
@@ -158,6 +141,39 @@ const { locale } = useI18n()
 ```
 
 ::
+
+### Dynamic direction
+
+Each locale has a `dir` property which will be used by the `App` component to set the directionality of all components.
+
+In a multilingual application, you might want to set the `lang` and `dir` attributes on the `<html>` element dynamically based on the user's locale, which you can do with the [useHead](https://unhead.unjs.io/usage/composables/use-head) composable:
+
+```vue [App.vue]
+<script setup lang="ts">
+import { computed } from 'vue'
+import { useI18n } from 'vue-i18n'
+import { useHead } from '@unhead/vue'
+import * as locales from '@nuxt/ui/locale'
+
+const { locale } = useI18n()
+
+const lang = computed(() => locales[locale.value].code)
+const dir = computed(() => locales[locale.value].dir)
+
+useHead({
+  htmlAttrs: {
+    lang,
+    dir
+  }
+})
+</script>
+
+<template>
+  <UApp :locale="locales[locale]">
+    <RouterView />
+  </UApp>
+</template>
+```
 
 ## Supported languages
 

--- a/docs/content/3.components/0.app.md
+++ b/docs/content/3.components/0.app.md
@@ -31,10 +31,6 @@ Use it as at the root of your app:
 Learn how to use the `locale` prop to change the locale of your app.
 ::
 
-::tip{to="/getting-started/i18n/nuxt#direction"}
-Learn how to use the `dir` prop to change the global reading direction of your app.
-::
-
 ## API
 
 ### Props

--- a/src/runtime/components/App.vue
+++ b/src/runtime/components/App.vue
@@ -5,7 +5,7 @@ import { extendDevtoolsMeta } from '../composables/extendDevtoolsMeta'
 import type { ToasterProps, Locale } from '../types'
 import { en } from '../locale'
 
-export interface AppProps extends Omit<ConfigProviderProps, 'useId'> {
+export interface AppProps extends Omit<ConfigProviderProps, 'useId' | 'dir'> {
   tooltip?: TooltipProviderProps
   toaster?: ToasterProps | null
   locale?: Locale
@@ -42,7 +42,7 @@ provide(localeContextInjectionKey, locale)
 </script>
 
 <template>
-  <ConfigProvider :use-id="() => (useId() as string)" :dir="dir || locale.dir" v-bind="configProviderProps">
+  <ConfigProvider :use-id="() => (useId() as string)" :dir="locale.dir" v-bind="configProviderProps">
     <TooltipProvider v-bind="tooltipProps">
       <UToaster v-if="toaster !== null" v-bind="toasterProps">
         <slot />

--- a/src/runtime/composables/defineLocale.ts
+++ b/src/runtime/composables/defineLocale.ts
@@ -1,5 +1,5 @@
-import type { Locale, Direction, Messages } from '../types/locale'
 import { defu } from 'defu'
+import type { Locale, Direction, Messages } from '../types/locale'
 
 interface DefineLocaleOptions {
   name: string


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
After talking with @Malik-Jouda, it doesn't really make sense to override the `dir` prop since any app with RTL mode will have their locale set already.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
