### PR TITLE
refactor(Form)!: drop explicit support for `zod` and `valibot`

### DIFF
--- a/docs/app/components/content/examples/form/FormExampleValibot.vue
+++ b/docs/app/components/content/examples/form/FormExampleValibot.vue
@@ -22,7 +22,7 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
 </script>
 
 <template>
-  <UForm :schema="v.safeParser(schema)" :state="state" class="space-y-4" @submit="onSubmit">
+  <UForm :schema="schema" :state="state" class="space-y-4" @submit="onSubmit">
     <UFormField label="Email" name="email">
       <UInput v-model="state.email" />
     </UFormField>

--- a/docs/content/3.components/form.md
+++ b/docs/content/3.components/form.md
@@ -9,7 +9,7 @@ links:
 
 ## Usage
 
-Use the Form component to validate form data using schema libraries such as [Valibot](https://github.com/fabian-hiller/valibot), [Zod](https://github.com/colinhacks/zod), [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi), [Superstruct](https://github.com/ianstormtaylor/superstruct) or your own validation logic.
+Use the Form component to validate form data using validation libraries such as [Valibot](https://github.com/fabian-hiller/valibot), [Zod](https://github.com/colinhacks/zod), [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi), [Superstruct](https://github.com/ianstormtaylor/superstruct) or your own validation logic.
 
 It works with the [FormField](/components/form-field) component to display error messages around form elements automatically.
 
@@ -18,7 +18,7 @@ It works with the [FormField](/components/form-field) component to display error
 It requires two props:
 
 - `state` - a reactive object holding the form's state.
-- `schema` - a schema object from a validation library like [Valibot](https://github.com/fabian-hiller/valibot), [Zod](https://github.com/colinhacks/zod), [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi) or [Superstruct](https://github.com/ianstormtaylor/superstruct).
+- `schema` - any [Standard Schema](https://standardschema.dev/) or a schema from [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi) or [Superstruct](https://github.com/ianstormtaylor/superstruct).
 
 ::warning
 **No validation library is included** by default, ensure you **install the one you need**.

--- a/docs/package.json
+++ b/docs/package.json
@@ -27,7 +27,7 @@
     "shiki-transformer-color-highlight": "^1.0.0",
     "superstruct": "^2.0.2",
     "ufo": "^1.5.4",
-    "valibot": "^0.42.1",
+    "valibot": "^1.0.0",
     "yup": "^1.6.1",
     "zod": "^3.24.2"
   },

--- a/package.json
+++ b/package.json
@@ -134,7 +134,7 @@
     "nuxt": "^3.16.0",
     "release-it": "^18.1.2",
     "superstruct": "^2.0.2",
-    "valibot": "^0.42.1",
+    "valibot": "^1.0.0",
     "vitest": "^3.0.9",
     "vitest-environment-nuxt": "^1.0.1",
     "vue-tsc": "^2.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -184,8 +184,8 @@ importers:
         specifier: ^2.0.2
         version: 2.0.2
       valibot:
-        specifier: ^0.42.1
-        version: 0.42.1(typescript@5.6.3)
+        specifier: ^1.0.0
+        version: 1.0.0(typescript@5.6.3)
       vitest:
         specifier: ^3.0.9
         version: 3.0.9(@types/debug@4.1.12)(@types/node@22.13.10)(happy-dom@17.4.4)(jiti@2.4.2)(lightningcss@1.29.2)(terser@5.39.0)(yaml@2.7.0)
@@ -292,8 +292,8 @@ importers:
         specifier: ^1.5.4
         version: 1.5.4
       valibot:
-        specifier: ^0.42.1
-        version: 0.42.1(typescript@5.6.3)
+        specifier: ^1.0.0
+        version: 1.0.0(typescript@5.6.3)
       yup:
         specifier: ^1.6.1
         version: 1.6.1
@@ -6827,8 +6827,8 @@ packages:
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
-  valibot@0.42.1:
-    resolution: {integrity: sha512-3keXV29Ar5b//Hqi4MbSdV7lfVp6zuYLZuA9V1PvQUsXqogr+u5lvLPLk3A4f74VUXDnf/JfWMN6sB+koJ/FFw==}
+  valibot@1.0.0:
+    resolution: {integrity: sha512-1Hc0ihzWxBar6NGeZv7fPLY0QuxFMyxwYR2sF1Blu7Wq7EnremwY2W02tit2ij2VJT8HcSkHAQqmFfl77f73Yw==}
     peerDependencies:
       typescript: 5.6.3
     peerDependenciesMeta:
@@ -14879,7 +14879,7 @@ snapshots:
 
   util-deprecate@1.0.2: {}
 
-  valibot@0.42.1(typescript@5.6.3):
+  valibot@1.0.0(typescript@5.6.3):
     optionalDependencies:
       typescript: 5.6.3
 

--- a/renovate.json
+++ b/renovate.json
@@ -6,8 +6,6 @@
     "enabled": true
   },
   "ignoreDeps": [
-    "valibot30",
-    "valibot31",
     "typescript",
     "vaul-vue",
     "vue-tsc"

--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,8 @@
     "enabled": true
   },
   "ignoreDeps": [
+    "valibot30",
+    "valibot31",
     "typescript",
     "vaul-vue",
     "vue-tsc"

--- a/src/runtime/types/form.ts
+++ b/src/runtime/types/form.ts
@@ -1,9 +1,7 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { ComputedRef, DeepReadonly, Ref } from 'vue'
-import type { ZodSchema } from 'zod'
 import type { Schema as JoiSchema } from 'joi'
 import type { ObjectSchema as YupObjectSchema } from 'yup'
-import type { GenericSchema as ValibotSchema, GenericSchemaAsync as ValibotSchemaAsync, SafeParser as ValibotSafeParser, SafeParserAsync as ValibotSafeParserAsync } from 'valibot'
 import type { GetObjectField } from './utils'
 import type { Struct as SuperstructSchema } from 'superstruct'
 
@@ -23,12 +21,7 @@ export interface Form<T extends object> {
 }
 
 export type FormSchema<T extends object> =
-  | ZodSchema
   | YupObjectSchema<T>
-  | ValibotSchema
-  | ValibotSchemaAsync
-  | ValibotSafeParser<any, any>
-  | ValibotSafeParserAsync<any, any>
   | JoiSchema<T>
   | SuperstructSchema<any, any>
   | StandardSchemaV1

--- a/src/runtime/utils/form.ts
+++ b/src/runtime/utils/form.ts
@@ -1,8 +1,6 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
-import type { ZodSchema } from 'zod'
 import type { ValidationError as JoiError, Schema as JoiSchema } from 'joi'
 import type { ObjectSchema as YupObjectSchema, ValidationError as YupError } from 'yup'
-import type { GenericSchema as ValibotSchema, GenericSchemaAsync as ValibotSchemaAsync, SafeParser as ValibotSafeParser, SafeParserAsync as ValibotSafeParserAsync } from 'valibot'
 import type { Struct } from 'superstruct'
 import type { FormSchema, ValidateReturnSchema } from '../types/form'
 
@@ -23,20 +21,12 @@ export function isSuperStructSchema(schema: any): schema is Struct<any, any> {
   )
 }
 
-export function isZodSchema(schema: any): schema is ZodSchema {
-  return schema.parse !== undefined
-}
-
 export function isJoiSchema(schema: any): schema is JoiSchema {
   return schema.validateAsync !== undefined && schema.id !== undefined
 }
 
 export function isJoiError(error: any): error is JoiError {
   return error.isJoi === true
-}
-
-export function isValibotSchema(schema: any): schema is ValibotSchema | ValibotSchemaAsync | ValibotSafeParser<any, any> | ValibotSafeParserAsync<any, any> {
-  return '_run' in schema || (typeof schema === 'function' && 'schema' in schema)
 }
 
 export function isStandardSchema(schema: any): schema is StandardSchemaV1 {
@@ -112,28 +102,6 @@ async function validateSuperstructSchema(state: any, schema: Struct<any, any>): 
   }
 }
 
-async function validateZodSchema(
-  state: any,
-  schema: ZodSchema
-): Promise<ValidateReturnSchema<typeof state>> {
-  const result = await schema.safeParseAsync(state)
-  if (result.success === false) {
-    const errors = result.error.issues.map(issue => ({
-      name: issue.path.join('.'),
-      message: issue.message
-    }))
-
-    return {
-      errors,
-      result: null
-    }
-  }
-  return {
-    result: result.data,
-    errors: null
-  }
-}
-
 async function validateJoiSchema(
   state: any,
   schema: JoiSchema
@@ -161,44 +129,11 @@ async function validateJoiSchema(
   }
 }
 
-async function validateValibotSchema(
-  state: any,
-  schema: ValibotSchema | ValibotSchemaAsync | ValibotSafeParser<any, any> | ValibotSafeParserAsync<any, any>
-): Promise<ValidateReturnSchema<typeof state>> {
-  const result = await ('_run' in schema ? schema._run({ typed: false, value: state }, {}) : schema(state))
-
-  if (!result.issues || result.issues.length === 0) {
-    const output = ('output' in result
-      ? result.output
-      : 'value' in result
-        ? result.value
-        : null)
-    return {
-      errors: null,
-      result: output
-    }
-  }
-
-  const errors = result.issues.map(issue => ({
-    name: issue.path?.map((item: any) => item.key).join('.') || '',
-    message: issue.message
-  }))
-
-  return {
-    errors,
-    result: null
-  }
-}
-
 export function validateSchema<T extends object>(state: T, schema: FormSchema<T>): Promise<ValidateReturnSchema<typeof state>> {
-  if (isZodSchema(schema)) {
-    return validateZodSchema(state, schema)
+  if (isStandardSchema(schema)) {
+    return validateStandardSchema(state, schema)
   } else if (isJoiSchema(schema)) {
     return validateJoiSchema(state, schema)
-  } else if (isStandardSchema(schema)) {
-    return validateStandardSchema(state, schema)
-  } else if (isValibotSchema(schema)) {
-    return validateValibotSchema(state, schema)
   } else if (isYupSchema(schema)) {
     return validateYupSchema(state, schema)
   } else if (isSuperStructSchema(schema)) {

--- a/test/components/Form.spec.ts
+++ b/test/components/Form.spec.ts
@@ -59,13 +59,6 @@ describe('Form', () => {
       })
     }
     ],
-    ['valibot safeParser', {
-      schema: valibot.safeParser(valibot.object({
-        email: valibot.string(),
-        password: valibot.pipe(valibot.string(), valibot.minLength(8, 'Must be at least 8 characters'))
-      }))
-    }
-    ],
     ['superstruct', {
       schema: object({
         email: nonempty(string()),


### PR DESCRIPTION
Removes explicit support of `zod` and `valibot` in the form component in favor of the `standard-schema` implementation.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
