### PR TITLE
fix(FormGroup): report error on multiple path string

### DIFF
--- a/docs/content/2.components/form.md
+++ b/docs/content/2.components/form.md
@@ -63,11 +63,10 @@ Note that **no validation library is included** by default, so ensure you **inst
 
 ## Custom validation
 
-Use the `validate` prop to apply your own validation logic.
+Use the `validate` prop to apply your own validation logic. The validation function must return a list of errors with the following attributes:
 
-The validation function must return a list of errors with the following attributes:
 - `message` - Error message for display.
-- `path` - Path to the form element corresponding to the `name` attribute.
+- `path` - Path to the form element corresponding to the `name` attribute. To address multiple paths, join the path names with a period (`.`).
 
 ::callout{icon="i-heroicons-light-bulb"}
 Note that it can be used alongside the `schema` prop to handle complex use cases.

--- a/src/runtime/components/forms/FormGroup.vue
+++ b/src/runtime/components/forms/FormGroup.vue
@@ -109,9 +109,10 @@ export default defineComponent({
     const formErrors = inject<Ref<FormError[]> | null>('form-errors', null)
 
     const error = computed(() => {
+      console.log('formErrors', formErrors?.value)
       return (props.error && typeof props.error === 'string') || typeof props.error === 'boolean'
         ? props.error
-        : formErrors?.value?.find(error => error.path === props.name)?.message
+        : formErrors?.value?.find(error => error.path.split('.').includes(props.name))?.message
     })
 
     const size = computed(() => ui.value.size[props.size ?? config.default.size])

--- a/src/runtime/components/forms/FormGroup.vue
+++ b/src/runtime/components/forms/FormGroup.vue
@@ -109,7 +109,6 @@ export default defineComponent({
     const formErrors = inject<Ref<FormError[]> | null>('form-errors', null)
 
     const error = computed(() => {
-      console.log('formErrors', formErrors?.value)
       return (props.error && typeof props.error === 'string') || typeof props.error === 'boolean'
         ? props.error
         : formErrors?.value?.find(error => error.path.split('.').includes(props.name))?.message


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #2981 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If the error path contains multiple paths, `<UForm />` joins them with a `.`(period) character as a delimiter. This is not checked when `<UFormGroup />` needs to pick up the error in their component. This is now fixed.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
