### PR TITLE
fix(Form): loses focus on submit

### DIFF
--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -210,9 +210,10 @@ const loading = ref(false)
 provide(formLoadingInjectionKey, readonly(loading))
 
 async function onSubmitWrapper(payload: Event) {
-  loading.value = true
-
   const event = payload as FormSubmitEvent<any>
+  const activeElement = document.activeElement as HTMLElement
+
+  loading.value = true
 
   try {
     event.data = await _validate({ nested: true, transform: props.transform })
@@ -231,6 +232,7 @@ async function onSubmitWrapper(payload: Event) {
     emits('error', errorEvent)
   } finally {
     loading.value = false
+    setTimeout(() => activeElement?.focus(), 0)
   }
 }
 

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -39,6 +39,12 @@ export interface FormProps<T extends object> {
    * @defaultValue `true`
    */
   transform?: boolean
+  /**
+   * When `true`, all form elements will be disabled on `@submit` event.
+   * This will cause any focused input elements to lose their focus state.
+   * @defaultValue `true`
+   */
+  loadingAuto?: boolean
   class?: any
   onSubmit?: ((event: FormSubmitEvent<T>) => void | Promise<void>) | (() => void | Promise<void>)
 }
@@ -65,7 +71,8 @@ const props = withDefaults(defineProps<FormProps<T>>(), {
     return ['input', 'blur', 'change'] as FormInputEvents[]
   },
   validateOnInputDelay: 300,
-  transform: true
+  transform: true,
+  loadingAuto: true
 })
 
 const emits = defineEmits<FormEmits<T>>()
@@ -210,10 +217,9 @@ const loading = ref(false)
 provide(formLoadingInjectionKey, readonly(loading))
 
 async function onSubmitWrapper(payload: Event) {
-  const event = payload as FormSubmitEvent<any>
-  const activeElement = document.activeElement as HTMLElement
-
   loading.value = true
+
+  const event = payload as FormSubmitEvent<any>
 
   try {
     event.data = await _validate({ nested: true, transform: props.transform })
@@ -232,11 +238,11 @@ async function onSubmitWrapper(payload: Event) {
     emits('error', errorEvent)
   } finally {
     loading.value = false
-    setTimeout(() => activeElement?.focus(), 0)
   }
 }
 
-const disabled = computed(() => props.disabled || loading.value)
+const isLoading = computed(() => loading.value && props.loadingAuto)
+const disabled = computed(() => props.disabled || isLoading.value)
 
 provide(formOptionsInjectionKey, computed(() => ({
   disabled: disabled.value,

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -217,7 +217,7 @@ const loading = ref(false)
 provide(formLoadingInjectionKey, readonly(loading))
 
 async function onSubmitWrapper(payload: Event) {
-  loading.value = true
+  loading.value = props.loadingAuto && true
 
   const event = payload as FormSubmitEvent<any>
 
@@ -241,8 +241,7 @@ async function onSubmitWrapper(payload: Event) {
   }
 }
 
-const isLoading = computed(() => loading.value && props.loadingAuto)
-const disabled = computed(() => props.disabled || isLoading.value)
+const disabled = computed(() => props.disabled || loading.value)
 
 provide(formOptionsInjectionKey, computed(() => ({
   disabled: disabled.value,


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #3786 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When submitting a form, the loading state disables the inputs causing the lose of focus, so this save the activeElement before updating the loading status and restoring the focus at the end of submit.

I was between this solution and stop disabling the inputs on loading state.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
