### PR TITLE
chore: make `zod` imports tree-shakeable

### DIFF
--- a/devtools/app/components/inputs/ArrayInput.vue
+++ b/devtools/app/components/inputs/ArrayInput.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { z } from 'zod'
+import * as z from 'zod'
 
 export const arrayInputSchema = z.object({
   kind: z.literal('array'),

--- a/devtools/app/components/inputs/BooleanInput.vue
+++ b/devtools/app/components/inputs/BooleanInput.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { z } from 'zod'
+import * as z from 'zod'
 
 export const booleanInputSchema = z.literal('boolean').or(z.object({
   kind: z.literal('enum'),

--- a/devtools/app/components/inputs/NumberInput.vue
+++ b/devtools/app/components/inputs/NumberInput.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { z } from 'zod'
+import * as z from 'zod'
 
 export const numberInputSchema = z.literal('number')
 export type NumberInputSchema = z.infer<typeof numberInputSchema>

--- a/devtools/app/components/inputs/ObjectInput.vue
+++ b/devtools/app/components/inputs/ObjectInput.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { z } from 'zod'
+import * as z from 'zod'
 
 export const objectInputSchema = z.object({
   kind: z.literal('object'),

--- a/devtools/app/components/inputs/StringEnumInput.vue
+++ b/devtools/app/components/inputs/StringEnumInput.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { z } from 'zod'
+import * as z from 'zod'
 
 export const stringEnumInputSchema = z.object({
   kind: z.literal('enum'),

--- a/devtools/app/components/inputs/StringInput.vue
+++ b/devtools/app/components/inputs/StringInput.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import { z } from 'zod'
+import * as z from 'zod'
 
 export const stringInputSchema = z.literal('string').or(z.string().transform(t => t.split('|').find(s => s.trim() === 'string')).pipe(z.string()))
 

--- a/docs/app/components/content/examples/form/FormExampleElements.vue
+++ b/docs/app/components/content/examples/form/FormExampleElements.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { z } from 'zod'
+import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
 
 const schema = z.object({

--- a/docs/app/components/content/examples/form/FormExampleNested.vue
+++ b/docs/app/components/content/examples/form/FormExampleNested.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { z } from 'zod'
+import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
 
 const schema = z.object({

--- a/docs/app/components/content/examples/form/FormExampleNestedList.vue
+++ b/docs/app/components/content/examples/form/FormExampleNestedList.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { z } from 'zod'
+import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
 
 const schema = z.object({

--- a/docs/app/components/content/examples/form/FormExampleZod.vue
+++ b/docs/app/components/content/examples/form/FormExampleZod.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { z } from 'zod'
+import * as z from 'zod'
 import type { FormSubmitEvent } from '#ui/types'
 
 const schema = z.object({

--- a/docs/content/3.components/form.md
+++ b/docs/content/3.components/form.md
@@ -8,7 +8,7 @@ links:
 
 ## Usage
 
-Use the Form component to validate form data using schema libraries such as [Zod](https://github.com/colinhacks/zod), [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi), [Valibot](https://github.com/fabian-hiller/valibot), [Superstruct](https://github.com/ianstormtaylor/superstruct) or your own validation logic.
+Use the Form component to validate form data using schema libraries such as [Valibot](https://github.com/fabian-hiller/valibot), [Zod](https://github.com/colinhacks/zod), [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi), [Superstruct](https://github.com/ianstormtaylor/superstruct) or your own validation logic.
 
 It works with the [FormField](/components/form-field) component to display error messages around form elements automatically.
 
@@ -16,7 +16,7 @@ It works with the [FormField](/components/form-field) component to display error
 
 It requires two props:
 - `state` - a reactive object holding the form's state.
-- `schema` - a schema object from a validation library like [Zod](https://github.com/colinhacks/zod), [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi), [Valibot](https://github.com/fabian-hiller/valibot) or [Superstruct](https://github.com/ianstormtaylor/superstruct).
+- `schema` - a schema object from a validation library like [Valibot](https://github.com/fabian-hiller/valibot), [Zod](https://github.com/colinhacks/zod), [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi) or [Superstruct](https://github.com/ianstormtaylor/superstruct).
 
 ::warning
 **No validation library is included** by default, ensure you **install the one you need**.

--- a/docs/content/3.components/form.md
+++ b/docs/content/3.components/form.md
@@ -23,6 +23,14 @@ It requires two props:
 ::
 
 ::tabs
+  ::component-example{label="Valibot"}
+  ---
+  name: 'form-example-valibot'
+  props:
+    class: 'w-60'
+  ---
+  ::
+  
   ::component-example{label="Zod"}
   ---
   name: 'form-example-zod'
@@ -42,14 +50,6 @@ It requires two props:
   ::component-example{label="Joi"}
   ---
   name: 'form-example-joi'
-  props:
-    class: 'w-60'
-  ---
-  ::
-
-  ::component-example{label="Valibot"}
-  ---
-  name: 'form-example-valibot'
   props:
     class: 'w-60'
   ---

--- a/playground/app/pages/components/form.vue
+++ b/playground/app/pages/components/form.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { z } from 'zod'
+import * as z from 'zod'
 import type { FormSubmitEvent } from '@nuxt/ui'
 import FormExampleElements from '../../../../docs/app/components/content/examples/form/FormExampleElements.vue'
 import FormExampleNestedList from '../../../../docs/app/components/content/examples/form/FormExampleNestedList.vue'

--- a/test/components/Form.spec.ts
+++ b/test/components/Form.spec.ts
@@ -1,7 +1,7 @@
 import { reactive, ref, nextTick } from 'vue'
 import { describe, it, expect, test, beforeEach, vi } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
-import { z } from 'zod'
+import * as z from 'zod'
 import * as yup from 'yup'
 import Joi from 'joi'
 import * as valibot from 'valibot'


### PR DESCRIPTION
The following import is not treeshakable:

```ts
import { z } from 'zod'
```

So I replaced it with

```ts
import * as z from 'zod'
```

Further, because zod is not very treeshakable (Issue: https://github.com/colinhacks/zod/issues/2596) and has a huge bundle size, I replaced its first place position in the docs with Valibot which is fully tree shakable, full type safe and has other benifits as well.