### PR TITLE
fix(Table): revert #2600 to fix excessive column data slot re-renders

### DIFF
--- a/src/runtime/components/data/Table.vue
+++ b/src/runtime/components/data/Table.vue
@@ -104,7 +104,6 @@
 
                 <slot
                   v-else
-                  :key="retriggerSlot"
                   :name="`${column.key}-data`"
                   :column="column"
                   :row="row"
@@ -132,7 +131,7 @@
 </template>
 
 <script lang="ts">
-import { computed, defineComponent, ref, toRaw, toRef, watch } from 'vue'
+import { computed, defineComponent, toRaw, toRef } from 'vue'
 import type { PropType, AriaAttributes } from 'vue'
 import { upperFirst } from 'scule'
 import { defu } from 'defu'
@@ -306,8 +305,6 @@ export default defineComponent({
         row: null
       })
     })
-
-    const retriggerSlot = ref(null)
 
     const savedSort = { column: sort.value.column, direction: null }
 
@@ -483,12 +480,6 @@ export default defineComponent({
       return undefined
     }
 
-    watch(rows, () => {
-      retriggerSlot.value = new Date()
-    }, {
-      deep: true
-    })
-
     return {
       // eslint-disable-next-line vue/no-dupe-keys
       ui,
@@ -515,8 +506,7 @@ export default defineComponent({
       getRowData,
       toggleOpened,
       getAriaSort,
-      isExpanded,
-      retriggerSlot
+      isExpanded
     }
   }
 })


### PR DESCRIPTION

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #3367

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This reverts commit b23f2decfc9607555a315d0d087d0a042f03a938.

Release v2.20.0 includes PR https://github.com/nuxt/ui/pull/2600 which re-renders every table column data slot on any changes to the table source data. This introduces significant performance impact on large tables and makes it difficult for users to interact with inputs within tables since the re-render will lose cursor position. This also makes it impossible to tab between columns when data changes. This change was attempting to fix an issue which is unrelated to the Table component as demonstrate in https://github.com/nuxt/ui/issues/2004#issuecomment-2671025567. This PR reverts those changes, returning Table data slot behavior to v2.19.1.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
