### PR TITLE
feat(Accordion): add `close` event

### DIFF
--- a/src/runtime/components/elements/Accordion.vue
+++ b/src/runtime/components/elements/Accordion.vue
@@ -126,7 +126,7 @@ export default defineComponent({
       default: () => ({})
     }
   },
-  emits: ['open'],
+  emits: ['open', 'close'],
   setup(props, { emit }) {
     const { ui, attrs } = useUI('accordion', toRef(props, 'ui'), config, toRef(props, 'class'))
 
@@ -142,6 +142,8 @@ export default defineComponent({
 
         if (!isOpenBefore && isOpenAfter) {
           emit('open', index)
+        } else if (isOpenBefore && !isOpenAfter) {
+          emit('close', index)
         }
       }
     }, { immediate: true })


### PR DESCRIPTION
This PR adds the new "close" event for `UAccordion`, so both "open" and "close" are properly supported.

Example:
```vue
<template>
  <UContainer class="min-h-screen flex items-center">
    <UCard class="flex-1" :ui="{ background: 'bg-gray-50 dark:bg-gray-800/50', ring: 'ring-1 ring-gray-300 dark:ring-gray-700', divide: 'divide-y divide-gray-300 dark:divide-gray-700', header: { base: 'font-bold' } }">
      <p class="text-gray-500 dark:text-gray-400">
        <UAccordion :items="[{ label: 'Test me' }]" @open="onOpen" @close="onClose" />
      </p>
    </UCard>
  </UContainer>
</template>

<script setup>
function onOpen() {
  alert('open!')
}
function onClose() {
  alert('close!')
}
</script>
```

Fixes https://github.com/nuxt/ui/issues/2745