### PR TITLE
fix(InputMenu/SelectMenu): support arbitrary `value`

### DIFF
--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -36,7 +36,6 @@ interface _InputMenuItem {
    * @defaultValue 'item'
    */
   type?: 'label' | 'separator' | 'item'
-  value?: string | number
   disabled?: boolean
   onSelect?(e?: Event): void
   [key: string]: any

--- a/src/runtime/components/NavigationMenu.vue
+++ b/src/runtime/components/NavigationMenu.vue
@@ -49,7 +49,6 @@ export interface NavigationMenuItem extends Omit<LinkProps, 'type' | 'raw' | 'cu
    */
   type?: 'label' | 'link'
   slot?: string
-  value?: string
   children?: NavigationMenuChildItem[]
   onSelect?(e: Event): void
   [key: string]: any

--- a/src/runtime/components/NavigationMenu.vue
+++ b/src/runtime/components/NavigationMenu.vue
@@ -49,6 +49,7 @@ export interface NavigationMenuItem extends Omit<LinkProps, 'type' | 'raw' | 'cu
    */
   type?: 'label' | 'link'
   slot?: string
+  value?: string
   children?: NavigationMenuChildItem[]
   onSelect?(e: Event): void
   [key: string]: any

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -36,7 +36,6 @@ interface _SelectMenuItem {
    * @defaultValue 'item'
    */
   type?: 'label' | 'separator' | 'item'
-  value?: string | number
   disabled?: boolean
   onSelect?(e?: Event): void
   [key: string]: any

--- a/test/components/InputMenu.spec.ts
+++ b/test/components/InputMenu.spec.ts
@@ -186,6 +186,12 @@ describe('InputMenu', () => {
         valueKey: 'value'
       })).toEqualTypeOf<[number[]]>()
 
+      // with object item and object valueKey
+      expectEmitPayloadType('update:modelValue', () => InputMenu({
+        items: [{ label: 'foo', value: { id: 1, name: 'bar' } }],
+        valueKey: 'value'
+      })).toEqualTypeOf<[{ id: number, name: string }]>()
+
       // with string item
       expectEmitPayloadType('update:modelValue', () => InputMenu({
         items: ['foo']

--- a/test/components/SelectMenu.spec.ts
+++ b/test/components/SelectMenu.spec.ts
@@ -191,6 +191,12 @@ describe('SelectMenu', () => {
         valueKey: 'value'
       })).toEqualTypeOf<[number[]]>()
 
+      // with object item and object valueKey
+      expectEmitPayloadType('update:modelValue', () => SelectMenu({
+        items: [{ label: 'foo', value: { id: 1, name: 'bar' } }],
+        valueKey: 'value'
+      })).toEqualTypeOf<[{ id: number, name: string }]>()
+
       // with string item
       expectEmitPayloadType('update:modelValue', () => SelectMenu({
         items: ['foo']


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #3718

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Most components that do have a `value` key also relies on it for internal logic and type checking at runtime, but this is not the case for `InputMenu` and `SelectMenu`. As such, developers might prefer to assign different types to `value` other than `string | number`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
