### PR TITLE
docs: broken 404 pages

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -105,9 +105,10 @@ export default defineNuxtConfig({
       routes: [
         '/getting-started',
         '/api/countries.json',
-        '/api/locales.json'
+        '/api/locales.json',
         // '/api/releases.json',
         // '/api/pulls.json'
+        '/404.html'
       ],
       crawlLinks: true,
       autoSubfolderIndex: false


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The 404 handling is a bit messed up with excluding the prerendered pages and cloudflare atm.

https://ui.nuxt.com/getting-started/missing-page

As it's excluded from the server handler cloudflare will try and fetch the html file, since it's missing it tries to fetch `404.html`, nitro doesn't generate that so it falls back to `index.html`. This results in a 200 response for a missing page, since we load index.html it redirects the path there.

We can probably fix this upstream but not exactly sure what it looks like yet.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
