### PR TITLE
fix(module): replace require with ES module import for tailwind colors

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -1,13 +1,12 @@
-import { createRequire } from 'node:module'
 import { defineNuxtModule, installModule, addComponentsDir, addImportsDir, createResolver, addPlugin } from '@nuxt/kit'
 import { name, version } from '../package.json'
 import createTemplates from './templates'
 import type * as config from './runtime/ui.config'
 import type { DeepPartial, Strategy } from './runtime/types'
 import installTailwind from './tailwind'
+import colors from 'tailwindcss/colors.js'
 
-const _require = createRequire(import.meta.url)
-const defaultColors = _require('tailwindcss/colors.js')
+const defaultColors = { ...colors })
 
 delete defaultColors.lightBlue
 delete defaultColors.warmGray


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
This PR replaces the use of createRequire and require() with a direct ES module import for tailwindcss/colors.js. This change resolves compatibility issues when loading ES modules in Node.js and eliminates the experimental warning caused by using require().
<!-- Why is this change required? What problem does it solve? -->

```
ERROR  (node:33684) ExperimentalWarning: CommonJS module \.nuxt\nuxtui-tailwind.config.cjs is loading ES Module \node_modules\@nuxt\ui\dist\runtime\utils\colors.js using require().
Support for loading ES Module in require() is an experimental feature and might change at any time
```
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
