### PR TITLE
fix(useOverlay): refine `open` method type to infer close emit return type

### DIFF
--- a/src/runtime/composables/useOverlay.ts
+++ b/src/runtime/composables/useOverlay.ts
@@ -1,7 +1,10 @@
 import type { Component } from 'vue'
 import { reactive, markRaw, shallowReactive } from 'vue'
 import { createSharedComposable } from '@vueuse/core'
-import type { ComponentProps } from 'vue-component-type-helpers'
+import type { ComponentProps, ComponentEmit } from 'vue-component-type-helpers'
+
+// Extracts the first argument of the close event
+type CloseEventArgType<T> = T extends (event: 'close', args_0: infer R) => void ? R : never
 
 export type OverlayOptions<OverlayAttrs = Record<string, any>> = {
   defaultOpen?: boolean
@@ -19,7 +22,7 @@ type ManagedOverlayOptionsPrivate<T extends Component> = {
 export type Overlay = OverlayOptions<Component> & ManagedOverlayOptionsPrivate<Component>
 
 interface OverlayInstance<T> {
-  open: (props?: ComponentProps<T>) => Promise<any>
+  open: (props?: ComponentProps<T>) => Promise<CloseEventArgType<ComponentEmit<T>>>
   close: (value?: any) => void
   patch: (props: Partial<ComponentProps<T>>) => void
 }


### PR DESCRIPTION


### 🔗 Linked issue

Resolves #3706 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Update the return type of the `open` method to infer the type that is emitted in the `close` event

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
