### PR TITLE
fix(Form): standard schema validation no longer wrapped in `value` object

### DIFF
--- a/src/runtime/utils/form.ts
+++ b/src/runtime/utils/form.ts
@@ -47,9 +47,7 @@ export async function validateStandardSchema(
   state: any,
   schema: StandardSchemaV1
 ): Promise<ValidateReturnSchema<typeof state>> {
-  const result = await schema['~standard'].validate({
-    value: state
-  })
+  const result = await schema['~standard'].validate(state)
 
   if (result.issues) {
     return {
@@ -63,7 +61,7 @@ export async function validateStandardSchema(
 
   return {
     errors: null,
-    result: result.value
+    result
   }
 }
 

--- a/src/runtime/utils/form.ts
+++ b/src/runtime/utils/form.ts
@@ -61,7 +61,7 @@ export async function validateStandardSchema(
 
   return {
     errors: null,
-    result
+    result: result.value
   }
 }
 
@@ -195,14 +195,14 @@ export function validateSchema<T extends object>(state: T, schema: FormSchema<T>
     return validateZodSchema(state, schema)
   } else if (isJoiSchema(schema)) {
     return validateJoiSchema(state, schema)
+  } else if (isStandardSchema(schema)) {
+    return validateStandardSchema(state, schema)
   } else if (isValibotSchema(schema)) {
     return validateValibotSchema(state, schema)
   } else if (isYupSchema(schema)) {
     return validateYupSchema(state, schema)
   } else if (isSuperStructSchema(schema)) {
     return validateSuperstructSchema(state, schema)
-  } else if (isStandardSchema(schema)) {
-    return validateStandardSchema(state, schema)
   } else {
     throw new Error('Form validation failed: Unsupported form schema')
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Not an issue, but it was noticed in this PR: #2880 

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

The standard schema validation implementation wrapped the state in an object with `value` as key:
```ts
const result = await schema['~standard'].validate({
  value: state,
})
```
The wrapped object is now also part of the object to be validated. This means all error messages also have `value` added to their path and breaks it. I highly suspect this is an artifact left behind from copying the valibot validator from UI2?

Anyways, in the `standard-schema` [repo](https://github.com/standard-schema/standard-schema?tab=readme-ov-file#third-party) the example does not show to wrap the input data.

New implementation:
```ts
const result = await schema['~standard'].validate(state)
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
