### PR TITLE
feat: onClick support for `BreadcrumbItem`

### DIFF
--- a/docs/content/3.components/breadcrumb.md
+++ b/docs/content/3.components/breadcrumb.md
@@ -19,7 +19,7 @@ Use the `items` prop as an array of objects with the following properties:
 - `class?: any`{lang="ts-type"}
 - [`slot?: string`{lang="ts-type"}](#with-custom-slot)
 
-You can pass any property from the [Link](/components/link#props) component such as `to`, `target`, etc.
+You can pass any property from the [Link](/components/link#props) component such as `to`, `target`, `onClick`, etc.
 
 ::component-code
 ---

--- a/playground/app/pages/components/breadcrumb.vue
+++ b/playground/app/pages/components/breadcrumb.vue
@@ -1,32 +1,48 @@
 <script setup lang="ts">
-const items = [{
+import type { BreadcrumbItem, DropdownMenuItem } from '#ui/types'
+
+type BreadcrumbItemWithChildren = BreadcrumbItem & { children?: DropdownMenuItem[] }
+
+const items = ref([{
   label: 'Home',
-  to: '/'
+  to: '/',
+  onClick: () => console.log('click Home')
 }, {
   slot: 'dropdown' as const,
   icon: 'i-lucide-ellipsis',
   children: [{
     label: 'Documentation'
   }, {
-    label: 'Themes'
+    label: 'Themes',
+    onSelect: () => console.log('select Themes')
   }, {
     label: 'GitHub'
   }]
-}, {
+} as BreadcrumbItemWithChildren, {
   label: 'Components',
-  disabled: true
+  disabled: true,
+  to: '/components',
+  onClick: (e) => {
+    console.log('click Components (should not fire when disabled)')
+    console.log('prevent default nav')
+    e.preventDefault()
+  }
 }, {
   label: 'Breadcrumb',
-  to: '/components/breadcrumb'
-}]
+  to: '/components/breadcrumb',
+  onClick: () => console.log('click Breadcrumb')
+}] as BreadcrumbItem[])
 </script>
 
 <template>
-  <UBreadcrumb :items="items">
-    <template #dropdown="{ item }">
-      <UDropdownMenu :items="item.children">
-        <UButton :icon="item.icon" color="neutral" variant="link" class="p-0.5" />
-      </UDropdownMenu>
-    </template>
-  </UBreadcrumb>
+  <div class="flex flex-col gap-2">
+    <UBreadcrumb :items="items">
+      <template #dropdown="{ item }">
+        <UDropdownMenu :items="(item as BreadcrumbItemWithChildren).children">
+          <UButton :icon="item.icon" color="neutral" variant="link" class="p-0.5" />
+        </UDropdownMenu>
+      </template>
+    </UBreadcrumb>
+    <USwitch v-if="items[2]" v-model="items[2].disabled" label="Components item disabled" />
+  </div>
 </template>

--- a/src/runtime/components/Breadcrumb.vue
+++ b/src/runtime/components/Breadcrumb.vue
@@ -11,7 +11,8 @@ const appConfigBreadcrumb = _appConfig as AppConfig & { ui: { breadcrumb: Partia
 
 const breadcrumb = tv({ extend: tv(theme), ...(appConfigBreadcrumb.ui?.breadcrumb || {}) })
 
-export interface BreadcrumbItem extends Omit<LinkProps, 'raw' | 'custom'> {
+type ItemBaseType = Omit<LinkProps, 'raw' | 'custom'> & Pick<LinkBaseProps, 'onClick'>
+export interface BreadcrumbItem extends ItemBaseType {
   label?: string
   /**
    * @IconifyIcon
@@ -64,7 +65,7 @@ import { get } from '../utils'
 import { pickLinkProps } from '../utils/link'
 import UIcon from './Icon.vue'
 import UAvatar from './Avatar.vue'
-import ULinkBase from './LinkBase.vue'
+import ULinkBase, { type LinkBaseProps } from './LinkBase.vue'
 import ULink from './Link.vue'
 
 const props = withDefaults(defineProps<BreadcrumbProps<T>>(), {
@@ -87,7 +88,7 @@ const ui = breadcrumb()
       <template v-for="(item, index) in items" :key="index">
         <li :class="ui.item({ class: props.ui?.item })">
           <ULink v-slot="{ active, ...slotProps }" v-bind="pickLinkProps(item)" custom>
-            <ULinkBase v-bind="slotProps" as="span" :aria-current="active && (index === items!.length - 1) ? 'page' : undefined" :class="ui.link({ class: [props.ui?.link, item.class], active: index === items!.length - 1, disabled: !!item.disabled, to: !!item.to })">
+            <ULinkBase v-bind="slotProps" as="span" :aria-current="active && (index === items!.length - 1) ? 'page' : undefined" :class="ui.link({ class: [props.ui?.link, item.class], active: index === items!.length - 1, disabled: !!item.disabled, to: !!item.to })" @click="item.onClick">
               <slot :name="item.slot || 'item'" :item="item" :index="index">
                 <slot :name="item.slot ? `${item.slot}-leading`: 'item-leading'" :item="item" :active="index === items!.length - 1" :index="index">
                   <UIcon v-if="item.icon" :name="item.icon" :class="ui.linkLeadingIcon({ class: props.ui?.linkLeadingIcon, active: index === items!.length - 1 })" />

--- a/test/components/Breadcrumb.spec.ts
+++ b/test/components/Breadcrumb.spec.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest'
-import Breadcrumb, { type BreadcrumbProps, type BreadcrumbSlots } from '../../src/runtime/components/Breadcrumb.vue'
+import Breadcrumb, { type BreadcrumbItem, type BreadcrumbProps, type BreadcrumbSlots } from '../../src/runtime/components/Breadcrumb.vue'
 import ComponentRender from '../component-render'
+import type theme from '~/theme/breadcrumb'
 
 describe('Breadcrumb', () => {
   const items = [{
@@ -18,7 +19,7 @@ describe('Breadcrumb', () => {
     to: '/components/breadcrumb',
     icon: 'i-lucide-link',
     slot: 'custom'
-  }]
+  }] as BreadcrumbItem[]
 
   const props = { items }
 
@@ -29,7 +30,7 @@ describe('Breadcrumb', () => {
     ['with separatorIcon', { props: { ...props, separatorIcon: 'i-lucide-minus' } }],
     ['with as', { props: { ...props, as: 'div' } }],
     ['with class', { props: { ...props, class: 'w-48' } }],
-    ['with ui', { props: { ...props, ui: { link: 'font-bold' } } }],
+    ['with ui', { props: { ...props, ui: { link: 'font-bold' } as theme } }],
     // Slots
     ['with item slot', { props, slots: { item: () => 'Item slot' } }],
     ['with item-leading slot', { props, slots: { 'item-leading': () => 'Item leading slot' } }],

--- a/test/components/Breadcrumb.spec.ts
+++ b/test/components/Breadcrumb.spec.ts
@@ -36,7 +36,8 @@ describe('Breadcrumb', () => {
     ['with item-label slot', { props, slots: { 'item-label': () => 'Item label slot' } }],
     ['with item-trailing slot', { props, slots: { 'item-trailing': () => 'Item trailing slot' } }],
     ['with custom slot', { props, slots: { custom: () => 'Custom slot' } }],
-    ['with separator slot', { props, slots: { separator: () => '/' } }]
+    ['with separator slot', { props, slots: { separator: () => '/' } }],
+    ['with onClick event handler', { props: { items: [...items, { label: 'clickable', onClick: () => { console.log('clicked') } }] } }]
   ])('renders %s correctly', async (nameOrHtml: string, options: { props?: BreadcrumbProps<typeof items[number]>, slots?: Partial<BreadcrumbSlots<typeof items[number]>> }) => {
     const html = await ComponentRender(nameOrHtml, options, Breadcrumb)
     expect(html).toMatchSnapshot()

--- a/test/components/Breadcrumb.spec.ts
+++ b/test/components/Breadcrumb.spec.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from 'vitest'
 import Breadcrumb, { type BreadcrumbItem, type BreadcrumbProps, type BreadcrumbSlots } from '../../src/runtime/components/Breadcrumb.vue'
 import ComponentRender from '../component-render'
-import type theme from '~/theme/breadcrumb'
+import type _ from '../../src/theme/breadcrumb' // needed for ui props typecheck to work
 
 describe('Breadcrumb', () => {
   const items = [{
@@ -30,7 +30,7 @@ describe('Breadcrumb', () => {
     ['with separatorIcon', { props: { ...props, separatorIcon: 'i-lucide-minus' } }],
     ['with as', { props: { ...props, as: 'div' } }],
     ['with class', { props: { ...props, class: 'w-48' } }],
-    ['with ui', { props: { ...props, ui: { link: 'font-bold' } as theme } }],
+    ['with ui', { props: { ...props, ui: { link: 'font-bold' } } }],
     // Slots
     ['with item slot', { props, slots: { item: () => 'Item slot' } }],
     ['with item-leading slot', { props, slots: { 'item-leading': () => 'Item leading slot' } }],

--- a/test/components/__snapshots__/Breadcrumb-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Breadcrumb-vue.spec.ts.snap
@@ -119,6 +119,21 @@ exports[`Breadcrumb > renders with labelKey correctly 1`] = `
 </nav>"
 `;
 
+exports[`Breadcrumb > renders with onClick event handler correctly 1`] = `
+"<nav aria-label="breadcrumb" class="relative min-w-0">
+  <ol class="flex items-center gap-1.5">
+    <li class="flex min-w-0"><a href="/" class="group relative flex items-center gap-1.5 text-sm min-w-0 focus-visible:outline-(--ui-primary) text-(--ui-text-muted) font-medium hover:text-(--ui-text) transition-colors"><span class="inline-flex items-center justify-center select-none overflow-hidden rounded-full align-middle bg-(--ui-bg-elevated) size-5 text-[10px] shrink-0"><img role="img" src="https://github.com/benjamincanac.png" width="20" height="20" class="h-full w-full rounded-[inherit] object-cover"></span><span class="truncate">Home</span></a></li>
+    <li role="presentation" aria-hidden="true" class="flex"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="shrink-0 size-5 text-(--ui-text-muted)" width="1em" height="1em" viewBox="0 0 16 16"></svg></li>
+    <li class="flex min-w-0"><span class="group relative flex items-center gap-1.5 text-sm min-w-0 focus-visible:outline-(--ui-primary) text-(--ui-text-muted) font-medium cursor-not-allowed opacity-75"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="shrink-0 size-5" width="1em" height="1em" viewBox="0 0 16 16"></svg><span class="truncate">Components</span></span></li>
+    <li role="presentation" aria-hidden="true" class="flex"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="shrink-0 size-5 text-(--ui-text-muted)" width="1em" height="1em" viewBox="0 0 16 16"></svg></li>
+    <li class="flex min-w-0"><a href="/components/breadcrumb" class="group relative flex items-center gap-1.5 text-sm min-w-0 focus-visible:outline-(--ui-primary) text-(--ui-text-muted) font-medium hover:text-(--ui-text) transition-colors"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="shrink-0 size-5" width="1em" height="1em" viewBox="0 0 16 16"></svg><span class="truncate">Breadcrumb</span></a></li>
+    <li role="presentation" aria-hidden="true" class="flex"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" class="shrink-0 size-5 text-(--ui-text-muted)" width="1em" height="1em" viewBox="0 0 16 16"></svg></li>
+    <li class="flex min-w-0"><span class="group relative flex items-center gap-1.5 text-sm min-w-0 focus-visible:outline-(--ui-primary) text-(--ui-primary) font-semibold"><!--v-if--><span class="truncate">clickable</span></span></li>
+    <!--v-if-->
+  </ol>
+</nav>"
+`;
+
 exports[`Breadcrumb > renders with separator slot correctly 1`] = `
 "<nav aria-label="breadcrumb" class="relative min-w-0">
   <ol class="flex items-center gap-1.5">

--- a/test/components/__snapshots__/Breadcrumb.spec.ts.snap
+++ b/test/components/__snapshots__/Breadcrumb.spec.ts.snap
@@ -119,6 +119,21 @@ exports[`Breadcrumb > renders with labelKey correctly 1`] = `
 </nav>"
 `;
 
+exports[`Breadcrumb > renders with onClick event handler correctly 1`] = `
+"<nav aria-label="breadcrumb" class="relative min-w-0">
+  <ol class="flex items-center gap-1.5">
+    <li class="flex min-w-0"><a href="/" class="group relative flex items-center gap-1.5 text-sm min-w-0 focus-visible:outline-(--ui-primary) text-(--ui-text-muted) font-medium hover:text-(--ui-text) transition-colors"><span class="inline-flex items-center justify-center select-none overflow-hidden rounded-full align-middle bg-(--ui-bg-elevated) size-5 text-[10px] shrink-0"><img role="img" src="https://github.com/benjamincanac.png" width="20" height="20" class="h-full w-full rounded-[inherit] object-cover"></span><span class="truncate">Home</span></a></li>
+    <li role="presentation" aria-hidden="true" class="flex"><span class="iconify i-lucide:chevron-right shrink-0 size-5 text-(--ui-text-muted)" aria-hidden="true"></span></li>
+    <li class="flex min-w-0"><span class="group relative flex items-center gap-1.5 text-sm min-w-0 focus-visible:outline-(--ui-primary) text-(--ui-text-muted) font-medium cursor-not-allowed opacity-75"><span class="iconify i-lucide:box shrink-0 size-5" aria-hidden="true"></span><span class="truncate">Components</span></span></li>
+    <li role="presentation" aria-hidden="true" class="flex"><span class="iconify i-lucide:chevron-right shrink-0 size-5 text-(--ui-text-muted)" aria-hidden="true"></span></li>
+    <li class="flex min-w-0"><a href="/components/breadcrumb" class="group relative flex items-center gap-1.5 text-sm min-w-0 focus-visible:outline-(--ui-primary) text-(--ui-text-muted) font-medium hover:text-(--ui-text) transition-colors"><span class="iconify i-lucide:link shrink-0 size-5" aria-hidden="true"></span><span class="truncate">Breadcrumb</span></a></li>
+    <li role="presentation" aria-hidden="true" class="flex"><span class="iconify i-lucide:chevron-right shrink-0 size-5 text-(--ui-text-muted)" aria-hidden="true"></span></li>
+    <li class="flex min-w-0"><span class="group relative flex items-center gap-1.5 text-sm min-w-0 focus-visible:outline-(--ui-primary) text-(--ui-primary) font-semibold"><!--v-if--><span class="truncate">clickable</span></span></li>
+    <!--v-if-->
+  </ol>
+</nav>"
+`;
+
 exports[`Breadcrumb > renders with separator slot correctly 1`] = `
 "<nav aria-label="breadcrumb" class="relative min-w-0">
   <ol class="flex items-center gap-1.5">


### PR DESCRIPTION
### 🔗 Linked issue

Implements #3631 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Passes the `onClick` prop to the LinkBase so that one can write following handlers to breadcrumb items.

```
<template>
 <UBreadcrumb :items="items" />
</template>
<script setup>
const items = [
 { label: "click for one", onClick: () => alert("1"), to: "/one" },
 { label: "click for two", onClick: () => alert("2"), to: "/two" },
]
</script>
```


### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
