### PR TITLE
fix(devtools): error with renderer when `colorMode` is disabled

### DIFF
--- a/src/devtools/runtime/DevtoolsRenderer.vue
+++ b/src/devtools/runtime/DevtoolsRenderer.vue
@@ -1,7 +1,8 @@
 <script setup lang="ts">
 import { onUnmounted, onMounted, reactive } from 'vue'
 import { pascalCase } from 'scule'
-import { defineAsyncComponent, useColorMode, useRoute } from '#imports'
+import { defineAsyncComponent, useRoute } from '#imports'
+import { useColorMode } from '@vueuse/core'
 
 const route = useRoute()
 const component = route.query?.example
@@ -15,9 +16,9 @@ function onUpdateRenderer(event: Event & { data?: any }) {
   state.slots = { ...event.data.slots }
 }
 
-const colorMode = useColorMode()
+const mode = useColorMode()
 function setColorMode(event: Event & { isDark?: boolean }) {
-  colorMode.preference = event.isDark ? 'dark' : 'light'
+  mode.value = event.isDark ? 'dark' : 'light'
 }
 
 onMounted(() => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
Resolves #2788 
<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Fixes an issue with the devtools when `colorMode` is disabled by using `@vueuse` instead of the colorMode module in the devtools renderer.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
