### PR TITLE
feat(NavigationMenu): conditionally-rendered links

### DIFF
--- a/docs/app/components/content/examples/navigation-menu/NavigationMenuConditionExample.vue
+++ b/docs/app/components/content/examples/navigation-menu/NavigationMenuConditionExample.vue
@@ -1,0 +1,110 @@
+<script setup lang="ts">
+const items = ref([
+  {
+    label: 'Guide',
+    icon: 'i-lucide-book-open',
+    children: [
+      {
+        label: 'Introduction',
+        description: 'Fully styled and customizable components for Nuxt.',
+        icon: 'i-lucide-house'
+      },
+      {
+        label: 'Installation',
+        description: 'Learn how to install and configure Nuxt UI in your application.',
+        icon: 'i-lucide-cloud-download'
+      },
+      {
+        label: 'Icons',
+        icon: 'i-lucide-smile',
+        description: 'You have nothing to do, @nuxt/icon will handle it automatically.'
+      },
+      {
+        label: 'Colors',
+        icon: 'i-lucide-swatch-book',
+        description: 'Choose a primary and a neutral color from your Tailwind CSS theme.'
+      },
+      {
+        label: 'Theme',
+        icon: 'i-lucide-cog',
+        description: 'You can customize components by using the `class` / `ui` props or in your app.config.ts.'
+      }
+    ]
+  },
+  {
+    label: 'Composables',
+    icon: 'i-lucide-database',
+    children: [
+      {
+        label: 'defineShortcuts',
+        icon: 'i-lucide-file-text',
+        description: 'Define shortcuts for your application.'
+      },
+      {
+        label: 'useModal',
+        icon: 'i-lucide-file-text',
+        description: 'Display a modal within your application.'
+      },
+      {
+        label: 'useSlideover',
+        icon: 'i-lucide-file-text',
+        description: 'Display a slideover within your application.'
+      },
+      {
+        label: 'useToast',
+        icon: 'i-lucide-file-text',
+        description: 'Display a toast within your application.'
+      }
+    ]
+  },
+  {
+    label: 'Components',
+    icon: 'i-lucide-box',
+    condition: true,
+    children: [
+      {
+        label: 'Link',
+        icon: 'i-lucide-file-text',
+        description: 'Use NuxtLink with superpowers.'
+      },
+      {
+        label: 'Modal',
+        icon: 'i-lucide-file-text',
+        description: 'Display a modal within your application.'
+      },
+      {
+        label: 'NavigationMenu',
+        icon: 'i-lucide-file-text',
+        description: 'Display a list of links.'
+      },
+      {
+        label: 'Pagination',
+        icon: 'i-lucide-file-text',
+        description: 'Display a list of pages.'
+      },
+      {
+        label: 'Popover',
+        icon: 'i-lucide-file-text',
+        description: 'Display a non-modal dialog that floats around a trigger element.'
+      },
+      {
+        label: 'Progress',
+        icon: 'i-lucide-file-text',
+        description: 'Show a horizontal bar to indicate task progression.'
+      }
+    ]
+  }
+])
+
+const active = ref()
+
+defineShortcuts({
+  c: () => {
+    items.value[2].condition = !items.value[2].condition
+  }
+})
+</script>
+
+<template>
+  <UNavigationMenu v-model="active" :items="items" class="w-full justify-center" />
+</template>

--- a/docs/content/3.components/navigation-menu.md
+++ b/docs/content/3.components/navigation-menu.md
@@ -24,6 +24,7 @@ Use the `items` prop as an array of objects with the following properties:
 - `type?: 'label' | 'link'`{lang="ts-type"}
 - `value?: string`{lang="ts-type"}
 - `disabled?: boolean`{lang="ts-type"}
+- `condition?: boolean`{lang="ts-type"}
 - `class?: any`{lang="ts-type"}
 - [`slot?: string`{lang="ts-type"}](#with-custom-slot)
 - `onSelect?(e: Event): void`{lang="ts-type"}
@@ -724,6 +725,21 @@ In this example, leveraging [`defineShortcuts`](/composables/define-shortcuts), 
 
 ::tip
 You can also pass the `value` of one of the items if provided.
+::
+
+### Conditionally rendered items
+
+Items can be conditionally rendered based on their provided `condition`.
+
+::component-example
+---
+collapse: true
+name: 'navigation-menu-condition-example'
+---
+::
+
+::note
+ In this example, you can change the condition of the last item using :kbd{value="c"}.
 ::
 
 ### With custom slot

--- a/src/runtime/components/NavigationMenu.vue
+++ b/src/runtime/components/NavigationMenu.vue
@@ -27,6 +27,13 @@ export interface NavigationMenuItem extends Omit<LinkProps, 'type' | 'raw' | 'cu
    * `{ size: 'sm', color: 'neutral', variant: 'outline' }`{lang="ts-type"}
    */
   badge?: string | number | BadgeProps
+  /**
+   * The condition under which to render the item
+   * Omitting this property will render the item at all times
+   *
+   * @defaultValue true
+   */
+  condition?: boolean
   trailingIcon?: string
   /**
    * The type of the item.
@@ -229,75 +236,79 @@ const lists = computed(() => props.items?.length ? (Array.isArray(props.items[0]
   <NavigationMenuRoot v-bind="rootProps" :data-collapsed="collapsed" :class="ui.root({ class: [props.class, props.ui?.root] })">
     <template v-for="(list, listIndex) in lists" :key="`list-${listIndex}`">
       <NavigationMenuList :class="ui.list({ class: props.ui?.list })">
-        <component
-          :is="(orientation === 'vertical' && item.children?.length) ? UCollapsible : NavigationMenuItem"
+        <template 
           v-for="(item, index) in list"
           :key="`list-${listIndex}-${index}`"
-          as="li"
-          :value="item.value || String(index)"
-          :default-open="item.defaultOpen"
-          :unmount-on-hide="(orientation === 'vertical' && item.children?.length) ? unmountOnHide : undefined"
-          :open="item.open"
-          :class="ui.item({ class: props.ui?.item })"
         >
-          <div v-if="orientation === 'vertical' && item.type === 'label'" :class="ui.label({ class: props.ui?.label })">
-            <ReuseItemTemplate :item="(item as T)" :index="index" />
-          </div>
-          <ULink v-else-if="item.type !== 'label'" v-slot="{ active, ...slotProps }" v-bind="(orientation === 'vertical' && item.children?.length) ? {} : pickLinkProps(item as Omit<NavigationMenuItem, 'type'>)" custom>
-            <component
-              :is="(orientation === 'horizontal' && (item.children?.length || !!slots[item.slot ? `${item.slot}-content` : 'item-content'])) ? NavigationMenuTrigger : NavigationMenuLink"
-              as-child
-              :active="active"
-              :disabled="item.disabled"
-              @select="item.onSelect"
-            >
-              <ULinkBase v-bind="slotProps" :class="ui.link({ class: [props.ui?.link, item.class], active: active || item.active, disabled: !!item.disabled, level: !(orientation === 'vertical' && item.children?.length) })">
-                <ReuseItemTemplate :item="(item as T)" :active="active || item.active" :index="index" />
-              </ULinkBase>
-            </component>
-
-            <NavigationMenuContent v-if="orientation === 'horizontal' && (item.children?.length || !!slots[item.slot ? `${item.slot}-content` : 'item-content'])" v-bind="contentProps" :class="ui.content({ class: props.ui?.content })">
-              <slot :name="item.slot ? `${item.slot}-content` : 'item-content'" :item="(item as T)" :active="active" :index="index">
-                <ul :class="ui.childList({ class: props.ui?.childList })">
-                  <li v-for="(childItem, childIndex) in item.children" :key="childIndex" :class="ui.childItem({ class: props.ui?.childItem })">
-                    <ULink v-slot="{ active: childActive, ...childSlotProps }" v-bind="pickLinkProps(childItem)" custom>
-                      <NavigationMenuLink as-child :active="childActive" @select="childItem.onSelect">
-                        <ULinkBase v-bind="childSlotProps" :class="ui.childLink({ class: [props.ui?.childLink, childItem.class], active: childActive })">
-                          <UIcon v-if="childItem.icon" :name="childItem.icon" :class="ui.childLinkIcon({ class: props.ui?.childLinkIcon, active: childActive })" />
-
-                          <div :class="ui.childLinkWrapper({ class: props.ui?.childLinkWrapper })">
-                            <p :class="ui.childLinkLabel({ class: props.ui?.childLinkLabel, active: childActive })">
-                              {{ get(childItem, props.labelKey as string) }}
-
-                              <UIcon v-if="childItem.target === '_blank'" :name="appConfig.ui.icons.external" :class="ui.childLinkLabelExternalIcon({ class: props.ui?.childLinkLabelExternalIcon, active: childActive })" />
-                            </p>
-                            <p v-if="childItem.description" :class="ui.childLinkDescription({ class: props.ui?.childLinkDescription, active: childActive })">
-                              {{ childItem.description }}
-                            </p>
-                          </div>
-                        </ULinkBase>
-                      </NavigationMenuLink>
-                    </ULink>
-                  </li>
-                </ul>
-              </slot>
-            </NavigationMenuContent>
-          </ULink>
-
-          <template v-if="orientation === 'vertical' && item.children?.length" #content>
-            <ul :class="ui.childList({ class: props.ui?.childList })">
-              <li v-for="(childItem, childIndex) in item.children" :key="childIndex" :class="ui.childItem({ class: props.ui?.childItem })">
-                <ULink v-slot="{ active: childActive, ...childSlotProps }" v-bind="pickLinkProps(childItem)" custom>
-                  <NavigationMenuLink as-child :active="childActive" @select="childItem.onSelect">
-                    <ULinkBase v-bind="childSlotProps" :class="ui.link({ class: [props.ui?.link, childItem.class], active: childActive, disabled: !!childItem.disabled, level: true })">
-                      <ReuseItemTemplate :item="(childItem as T)" :active="childActive" :index="childIndex" />
-                    </ULinkBase>
-                  </NavigationMenuLink>
-                </ULink>
-              </li>
-            </ul>
-          </template>
-        </component>
+          <component
+            v-if="item.condition ?? true"
+            :is="(orientation === 'vertical' && item.children?.length) ? UCollapsible : NavigationMenuItem"
+            as="li"
+            :value="item.value || String(index)"
+            :default-open="item.defaultOpen"
+            :unmount-on-hide="(orientation === 'vertical' && item.children?.length) ? unmountOnHide : undefined"
+            :open="item.open"
+            :class="ui.item({ class: props.ui?.item })"
+          >
+            <div v-if="orientation === 'vertical' && item.type === 'label'" :class="ui.label({ class: props.ui?.label })">
+              <ReuseItemTemplate :item="(item as T)" :index="index" />
+            </div>
+            <ULink v-else-if="item.type !== 'label'" v-slot="{ active, ...slotProps }" v-bind="(orientation === 'vertical' && item.children?.length) ? {} : pickLinkProps(item as Omit<NavigationMenuItem, 'type'>)" custom>
+              <component
+                :is="(orientation === 'horizontal' && (item.children?.length || !!slots[item.slot ? `${item.slot}-content` : 'item-content'])) ? NavigationMenuTrigger : NavigationMenuLink"
+                as-child
+                :active="active"
+                :disabled="item.disabled"
+                @select="item.onSelect"
+              >
+                <ULinkBase v-bind="slotProps" :class="ui.link({ class: [props.ui?.link, item.class], active: active || item.active, disabled: !!item.disabled, level: !(orientation === 'vertical' && item.children?.length) })">
+                  <ReuseItemTemplate :item="(item as T)" :active="active || item.active" :index="index" />
+                </ULinkBase>
+              </component>
+  
+              <NavigationMenuContent v-if="orientation === 'horizontal' && (item.children?.length || !!slots[item.slot ? `${item.slot}-content` : 'item-content'])" v-bind="contentProps" :class="ui.content({ class: props.ui?.content })">
+                <slot :name="item.slot ? `${item.slot}-content` : 'item-content'" :item="(item as T)" :active="active" :index="index">
+                  <ul :class="ui.childList({ class: props.ui?.childList })">
+                    <li v-for="(childItem, childIndex) in item.children" :key="childIndex" :class="ui.childItem({ class: props.ui?.childItem })">
+                      <ULink v-slot="{ active: childActive, ...childSlotProps }" v-bind="pickLinkProps(childItem)" custom>
+                        <NavigationMenuLink as-child :active="childActive" @select="childItem.onSelect">
+                          <ULinkBase v-bind="childSlotProps" :class="ui.childLink({ class: [props.ui?.childLink, childItem.class], active: childActive })">
+                            <UIcon v-if="childItem.icon" :name="childItem.icon" :class="ui.childLinkIcon({ class: props.ui?.childLinkIcon, active: childActive })" />
+  
+                            <div :class="ui.childLinkWrapper({ class: props.ui?.childLinkWrapper })">
+                              <p :class="ui.childLinkLabel({ class: props.ui?.childLinkLabel, active: childActive })">
+                                {{ get(childItem, props.labelKey as string) }}
+  
+                                <UIcon v-if="childItem.target === '_blank'" :name="appConfig.ui.icons.external" :class="ui.childLinkLabelExternalIcon({ class: props.ui?.childLinkLabelExternalIcon, active: childActive })" />
+                              </p>
+                              <p v-if="childItem.description" :class="ui.childLinkDescription({ class: props.ui?.childLinkDescription, active: childActive })">
+                                {{ childItem.description }}
+                              </p>
+                            </div>
+                          </ULinkBase>
+                        </NavigationMenuLink>
+                      </ULink>
+                    </li>
+                  </ul>
+                </slot>
+              </NavigationMenuContent>
+            </ULink>
+  
+            <template v-if="orientation === 'vertical' && item.children?.length" #content>
+              <ul :class="ui.childList({ class: props.ui?.childList })">
+                <li v-for="(childItem, childIndex) in item.children" :key="childIndex" :class="ui.childItem({ class: props.ui?.childItem })">
+                  <ULink v-slot="{ active: childActive, ...childSlotProps }" v-bind="pickLinkProps(childItem)" custom>
+                    <NavigationMenuLink as-child :active="childActive" @select="childItem.onSelect">
+                      <ULinkBase v-bind="childSlotProps" :class="ui.link({ class: [props.ui?.link, childItem.class], active: childActive, disabled: !!childItem.disabled, level: true })">
+                        <ReuseItemTemplate :item="(childItem as T)" :active="childActive" :index="childIndex" />
+                      </ULinkBase>
+                    </NavigationMenuLink>
+                  </ULink>
+                </li>
+              </ul>
+            </template>
+          </component>
+        </template>
       </NavigationMenuList>
 
       <div v-if="orientation === 'vertical' && listIndex < lists.length - 1" :class="ui.separator({ class: props.ui?.separator })" />

--- a/src/runtime/components/NavigationMenu.vue
+++ b/src/runtime/components/NavigationMenu.vue
@@ -236,13 +236,13 @@ const lists = computed(() => props.items?.length ? (Array.isArray(props.items[0]
   <NavigationMenuRoot v-bind="rootProps" :data-collapsed="collapsed" :class="ui.root({ class: [props.class, props.ui?.root] })">
     <template v-for="(list, listIndex) in lists" :key="`list-${listIndex}`">
       <NavigationMenuList :class="ui.list({ class: props.ui?.list })">
-        <template 
+        <template
           v-for="(item, index) in list"
           :key="`list-${listIndex}-${index}`"
         >
           <component
-            v-if="item.condition ?? true"
             :is="(orientation === 'vertical' && item.children?.length) ? UCollapsible : NavigationMenuItem"
+            v-if="item.condition ?? true"
             as="li"
             :value="item.value || String(index)"
             :default-open="item.defaultOpen"
@@ -265,7 +265,7 @@ const lists = computed(() => props.items?.length ? (Array.isArray(props.items[0]
                   <ReuseItemTemplate :item="(item as T)" :active="active || item.active" :index="index" />
                 </ULinkBase>
               </component>
-  
+
               <NavigationMenuContent v-if="orientation === 'horizontal' && (item.children?.length || !!slots[item.slot ? `${item.slot}-content` : 'item-content'])" v-bind="contentProps" :class="ui.content({ class: props.ui?.content })">
                 <slot :name="item.slot ? `${item.slot}-content` : 'item-content'" :item="(item as T)" :active="active" :index="index">
                   <ul :class="ui.childList({ class: props.ui?.childList })">
@@ -274,11 +274,11 @@ const lists = computed(() => props.items?.length ? (Array.isArray(props.items[0]
                         <NavigationMenuLink as-child :active="childActive" @select="childItem.onSelect">
                           <ULinkBase v-bind="childSlotProps" :class="ui.childLink({ class: [props.ui?.childLink, childItem.class], active: childActive })">
                             <UIcon v-if="childItem.icon" :name="childItem.icon" :class="ui.childLinkIcon({ class: props.ui?.childLinkIcon, active: childActive })" />
-  
+
                             <div :class="ui.childLinkWrapper({ class: props.ui?.childLinkWrapper })">
                               <p :class="ui.childLinkLabel({ class: props.ui?.childLinkLabel, active: childActive })">
                                 {{ get(childItem, props.labelKey as string) }}
-  
+
                                 <UIcon v-if="childItem.target === '_blank'" :name="appConfig.ui.icons.external" :class="ui.childLinkLabelExternalIcon({ class: props.ui?.childLinkLabelExternalIcon, active: childActive })" />
                               </p>
                               <p v-if="childItem.description" :class="ui.childLinkDescription({ class: props.ui?.childLinkDescription, active: childActive })">
@@ -293,7 +293,7 @@ const lists = computed(() => props.items?.length ? (Array.isArray(props.items[0]
                 </slot>
               </NavigationMenuContent>
             </ULink>
-  
+
             <template v-if="orientation === 'vertical' && item.children?.length" #content>
               <ul :class="ui.childList({ class: props.ui?.childList })">
                 <li v-for="(childItem, childIndex) in item.children" :key="childIndex" :class="ui.childItem({ class: props.ui?.childItem })">


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
This PR introduces the possibility of conditionally rendered items in `UNavigationMenu`.

This improves the overall support `UNavigationMenu` will have to all kinds of navigations, including providing links to items that only need to exist under certain conditions.

For example, only an authorized user should see a link to their profile page.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
