### PR TITLE
v3 docs: Fixed Tailwind theming

### DIFF
--- a/docs/content/1.getting-started/3.theme.md
+++ b/docs/content/1.getting-started/3.theme.md
@@ -7,9 +7,9 @@ description: 'Learn how to customize Nuxt UI components using Tailwind CSS v4, C
 
 Nuxt UI v3 uses Tailwind CSS v4 beta, you can read the [prerelease documentation](https://tailwindcss.com/docs/v4-beta) for more information.
 
-### `@theme`
+### `@layer`
 
-Tailwind CSS v4 takes a CSS-first configuration approach, you now customize your theme with CSS variables inside a `@theme` directive:
+Tailwind CSS v4 takes a CSS-first configuration approach, you now customize your theme with CSS variables inside a `@layer` directive:
 
 ::module-only
 #ui
@@ -18,7 +18,7 @@ Tailwind CSS v4 takes a CSS-first configuration approach, you now customize your
 @import "tailwindcss";
 @import "@nuxt/ui";
 
-@theme {
+@layer theme {
   --font-sans: 'Public Sans', sans-serif;
 
   --breakpoint-3xl: 1920px;
@@ -44,7 +44,7 @@ Tailwind CSS v4 takes a CSS-first configuration approach, you now customize your
 @import "tailwindcss";
 @import "@nuxt/ui-pro";
 
-@theme {
+@layer theme {
   --font-sans: 'Public Sans', sans-serif;
 
   --breakpoint-3xl: 1920px;
@@ -65,7 +65,7 @@ Tailwind CSS v4 takes a CSS-first configuration approach, you now customize your
 :::
 ::
 
-The `@theme` directive tells Tailwind to make new utilities and variants available based on these variables. It's the equivalent of the `theme.extend` key in Tailwind CSS v3 `tailwind.config.ts` file.
+The `@layer theme` directive tells Tailwind to make new utilities and variants available based on these variables. It's the equivalent of the `theme.extend` key in Tailwind CSS v3 `tailwind.config.ts` file.
 
 ::note{to="https://tailwindcss.com/docs/v4-beta#css-first-configuration" target="_blank"}
 Learn more about Tailwind CSS v4 CSS-first configuration approach.
@@ -273,7 +273,7 @@ export default defineConfig({
 ::warning
 These color aliases are not automatically defined as Tailwind CSS colors, so classes like `text-primary-500 dark:text-primary-400` won't be available by default as in Nuxt UI v2. This approach provides more flexibility and prevents overwriting of user-defined Tailwind CSS colors.<br><br>
 
-However, you can generate these classes using Tailwind's `@theme` directive, allowing you to use custom color utility classes while maintaining dynamic color aliases:
+However, you can generate these classes using Tailwind's `@layer theme` directive, allowing you to use custom color utility classes while maintaining dynamic color aliases:
 
 ::module-only
 #ui
@@ -282,7 +282,7 @@ However, you can generate these classes using Tailwind's `@theme` directive, all
 @import "tailwindcss";
 @import "@nuxt/ui";
 
-@theme {
+@layer theme {
   --color-primary-50: var(--ui-color-primary-50);
   --color-primary-100: var(--ui-color-primary-100);
   --color-primary-200: var(--ui-color-primary-200);
@@ -304,7 +304,7 @@ However, you can generate these classes using Tailwind's `@theme` directive, all
 @import "tailwindcss";
 @import "@nuxt/ui-pro";
 
-@theme {
+@layer theme {
   --color-primary-50: var(--ui-color-primary-50);
   --color-primary-100: var(--ui-color-primary-100);
   --color-primary-200: var(--ui-color-primary-200);
@@ -596,7 +596,7 @@ You can customize the default container width using the default Tailwind CSS var
 @import "tailwindcss";
 @import "@nuxt/ui";
 
-@theme {
+@layer theme {
   --container-8xl: 90rem;
 }
 
@@ -612,7 +612,7 @@ You can customize the default container width using the default Tailwind CSS var
 @import "tailwindcss";
 @import "@nuxt/ui-pro";
 
-@theme {
+@layer theme {
   --container-8xl: 90rem;
 }
 


### PR DESCRIPTION
Corrected usage, should be `@layer theme` and not `@theme`.

What I didnt change is the fact that `@theme` is not a "directive" as it is often written on this page. Instead the are using [CSS cascade layers](https://developer.mozilla.org/en-US/docs/Web/CSS/@layer).

Docs: https://tailwindcss.com/docs/v4-beta#native-css-cascade-layers