### PR TITLE
docs(input): fix `aria-label` on examples

### DIFF
--- a/docs/app/components/content/examples/input/InputPasswordStrengthIndicatorExample.vue
+++ b/docs/app/components/content/examples/input/InputPasswordStrengthIndicatorExample.vue
@@ -51,7 +51,7 @@ const text = computed(() => {
             variant="link"
             size="sm"
             :icon="show ? 'i-lucide-eye-off' : 'i-lucide-eye'"
-            aria-label="show ? 'Hide password' : 'Show password'"
+            :aria-label="show ? 'Hide password' : 'Show password'"
             :aria-pressed="show"
             aria-controls="password"
             @click="show = !show"

--- a/docs/app/components/content/examples/input/InputPasswordToggleExample.vue
+++ b/docs/app/components/content/examples/input/InputPasswordToggleExample.vue
@@ -16,7 +16,7 @@ const password = ref('password')
         variant="link"
         size="sm"
         :icon="show ? 'i-lucide-eye-off' : 'i-lucide-eye'"
-        aria-label="show ? 'Hide password' : 'Show password'"
+        :aria-label="show ? 'Hide password' : 'Show password'"
         :aria-pressed="show"
         aria-controls="password"
         @click="show = !show"


### PR DESCRIPTION
### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `:` was missing here, causing the value to be set to the JS code as a string literal instead of the correct label.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
