### PR TITLE
refactor(App): remove default locale handling

### DIFF
--- a/src/runtime/components/App.vue
+++ b/src/runtime/components/App.vue
@@ -3,7 +3,6 @@ import type { ConfigProviderProps, TooltipProviderProps } from 'radix-vue'
 import { localeContextInjectionKey } from '../composables/useLocale'
 import { extendDevtoolsMeta } from '../composables/extendDevtoolsMeta'
 import type { ToasterProps, Locale } from '../types'
-import { en } from '../locale'
 
 export interface AppProps extends Omit<ConfigProviderProps, 'useId' | 'dir'> {
   tooltip?: TooltipProviderProps
@@ -23,7 +22,7 @@ extendDevtoolsMeta({ ignore: true })
 </script>
 
 <script setup lang="ts">
-import { toRef, useId, provide, computed } from 'vue'
+import { toRef, useId, provide } from 'vue'
 import { ConfigProvider, TooltipProvider, useForwardProps } from 'radix-vue'
 import { reactivePick } from '@vueuse/core'
 import UToaster from './Toaster.vue'
@@ -37,12 +36,12 @@ const configProviderProps = useForwardProps(reactivePick(props, 'scrollBody'))
 const tooltipProps = toRef(() => props.tooltip)
 const toasterProps = toRef(() => props.toaster)
 
-const locale = computed(() => props.locale || en)
+const locale = toRef(() => props.locale)
 provide(localeContextInjectionKey, locale)
 </script>
 
 <template>
-  <ConfigProvider :use-id="() => (useId() as string)" :dir="locale.dir" v-bind="configProviderProps">
+  <ConfigProvider :use-id="() => (useId() as string)" :dir="locale?.dir" v-bind="configProviderProps">
     <TooltipProvider v-bind="tooltipProps">
       <UToaster v-if="toaster !== null" v-bind="toasterProps">
         <slot />

--- a/src/runtime/composables/useLocale.ts
+++ b/src/runtime/composables/useLocale.ts
@@ -10,9 +10,6 @@ export const localeContextInjectionKey: InjectionKey<Ref<Locale | undefined>> = 
 const _useLocale = (localeOverrides?: Ref<Locale | undefined>) => {
   const locale = localeOverrides || inject(localeContextInjectionKey, ref())!
 
-  /**
-   * If for some reason the developer does not use `UApp`, we get the language back just in case.
-   */
   return buildLocaleContext(computed(() => locale.value || en))
 }
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
Resolves #2759

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
This PR removes the default locale handling from the `App` component, as this functionality is already managed by the `useLocale` composable at: https://github.com/nuxt/ui/blob/ba874c91914b029f5da2c3529b6818d6aacb839d/src/runtime/composables/useLocale.ts#L16

Additionally, the value of `dir` prop is set to be optional because current default language is English, and Radix Vue already provides a default `ltr` value for it: https://www.radix-vue.com/utilities/config-provider.html#config-provider-1

Example results of `locale` prop from `App` component:
- With `undefined` value 
![image](https://github.com/user-attachments/assets/bcc57d4d-1859-4509-b014-c1030e221ea4)
- With `fr` value 
![image](https://github.com/user-attachments/assets/37caccc8-a3d0-4486-89b1-c9bdf1353a77)
- With `ar` value 
![image](https://github.com/user-attachments/assets/afd15c0a-1596-4d3d-ae59-f981c3f98260)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
