### PR TITLE
docs(Header): fix github link

### DIFF
--- a/docs/app/components/Header.vue
+++ b/docs/app/components/Header.vue
@@ -64,6 +64,7 @@ const items = computed(() => props.links.map(({ icon, ...link }) => link))
 
       <UTooltip text="Open on GitHub" class="hidden lg:flex">
         <UButton
+          :key="value"
           color="neutral"
           variant="ghost"
           :to="`https://github.com/nuxt/${value}`"


### PR DESCRIPTION
I’m adding the `:key` attribute to the button to force its render with the correct URL when a page loads with a selector already set to `ui-pro`. I had a similar issue on a project last week, occurring only in the build, and adding this attribute resolved the problem.

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
