### PR TITLE
docs(radio-group): items only accept strings or numbers

### DIFF
--- a/docs/content/3.components/radio-group.md
+++ b/docs/content/3.components/radio-group.md
@@ -17,7 +17,7 @@ Use the `v-model` directive to control the value of the RadioGroup or the `defau
 
 ### Items
 
-Use the `items` prop as an array of strings, numbers or booleans:
+Use the `items` prop as an array of strings or numbers:
 
 ::component-code
 ---


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #3724

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The RadioGroupItems only accepts strings and numbers. The current documentation states that It also accepts Booleans which is not true.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
