### PR TITLE
fix(vue): missing unhead context

### DIFF
--- a/src/runtime/plugins/colors.ts
+++ b/src/runtime/plugins/colors.ts
@@ -2,6 +2,7 @@ import { computed } from 'vue'
 import { defineNuxtPlugin, useAppConfig, useNuxtApp, useHead } from '#imports'
 // FIXME: https://github.com/nuxt/module-builder/issues/141#issuecomment-2078248248
 import type {} from '#app'
+import type { UseHeadInput } from '@unhead/vue/types'
 
 export default defineNuxtPlugin(() => {
   const appConfig = useAppConfig()
@@ -33,12 +34,11 @@ export default defineNuxtPlugin(() => {
   })
 
   // Head
-  const headData: any = {
+  const headData: UseHeadInput = {
     style: [{
       innerHTML: () => root.value,
-      tagPriority: -2,
-      id: 'nuxt-ui-colors',
-      type: 'text/css'
+      tagPriority: 'critical',
+      id: 'nuxt-ui-colors'
     }]
   }
 
@@ -55,7 +55,5 @@ export default defineNuxtPlugin(() => {
     }]
   }
 
-  if (!nuxtApp.isVue) {
-    useHead(headData)
-  }
+  useHead(headData)
 })

--- a/src/runtime/vue/plugins/head.ts
+++ b/src/runtime/vue/plugins/head.ts
@@ -3,6 +3,11 @@ import type { Plugin } from 'vue'
 
 export default {
   install(app) {
+    // check for existing head instance to avoid replacement
+    // bit hacky but we can't use injectHead() here
+    if (app._context.provides.usehead) {
+      return
+    }
     const head = createHead()
     app.use(head)
   }

--- a/src/runtime/vue/stubs.ts
+++ b/src/runtime/vue/stubs.ts
@@ -69,7 +69,7 @@ export function useNuxtApp() {
 export function defineNuxtPlugin(plugin: (nuxtApp: NuxtApp) => void) {
   return {
     install(app) {
-      plugin({ vueApp: app } as NuxtApp)
+      app.runWithContext(() => plugin({ vueApp: app } as NuxtApp))
     }
   } satisfies VuePlugin
 }

--- a/src/runtime/vue/stubs.ts
+++ b/src/runtime/vue/stubs.ts
@@ -61,7 +61,6 @@ export const useState = <T>(key: string, init: () => T): Ref<T> => {
 export function useNuxtApp() {
   return {
     isHydrating: true,
-    isVue: true,
     payload: { serverRendered: false }
   }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The Vue context is not set when we're executing plugins which is causing the Unhead instance to not be available. 

We also tidy up some of the input:
- Prefer relative `tagPriority` which will ensure Capo.js sorting is correctly applied
- Missing type
- `type="text/css"` is not typed as it's deprecated, better to just remove it

& fix an issue where the Unhead instance will be replaced if it's already installed.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
