### PR TITLE
fix(CommandPalette): keep `ignoreFilter` groups at their place

### DIFF
--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -220,14 +220,15 @@ const groups = computed(() => {
     return getGroupWithItems(group, items)
   }).filter(group => !!group)
 
-  const nonFuseGroups = props.groups?.filter(group => group.ignoreFilter && group.items?.length).map((group) => {
-    return getGroupWithItems(group, group.items || [])
-  }) || []
+  const nonFuseGroups = props.groups
+    ?.map((group, index) => ({ ...group, index }))
+    ?.filter(group => group.ignoreFilter && group.items?.length)
+    ?.map(group => ({ ...getGroupWithItems(group, group.items || []), index: group.index })) || []
 
-  return [
-    ...fuseGroups,
-    ...nonFuseGroups
-  ]
+  return nonFuseGroups.reduce((acc, group) => {
+    acc.splice(group.index, 0, group)
+    return acc
+  }, [...fuseGroups])
 })
 </script>
 


### PR DESCRIPTION
Related to #2832

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
