### PR TITLE
feat(Table): add pagination feature

### DIFF
--- a/playground/app/pages/components/table.vue
+++ b/playground/app/pages/components/table.vue
@@ -264,6 +264,12 @@ const columnPinning = ref({
   right: ['actions']
 })
 
+const page = ref(1)
+
+watch(page, () => {
+  tableApi.setPageIndex(page.value - 1)
+})
+
 function randomize() {
   data.value = [...data.value].sort(() => Math.random() - 0.5)
 }
@@ -325,6 +331,7 @@ onMounted(() => {
         <pre>{{ row.original }}</pre>
       </template>
     </UTable>
+    <UPagination v-if="table?.tableApi?.getPageCount() > 1" v-model:page="page" :items-per-page="1" :total="table?.tableApi?.getPageCount()" />
 
     <div class="flex items-center justify-between gap-3">
       <div class="text-sm text-[var(--ui-text-muted)]">

--- a/playground/app/pages/components/table.vue
+++ b/playground/app/pages/components/table.vue
@@ -317,6 +317,7 @@ onMounted(() => {
       :columns="columns"
       :column-pinning="columnPinning"
       :loading="loading"
+      :pagination="{ pageSize: 10, pageIndex: 0 }"
       sticky
       class="border border-[var(--ui-border-accented)] rounded-[var(--ui-radius)] flex-1"
     >

--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -277,13 +277,9 @@ defineExpose({
           </td>
         </tr>
       </tbody>
-      <tfoot v-if="tableApi.getPageCount() > 1">
-        <tr>
-          <td :colspan="columns?.length">
-            <UPagination v-model:page="page" :items-per-page="1" :total="tableApi.getPageCount()" />
-          </td>
-        </tr>
-      </tfoot>
     </table>
+    <div :class="ui.pagination({ class: [props.ui?.pagination] })">
+      <UPagination v-if="tableApi.getPageCount() > 1" v-model:page="page" :items-per-page="1" :total="tableApi.getPageCount()" />
+    </div>
   </div>
 </template>

--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -104,6 +104,7 @@ export type TableSlots<T> = {
   expanded: (props: { row: Row<T> }) => any
   empty: (props?: {}) => any
   caption: (props?: {}) => any
+  pagination: (props?: {}) => any
 } & DynamicHeaderSlots<T> & DynamicCellSlots<T>
 
 </script>
@@ -278,8 +279,10 @@ defineExpose({
         </tr>
       </tbody>
     </table>
-    <div :class="ui.pagination({ class: [props.ui?.pagination] })">
-      <UPagination v-if="tableApi.getPageCount() > 1" v-model:page="page" :items-per-page="1" :total="tableApi.getPageCount()" />
-    </div>
+    <slot name="pagination">
+      <div :class="ui.pagination({ class: [props.ui?.pagination] })">
+        <UPagination v-if="tableApi.getPageCount() > 1" v-model:page="page" :items-per-page="1" :total="tableApi.getPageCount()" />
+      </div>
+    </slot>
   </div>
 </template>

--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -110,7 +110,7 @@ export type TableSlots<T> = {
 </script>
 
 <script setup lang="ts" generic="T extends TableData">
-import { computed, ref, watch } from 'vue'
+import { computed } from 'vue'
 import {
   FlexRender,
   getCoreRowModel,
@@ -122,7 +122,6 @@ import {
 } from '@tanstack/vue-table'
 import { upperFirst } from 'scule'
 import { useLocale } from '../composables/useLocale'
-import UPagination from './Pagination.vue'
 
 const props = defineProps<TableProps<T>>()
 defineSlots<TableSlots<T>>()
@@ -208,12 +207,6 @@ const tableApi = useVueTable({
   }
 })
 
-const page = ref(1)
-
-watch(page, () => {
-  tableApi.setPageIndex(page.value - 1)
-})
-
 function valueUpdater<T extends Updater<any>>(updaterOrValue: T, ref: Ref) {
   ref.value = typeof updaterOrValue === 'function' ? updaterOrValue(ref.value) : updaterOrValue
 }
@@ -279,10 +272,5 @@ defineExpose({
         </tr>
       </tbody>
     </table>
-    <slot name="pagination">
-      <div :class="ui.pagination({ class: [props.ui?.pagination] })">
-        <UPagination v-if="tableApi.getPageCount() > 1" v-model:page="page" :items-per-page="1" :total="tableApi.getPageCount()" />
-      </div>
-    </slot>
   </div>
 </template>

--- a/src/theme/table.ts
+++ b/src/theme/table.ts
@@ -10,8 +10,7 @@ export default (options: Required<ModuleOptions>) => ({
     tr: 'data-[selected=true]:bg-[var(--ui-bg-elevated)]/50',
     th: 'px-4 py-3.5 text-sm text-[var(--ui-text-highlighted)] text-left rtl:text-right font-semibold [&:has([role=checkbox])]:pe-0',
     td: 'p-4 text-sm text-[var(--ui-text-muted)] whitespace-nowrap [&:has([role=checkbox])]:pe-0',
-    empty: 'py-6 text-center text-sm text-[var(--ui-text-muted)]',
-    pagination: 'flex justify-center items-center py-4'
+    empty: 'py-6 text-center text-sm text-[var(--ui-text-muted)]'
   },
   variants: {
     pinned: {

--- a/src/theme/table.ts
+++ b/src/theme/table.ts
@@ -10,7 +10,8 @@ export default (options: Required<ModuleOptions>) => ({
     tr: 'data-[selected=true]:bg-[var(--ui-bg-elevated)]/50',
     th: 'px-4 py-3.5 text-sm text-[var(--ui-text-highlighted)] text-left rtl:text-right font-semibold [&:has([role=checkbox])]:pe-0',
     td: 'p-4 text-sm text-[var(--ui-text-muted)] whitespace-nowrap [&:has([role=checkbox])]:pe-0',
-    empty: 'py-6 text-center text-sm text-[var(--ui-text-muted)]'
+    empty: 'py-6 text-center text-sm text-[var(--ui-text-muted)]',
+    pagination: 'flex justify-center items-center py-4'
   },
   variants: {
     pinned: {


### PR DESCRIPTION
### 🔗 Linked issue

#2441 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I've added pagination to the Table component by integrating the existing pagination component we have. This should help users navigate through large datasets more easily by breaking the data into pages.

I updated the playground table page so it shows the pagination.

Since I am bad at html and css I would like to get some help here so it fits well into the Table component. 

I will update the documentation aswell once the html and css is done.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
