### PR TITLE
feat(SelectMenu): add inputTargetForm prop to handle input validation

### DIFF
--- a/src/runtime/components/forms/SelectMenu.vue
+++ b/src/runtime/components/forms/SelectMenu.vue
@@ -16,6 +16,7 @@
       :value="modelValue"
       :required="required"
       :class="uiMenu.required"
+      :form="inputTargetForm"
       tabindex="-1"
       aria-hidden="true"
     >
@@ -312,6 +313,10 @@ export default defineComponent({
     },
     searchAttributes: {
       type: Array,
+      default: null
+    },
+    inputTargetForm: {
+      type: String,
       default: null
     },
     popper: {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves [#3106](https://github.com/nuxt/ui/issues/3106)

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds an inputTargetForm prop in the SelectMenu component to be able to use form validation on the component's input.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
