### PR TITLE
fix(CommandPalette/SelectMenu): missing translations

### DIFF
--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -145,7 +145,6 @@ import UInput from './Input.vue'
 
 const props = withDefaults(defineProps<CommandPaletteProps<G, T>>(), {
   modelValue: '',
-  placeholder: 'Type a command or search...',
   labelKey: 'label',
   autofocus: true
 })
@@ -244,6 +243,7 @@ const groups = computed(() => {
   <ListboxRoot v-bind="rootProps" :class="ui.root({ class: [props.class, props.ui?.root] })">
     <ListboxFilter v-model="searchTerm" as-child>
       <UInput
+        :placeholder="placeholder || t('commandPalette.placeholder')"
         variant="none"
         :autofocus="autofocus"
         size="lg"

--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -157,7 +157,7 @@ const { t } = useLocale()
 const appConfig = useAppConfig()
 
 const rootProps = useForwardPropsEmits(reactivePick(props, 'as', 'disabled', 'multiple', 'modelValue', 'defaultValue', 'highlightOnHover'), emits)
-const inputProps = useForwardProps(reactivePick(props, 'loading', 'loadingIcon', 'placeholder'))
+const inputProps = useForwardProps(reactivePick(props, 'loading', 'loadingIcon'))
 
 // eslint-disable-next-line vue/no-dupe-keys
 const ui = commandPalette()

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -165,7 +165,7 @@ const { contains } = useFilter({ sensitivity: 'base' })
 const rootProps = useForwardPropsEmits(reactivePick(props, 'modelValue', 'defaultValue', 'open', 'defaultOpen', 'multiple', 'resetSearchTermOnBlur', 'highlightOnHover'), emits)
 const contentProps = toRef(() => defu(props.content, { side: 'bottom', sideOffset: 8, collisionPadding: 8, position: 'popper' }) as ComboboxContentProps)
 const arrowProps = toRef(() => props.arrow as ComboboxArrowProps)
-const searchInputProps = toRef(() => defu(props.searchInput, { placeholder: 'Search...', variant: 'none' }) as InputProps)
+const searchInputProps = toRef(() => defu(props.searchInput, { placeholder: t('selectMenu.search'), variant: 'none' }) as InputProps)
 
 const { emitFormBlur, emitFormInput, emitFormChange, size: formGroupSize, color, id, name, highlight, disabled } = useFormField<InputProps>(props)
 const { orientation, size: buttonGroupSize } = useButtonGroup<InputProps>(props)

--- a/src/runtime/locale/ar.ts
+++ b/src/runtime/locale/ar.ts
@@ -21,6 +21,7 @@ export default defineLocale({
       decrement: 'تقليل'
     },
     commandPalette: {
+      placeholder: 'اكتب أمرًا أو ابحث...',
       noMatch: 'لا توجد نتائج مطابقة',
       noData: 'لا توجد بيانات',
       close: 'إغلاق'
@@ -28,7 +29,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'لا توجد نتائج مطابقة',
       noData: 'لا توجد بيانات',
-      create: 'إنشاء "{label}"'
+      create: 'إنشاء "{label}"',
+      search: 'بحث...'
     },
     toast: {
       close: 'إغلاق'

--- a/src/runtime/locale/cs.ts
+++ b/src/runtime/locale/cs.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Snížit'
     },
     commandPalette: {
+      placeholder: 'Zadejte příkaz nebo hledejte...',
       noMatch: 'Žádná shoda',
       noData: 'Žádná data',
       close: 'Zavřít'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Žádná shoda',
       noData: 'Žádná data',
-      create: 'Vytvořit "{label}"'
+      create: 'Vytvořit "{label}"',
+      search: 'Hledat...'
     },
     toast: {
       close: 'Zavřít'

--- a/src/runtime/locale/da.ts
+++ b/src/runtime/locale/da.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Reducer'
     },
     commandPalette: {
+      placeholder: 'Skriv en kommando eller søg...',
       noMatch: 'Ingen matchende data',
       noData: 'Ingen data',
       close: 'Luk'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Ingen matchende data',
       noData: 'Ingen data',
-      create: 'Opret "{label}"'
+      create: 'Opret "{label}"',
+      search: 'Søg...'
     },
     toast: {
       close: 'Luk'

--- a/src/runtime/locale/de.ts
+++ b/src/runtime/locale/de.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Verringern'
     },
     commandPalette: {
+      placeholder: 'Geben Sie einen Befehl ein oder suchen Sie...',
       noMatch: 'Nichts gefunden',
       noData: 'Keine Daten',
       close: 'Schließen'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Nichts gefunden',
       noData: 'Keine Daten',
-      create: '"{label}" erstellen'
+      create: '"{label}" erstellen',
+      search: 'Suchen...'
     },
     toast: {
       close: 'Schließen'

--- a/src/runtime/locale/el.ts
+++ b/src/runtime/locale/el.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Μείωση'
     },
     commandPalette: {
+      placeholder: 'Πληκτρολογήστε μια εντολή ή αναζητήστε...',
       noMatch: 'Δεν βρέθηκαν δεδομένα',
       noData: 'Δεν υπάρχουν δεδομένα',
       close: 'Κλείσιμο'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Δεν βρέθηκαν δεδομένα',
       noData: 'Δεν υπάρχουν δεδομένα',
-      create: 'Δημιουργία "{label}"'
+      create: 'Δημιουργία "{label}"',
+      search: 'Αναζήτηση...'
     },
     toast: {
       close: 'Κλείσιμο'

--- a/src/runtime/locale/en.ts
+++ b/src/runtime/locale/en.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Decrement'
     },
     commandPalette: {
+      placeholder: 'Type a command or search...',
       noMatch: 'No matching data',
       noData: 'No data',
       close: 'Close'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'No matching data',
       noData: 'No data',
-      create: 'Create "{label}"'
+      create: 'Create "{label}"',
+      search: 'Search...'
     },
     toast: {
       close: 'Close'

--- a/src/runtime/locale/es.ts
+++ b/src/runtime/locale/es.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Decremento'
     },
     commandPalette: {
+      placeholder: 'Escribe un comando o busca...',
       noMatch: 'No hay datos coincidentes',
       noData: 'Sin datos',
       close: 'Cerrar'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'No hay datos coincidentes',
       noData: 'Sin datos',
-      create: 'Crear "{label}"'
+      create: 'Crear "{label}"',
+      search: 'Buscar...'
     },
     toast: {
       close: 'Cerrar'

--- a/src/runtime/locale/et.ts
+++ b/src/runtime/locale/et.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Vähenda'
     },
     commandPalette: {
+      placeholder: 'Sisesta käsk või otsi...',
       noMatch: 'Pole vastavaid andmeid',
       noData: 'Pole andmeid',
       close: 'Sulge'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Pole vastavaid andmeid',
       noData: 'Pole andmeid',
-      create: 'Loo "{label}"'
+      create: 'Loo "{label}"',
+      search: 'Otsi...'
     },
     toast: {
       close: 'Sulge'

--- a/src/runtime/locale/fa_ir.ts
+++ b/src/runtime/locale/fa_ir.ts
@@ -21,6 +21,7 @@ export default defineLocale({
       decrement: 'کاهش'
     },
     commandPalette: {
+      placeholder: 'یک دستور وارد کنید یا جستجو کنید...',
       noMatch: 'داده‌ای یافت نشد',
       noData: 'داده‌ای موجود نیست',
       close: 'بستن'
@@ -28,7 +29,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'داده‌ای یافت نشد',
       noData: 'داده‌ای موجود نیست',
-      create: 'ایجاد "{label}"'
+      create: 'ایجاد "{label}"',
+      search: 'جستجو...'
     },
     toast: {
       close: 'بستن'

--- a/src/runtime/locale/fi.ts
+++ b/src/runtime/locale/fi.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Vähennä'
     },
     commandPalette: {
+      placeholder: 'Kirjoita komento tai hae...',
       noMatch: 'Ei vastaavia tietoja',
       noData: 'Ei tietoja',
       close: 'Sulje'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Ei vastaavia tietoja',
       noData: 'Ei tietoja',
-      create: 'Luo "{label}"'
+      create: 'Luo "{label}"',
+      search: 'Hae...'
     },
     toast: {
       close: 'Sulje'

--- a/src/runtime/locale/fr.ts
+++ b/src/runtime/locale/fr.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Diminuer'
     },
     commandPalette: {
+      placeholder: 'Tapez une commande ou recherchez...',
       noMatch: 'Aucune donnée correspondante',
       noData: 'Aucune donnée',
       close: 'Fermer'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Aucune donnée correspondante',
       noData: 'Aucune donnée',
-      create: 'Créer "{label}"'
+      create: 'Créer "{label}"',
+      search: 'Rechercher...'
     },
     toast: {
       close: 'Fermer'

--- a/src/runtime/locale/id.ts
+++ b/src/runtime/locale/id.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Kurangi'
     },
     commandPalette: {
+      placeholder: 'Ketik perintah atau cari...',
       noMatch: 'Tidak ada data yang cocok',
       noData: 'Tidak ada data',
       close: 'Tutup'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Tidak ada data yang cocok',
       noData: 'Tidak ada data',
-      create: 'Buat "{label}"'
+      create: 'Buat "{label}"',
+      search: 'Cari...'
     },
     toast: {
       close: 'Tutup'

--- a/src/runtime/locale/it.ts
+++ b/src/runtime/locale/it.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Diminuisci'
     },
     commandPalette: {
+      placeholder: 'Digita un comando o cerca...',
       noMatch: 'Nessun dato corrispondente',
       noData: 'Nessun dato',
       close: 'Chiudi'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Nessun dato corrispondente',
       noData: 'Nessun dato',
-      create: 'Crea "{label}"'
+      create: 'Crea "{label}"',
+      search: 'Cerca...'
     },
     toast: {
       close: 'Chiudi'

--- a/src/runtime/locale/ja.ts
+++ b/src/runtime/locale/ja.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: '減らす'
     },
     commandPalette: {
+      placeholder: 'コマンドを入力するか検索...',
       noMatch: '一致するデータがありません',
       noData: 'データがありません',
       close: '閉じる'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: '一致するデータがありません',
       noData: 'データがありません',
-      create: '"{label}"を作成'
+      create: '"{label}"を作成',
+      search: '検索...'
     },
     toast: {
       close: '閉じる'

--- a/src/runtime/locale/ko.ts
+++ b/src/runtime/locale/ko.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: '감소'
     },
     commandPalette: {
+      placeholder: '명령을 입력하거나 검색...',
       noMatch: '일치하는 데이터가 없습니다.',
       noData: '데이터가 없습니다.',
       close: '닫기'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: '일치하는 데이터가 없습니다.',
       noData: '데이터가 없습니다.',
-      create: '"{label}" 생성'
+      create: '"{label}" 생성',
+      search: '검색...'
     },
     toast: {
       close: '닫기'

--- a/src/runtime/locale/nl.ts
+++ b/src/runtime/locale/nl.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Verlagen'
     },
     commandPalette: {
+      placeholder: 'Typ een commando of zoek...',
       noMatch: 'Geen overeenkomende gegevens',
       noData: 'Geen gegevens',
       close: 'Sluiten'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Geen overeenkomende gegevens',
       noData: 'Geen gegevens',
-      create: '"{label}" creëren'
+      create: '"{label}" creëren',
+      search: 'Zoeken...'
     },
     toast: {
       close: 'Sluiten'

--- a/src/runtime/locale/pl.ts
+++ b/src/runtime/locale/pl.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Zmniejsz'
     },
     commandPalette: {
+      placeholder: 'Wpisz polecenie lub wyszukaj...',
       noMatch: 'Brak pasujących danych',
       noData: 'Brak danych',
       close: 'Zamknij'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Brak pasujących danych',
       noData: 'Brak danych',
-      create: 'Utwórz "{label}"'
+      create: 'Utwórz "{label}"',
+      search: 'Szukaj...'
     },
     toast: {
       close: 'Zamknij'

--- a/src/runtime/locale/pt.ts
+++ b/src/runtime/locale/pt.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Decrementar'
     },
     commandPalette: {
+      placeholder: 'Digite um comando ou pesquise...',
       noMatch: 'Nenhum dado correspondente',
       noData: 'Sem dados',
       close: 'Fechar'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Nenhum dado correspondente',
       noData: 'Sem dados',
-      create: 'Criar "{label}"'
+      create: 'Criar "{label}"',
+      search: 'Buscar...'
     },
     toast: {
       close: 'Fechar'

--- a/src/runtime/locale/pt_br.ts
+++ b/src/runtime/locale/pt_br.ts
@@ -29,7 +29,7 @@ export default defineLocale({
       noMatch: 'Nenhum dado correspondente',
       noData: 'Nenhum dado',
       create: 'Criar "{label}"',
-      search: 'Buscar...'
+      search: 'Pesquisar...'
     },
     toast: {
       close: 'Fechar'

--- a/src/runtime/locale/pt_br.ts
+++ b/src/runtime/locale/pt_br.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Decrementar'
     },
     commandPalette: {
+      placeholder: 'Digite um comando ou pesquise...',
       noMatch: 'Nenhum dado correspondente',
       noData: 'Nenhum dado',
       close: 'Fechar'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Nenhum dado correspondente',
       noData: 'Nenhum dado',
-      create: 'Criar "{label}"'
+      create: 'Criar "{label}"',
+      search: 'Buscar...'
     },
     toast: {
       close: 'Fechar'

--- a/src/runtime/locale/ru.ts
+++ b/src/runtime/locale/ru.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Уменьшить'
     },
     commandPalette: {
+      placeholder: 'Введите команду или выполните поиск...',
       noMatch: 'Совпадений не найдено',
       noData: 'Нет данных',
       close: 'Закрыть'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Совпадений не найдено',
       noData: 'Нет данных',
-      create: 'Создать "{label}"'
+      create: 'Создать "{label}"',
+      search: 'Поиск...'
     },
     toast: {
       close: 'Закрыть'

--- a/src/runtime/locale/sk.ts
+++ b/src/runtime/locale/sk.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Znížiť'
     },
     commandPalette: {
+      placeholder: 'Zadajte príkaz alebo vyhľadajte...',
       noMatch: 'Žiadna zhoda',
       noData: 'Žiadne dáta',
       close: 'Zatvoriť'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Žiadna zhoda',
       noData: 'Žiadne dáta',
-      create: 'Vytvoriť "{label}"'
+      create: 'Vytvoriť "{label}"',
+      search: 'Hľadať...'
     },
     toast: {
       close: 'Zatvoriť'

--- a/src/runtime/locale/sv.ts
+++ b/src/runtime/locale/sv.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Minska'
     },
     commandPalette: {
+      placeholder: 'Skriv ett kommando eller sök...',
       noMatch: 'Inga matchande data',
       noData: 'Inga data',
       close: 'Stäng'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Inga matchande data',
       noData: 'Inga data',
-      create: 'Skapa "{label}"'
+      create: 'Skapa "{label}"',
+      search: 'Sök...'
     },
     toast: {
       close: 'Stäng'

--- a/src/runtime/locale/th.ts
+++ b/src/runtime/locale/th.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'ลด'
     },
     commandPalette: {
+      placeholder: 'พิมพ์คำสั่งหรือค้นหา...',
       noMatch: 'ไม่พบข้อมูลที่ตรงกัน',
       noData: 'ไม่มีข้อมูล',
       close: 'ปิด'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'ไม่พบข้อมูลที่ตรงกัน',
       noData: 'ไม่มีข้อมูล',
-      create: 'สร้าง "{label}"'
+      create: 'สร้าง "{label}"',
+      search: 'ค้นหา...'
     },
     toast: {
       close: 'ปิด'

--- a/src/runtime/locale/tr.ts
+++ b/src/runtime/locale/tr.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Azalt'
     },
     commandPalette: {
+      placeholder: 'Bir komut yazın veya arama yapın...',
       noMatch: 'Eşleşen veri yok',
       noData: 'Veri yok',
       close: 'Kapat'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Eşleşen veri yok',
       noData: 'Veri yok',
-      create: '"{label}" oluştur'
+      create: '"{label}" oluştur',
+      search: 'Ara...'
     },
     toast: {
       close: 'Kapat'

--- a/src/runtime/locale/uk.ts
+++ b/src/runtime/locale/uk.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Зменшити'
     },
     commandPalette: {
+      placeholder: 'Введіть команду або шукайте...',
       noMatch: 'Збігів не знайдено',
       noData: 'Немає даних',
       close: 'Закрити'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Збігів не знайдено',
       noData: 'Немає даних',
-      create: 'Створити "{label}"'
+      create: 'Створити "{label}"',
+      search: 'Пошук...'
     },
     toast: {
       close: 'Закрити'

--- a/src/runtime/locale/vi.ts
+++ b/src/runtime/locale/vi.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: 'Giảm'
     },
     commandPalette: {
+      placeholder: 'Nhập lệnh hoặc tìm kiếm...',
       noMatch: 'Không có kết quả phù hợp',
       noData: 'Không có dữ liệu',
       close: 'Đóng'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: 'Không có kết quả phù hợp',
       noData: 'Không có dữ liệu',
-      create: 'Tạo "{label}"'
+      create: 'Tạo "{label}"',
+      search: 'Tìm kiếm...'
     },
     toast: {
       close: 'Đóng'

--- a/src/runtime/locale/zh_hans.ts
+++ b/src/runtime/locale/zh_hans.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: '减少'
     },
     commandPalette: {
+      placeholder: '输入命令或搜索...',
       noMatch: '没有匹配的数据',
       noData: '没有数据',
       close: '关闭'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: '没有匹配的数据',
       noData: '没有数据',
-      create: '创建 "{label}"'
+      create: '创建 "{label}"',
+      search: '搜索...'
     },
     toast: {
       close: '关闭'

--- a/src/runtime/locale/zh_hant.ts
+++ b/src/runtime/locale/zh_hant.ts
@@ -20,6 +20,7 @@ export default defineLocale({
       decrement: '减少'
     },
     commandPalette: {
+      placeholder: '輸入命令或搜尋...',
       noMatch: '沒有匹配的資料',
       noData: '沒有資料',
       close: '關閉'
@@ -27,7 +28,8 @@ export default defineLocale({
     selectMenu: {
       noMatch: '沒有匹配的資料',
       noData: '沒有資料',
-      create: '創建 "{label}"'
+      create: '創建 "{label}"',
+      search: '搜尋...'
     },
     toast: {
       close: '關閉'

--- a/src/runtime/types/locale.ts
+++ b/src/runtime/types/locale.ts
@@ -15,6 +15,7 @@ export type Messages = {
     decrement: string
   }
   commandPalette: {
+    placeholder: string
     noMatch: string
     noData: string
     close: string
@@ -23,6 +24,7 @@ export type Messages = {
     noMatch: string
     noData: string
     create: string
+    search: string
   }
   toast: {
     close: string


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
Resolves #2906
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
selectMenu: `Search...`
commandPalette: `Type a command or search...`
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
