### PR TITLE
fix(locale): year translation missing `ñ` in `es`

### DIFF
--- a/src/runtime/locale/es.ts
+++ b/src/runtime/locale/es.ts
@@ -10,8 +10,8 @@ export default defineLocale({
       create: 'Crear "{label}"'
     },
     calendar: {
-      prevYear: 'A o anterior',
-      nextYear: 'A o siguiente',
+      prevYear: 'Año anterior',
+      nextYear: 'Año siguiente',
       prevMonth: 'Mes anterior',
       nextMonth: 'Mes siguiente'
     },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Probably due to some encoding issues character `ñ` is missing.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
