### PR TITLE
fix(FormField): missing conditions to apply container classes

### DIFF
--- a/src/runtime/components/FormField.vue
+++ b/src/runtime/components/FormField.vue
@@ -96,7 +96,7 @@ provide(formFieldInjectionKey, computed(() => ({
       </p>
     </div>
 
-    <div :class="[label && ui.container({ class: props.ui?.container })]">
+    <div :class="[(label || !!slots.label || description || !!slots.description) && ui.container({ class: props.ui?.container })]">
       <slot :error="error" />
 
       <p v-if="(typeof error === 'string' && error) || !!slots.error" :class="ui.error({ class: props.ui?.error })">

--- a/test/components/__snapshots__/FormField-vue.spec.ts.snap
+++ b/test/components/__snapshots__/FormField-vue.spec.ts.snap
@@ -30,7 +30,7 @@ exports[`FormField > renders with description slot correctly 1`] = `
     <!--v-if-->
     <p class="text-[var(--ui-text-muted)]">Description slot</p>
   </div>
-  <div class="">
+  <div class="mt-1 relative">
     <!--v-if-->
   </div>
 </div>"
@@ -130,7 +130,7 @@ exports[`FormField > renders with label slot correctly 1`] = `
     </div>
     <!--v-if-->
   </div>
-  <div class="">
+  <div class="mt-1 relative">
     <!--v-if-->
   </div>
 </div>"

--- a/test/components/__snapshots__/FormField.spec.ts.snap
+++ b/test/components/__snapshots__/FormField.spec.ts.snap
@@ -30,7 +30,7 @@ exports[`FormField > renders with description slot correctly 1`] = `
     <!--v-if-->
     <p class="text-[var(--ui-text-muted)]">Description slot</p>
   </div>
-  <div class="">
+  <div class="mt-1 relative">
     <!--v-if-->
   </div>
 </div>"
@@ -130,7 +130,7 @@ exports[`FormField > renders with label slot correctly 1`] = `
     </div>
     <!--v-if-->
   </div>
-  <div class="">
+  <div class="mt-1 relative">
     <!--v-if-->
   </div>
 </div>"


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

If the `label` prop is not passed but the `label` slot is used, or if a description is put but no label, the `container` class is ignored.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
