### PR TITLE
docs(i18n): remove `next` tag from `@nuxtjs/i18n` installation

### DIFF
--- a/docs/content/1.getting-started/7.i18n/1.nuxt.md
+++ b/docs/content/1.getting-started/7.i18n/1.nuxt.md
@@ -136,19 +136,19 @@ To dynamically switch between languages, you can use the [Nuxt I18n](https://i18
 ::code-group{sync="pm"}
 
 ```bash [pnpm]
-pnpm add @nuxtjs/i18n@next
+pnpm add @nuxtjs/i18n
 ```
 
 ```bash [yarn]
-yarn add @nuxtjs/i18n@next
+yarn add @nuxtjs/i18n
 ```
 
 ```bash [npm]
-npm install @nuxtjs/i18n@next
+npm install @nuxtjs/i18n
 ```
 
 ```bash [bun]
-bun add @nuxtjs/i18n@next
+bun add @nuxtjs/i18n
 ```
 
 ::


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The `next` tag no longer exists for nuxt-i18n, it was pointing to a v9 release candidate and might be used for the next major pre-releases as well.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
