### PR TITLE
feat(Tabs): add before-change event

### DIFF
--- a/docs/components/content/examples/TabsExampleBeforeChange.vue
+++ b/docs/components/content/examples/TabsExampleBeforeChange.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+const items = [{
+  label: 'Tab1',
+  icon: 'i-heroicons-information-circle',
+  content: 'This is the content shown for Tab1'
+}, {
+  label: 'Tab2',
+  icon: 'i-heroicons-arrow-down-tray',
+  content: 'And, this is the content for Tab2'
+}, {
+  label: 'Tab3',
+  icon: 'i-heroicons-eye-dropper',
+  content: 'Finally, this is the content for Tab3'
+}]
+
+function onBeforeChange(prevIndex, next) {
+  if (window.confirm('Do you want to change tab?')) {
+    const prevItem = items[prevIndex]
+    alert(`Tab was changed! Previous tab is ${prevItem.label}`)
+    return next()
+  }
+  alert('Tab was not changed!')
+}
+</script>
+
+<template>
+  <UTabs :items="items" @before-change="onBeforeChange" />
+</template>

--- a/docs/content/2.components/tabs.md
+++ b/docs/content/2.components/tabs.md
@@ -66,6 +66,20 @@ componentProps:
 
 You can use the `content` prop and set it to `false` to avoid the rendering of the HTML content if you don't need it.
 
+#### Listen to @before-change event
+
+You can execute code before the `@change` event is triggered by using the `@before-change` event. This event emits the index of the previously selected item and provides a second `next()` argument, which you can use to continue handling the `@change` event.
+
+::component-example
+---
+component: 'tabs-example-before-change'
+componentProps:
+  class: 'w-full'
+---
+::
+
+This event is useful when you need to validate data before switching tabs or display a confirmation window with a relevant message to users.
+
 ### Control the selected index
 
 Use a `v-model` to control the selected index.

--- a/src/runtime/components/navigation/Tabs.vue
+++ b/src/runtime/components/navigation/Tabs.vue
@@ -53,7 +53,7 @@
 </template>
 
 <script lang="ts">
-import { toRef, ref, watch, onMounted, defineComponent, nextTick } from 'vue'
+import { toRef, ref, watch, onMounted, defineComponent, nextTick, getCurrentInstance } from 'vue'
 import type { PropType } from 'vue'
 import { TabGroup as HTabGroup, TabList as HTabList, Tab as HTab, TabPanels as HTabPanels, TabPanel as HTabPanel, provideUseId } from '@headlessui/vue'
 import { useResizeObserver } from '@vueuse/core'
@@ -113,7 +113,7 @@ export default defineComponent({
       default: () => ({})
     }
   },
-  emits: ['update:modelValue', 'change'],
+  emits: ['update:modelValue', 'change', 'beforeChange'],
   setup(props, { emit }) {
     const { ui, attrs } = useUI('tabs', toRef(props, 'ui'), config, toRef(props, 'class'))
 
@@ -122,6 +122,7 @@ export default defineComponent({
     const markerRef = ref<HTMLElement>()
 
     const selectedIndex = ref<number | undefined>(props.modelValue || props.defaultIndex)
+    const beforeChangeEventPassed = ref(!!getCurrentInstance()?.vnode.props?.onBeforeChange)
 
     // Methods
 
@@ -142,7 +143,13 @@ export default defineComponent({
       markerRef.value.style.height = `${tab.offsetHeight}px`
     }
 
-    function onChange(index: number) {
+    async function onChange(index: number) {
+      if (beforeChangeEventPassed.value) {
+        await new Promise((resolve) => {
+          emit('beforeChange', selectedIndex.value, resolve)
+        })
+      }
+
       selectedIndex.value = index
 
       emit('change', index)
@@ -185,6 +192,7 @@ export default defineComponent({
       markerRef,
       selectedIndex,
       onChange
+      // computedSelectedIndex
     }
   }
 })

--- a/src/runtime/components/navigation/Tabs.vue
+++ b/src/runtime/components/navigation/Tabs.vue
@@ -192,7 +192,6 @@ export default defineComponent({
       markerRef,
       selectedIndex,
       onChange
-      // computedSelectedIndex
     }
   }
 })


### PR DESCRIPTION
### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR introduces a new `@before-change` event for the Tabs component, allowing code execution before the `@change` event is triggered. This is useful in scenarios where data validation is required before switching tabs or when preventing (or resolving) the next `@change` event handling.

Under the hood, it uses a `Promise` object with the `resolve()` method, which is passed to the `before-change` event emitter. This allows it to be invoked when needed to resolve the next @change event handling.

Example: Verify that form data in a tab has been properly saved before switching to another tab, and display a confirmation window with a relevant message to users.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.