### PR TITLE
fix(Table): allow links to be opened when @select is used

### DIFF
--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -289,7 +289,7 @@ function handleRowSelect(row: TableRow<T>, e: Event) {
     return
   }
   const target = e.target as HTMLElement
-  const isInteractive = target.closest('button')
+  const isInteractive = target.closest('button') || target.closest('a')
   if (isInteractive) {
     return
   }


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

If `@select` is used on a Table like in the [documentation](https://ui.nuxt.com/components/table#with-select-event), clicking on `<a>` tags in a cell doesn't open the link.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
