### PR TITLE
fix(Modal): button side-effects when used within a button group

### DIFF
--- a/src/runtime/components/Modal.vue
+++ b/src/runtime/components/Modal.vue
@@ -73,7 +73,7 @@ extendDevtoolsMeta({ example: 'ModalExample' })
 </script>
 
 <script setup lang="ts">
-import { computed, toRef } from 'vue'
+import { computed, toRef, provide } from 'vue'
 import { DialogRoot, DialogTrigger, DialogPortal, DialogOverlay, DialogContent, DialogTitle, DialogDescription, DialogClose, useForwardPropsEmits } from 'reka-ui'
 import { reactivePick } from '@vueuse/core'
 import { useAppConfig } from '#imports'
@@ -112,6 +112,9 @@ const ui = computed(() => modal({
   transition: props.transition,
   fullscreen: props.fullscreen
 }))
+
+// Blocks ButtonGroup injections to avoid side-effects if the modal is within a button group.
+provide(buttonGroupInjectionKey, undefined)
 </script>
 
 <template>

--- a/src/runtime/composables/useButtonGroup.ts
+++ b/src/runtime/composables/useButtonGroup.ts
@@ -6,7 +6,7 @@ import type { GetObjectField } from '../types/utils'
 export const buttonGroupInjectionKey: InjectionKey<ComputedRef<{
   size: ButtonGroupProps['size']
   orientation: ButtonGroupProps['orientation']
-}>> = Symbol('nuxt-ui.button-group')
+}> | undefined> = Symbol('nuxt-ui.button-group')
 
 type Props<T> = {
   size?: GetObjectField<T, 'size'>
@@ -14,6 +14,7 @@ type Props<T> = {
 
 export function useButtonGroup<T>(props: Props<T>) {
   const buttonGroup = inject(buttonGroupInjectionKey, undefined)
+
   return {
     orientation: computed(() => buttonGroup?.value.orientation),
     size: computed(() => props?.size ?? buttonGroup?.value.size)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
Resolves #2978 
<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Fixes side-effects on button components in a modal which are rendered as if they are in a ButtonGroup if the modal is within a ButtonGroup.

The solution here is to override Button's group injection key in the Modal component. This is not ideal but solves the issue. A better solution could be to update the button groups style to only affect direct childs (https://github.com/nuxt/ui/blob/v3/src/theme/button-group.ts#L1).

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
