### PR TITLE
feat(Tabs): add `list-leading` and `list-trailing` slots

### DIFF
--- a/playground/app/pages/components/tabs.vue
+++ b/playground/app/pages/components/tabs.vue
@@ -59,6 +59,14 @@ const items = [{
         <template #custom="{ item }">
           <span class="text-(--ui-text-muted)">Custom: {{ item.content }}</span>
         </template>
+
+        <template #list-trailing>
+          <UButton
+            icon="lucide:refresh-cw"
+            variant="soft"
+            class="ml-2"
+          />
+        </template>
       </UTabs>
     </div>
   </div>

--- a/src/runtime/components/Tabs.vue
+++ b/src/runtime/components/Tabs.vue
@@ -77,8 +77,8 @@ export type TabsSlots<T extends TabsItem = TabsItem> = {
   'default': SlotProps<T>
   'trailing': SlotProps<T>
   'content': SlotProps<T>
-  'list-leading': {}
-  'list-trailing': {}
+  'list-leading': (props: {}) => any
+  'list-trailing': (props: {}) => any
 } & DynamicSlots<T, undefined, { index: number }>
 
 </script>

--- a/src/runtime/components/Tabs.vue
+++ b/src/runtime/components/Tabs.vue
@@ -114,6 +114,8 @@ const ui = computed(() => tabs({
     <TabsList :class="ui.list({ class: props.ui?.list })">
       <TabsIndicator :class="ui.indicator({ class: props.ui?.indicator })" />
 
+      <slot name="list-leading" />
+
       <TabsTrigger v-for="(item, index) of items" :key="index" :value="item.value || String(index)" :disabled="item.disabled" :class="ui.trigger({ class: props.ui?.trigger })">
         <slot name="leading" :item="item" :index="index">
           <UIcon v-if="item.icon" :name="item.icon" :class="ui.leadingIcon({ class: props.ui?.leadingIcon })" />
@@ -126,6 +128,8 @@ const ui = computed(() => tabs({
 
         <slot name="trailing" :item="item" :index="index" />
       </TabsTrigger>
+
+      <slot name="list-trailing" />
     </TabsList>
 
     <template v-if="!!content">

--- a/src/runtime/components/Tabs.vue
+++ b/src/runtime/components/Tabs.vue
@@ -77,8 +77,8 @@ export type TabsSlots<T extends TabsItem = TabsItem> = {
   'default': SlotProps<T>
   'trailing': SlotProps<T>
   'content': SlotProps<T>
-  'list-leading': (props: {}) => any
-  'list-trailing': (props: {}) => any
+  'list-leading': (props?: {}) => any
+  'list-trailing': (props?: {}) => any
 } & DynamicSlots<T, undefined, { index: number }>
 
 </script>

--- a/src/runtime/components/Tabs.vue
+++ b/src/runtime/components/Tabs.vue
@@ -73,12 +73,12 @@ export interface TabsEmits extends TabsRootEmits<string | number> {}
 type SlotProps<T extends TabsItem> = (props: { item: T, index: number }) => any
 
 export type TabsSlots<T extends TabsItem = TabsItem> = {
-  leading: SlotProps<T>
-  default: SlotProps<T>
-  trailing: SlotProps<T>
-  content: SlotProps<T>
-  'list-leading': {},
-  'list-trailing': {},
+  'leading': SlotProps<T>
+  'default': SlotProps<T>
+  'trailing': SlotProps<T>
+  'content': SlotProps<T>
+  'list-leading': {}
+  'list-trailing': {}
 } & DynamicSlots<T, undefined, { index: number }>
 
 </script>

--- a/src/runtime/components/Tabs.vue
+++ b/src/runtime/components/Tabs.vue
@@ -77,6 +77,8 @@ export type TabsSlots<T extends TabsItem = TabsItem> = {
   default: SlotProps<T>
   trailing: SlotProps<T>
   content: SlotProps<T>
+  'list-leading': {},
+  'list-trailing': {},
 } & DynamicSlots<T, undefined, { index: number }>
 
 </script>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Adds two slots in the `<TabsList>` of the `UTabs` component:
- `list-leading`
- `list-trailing`

![Screenshot From 2025-04-09 13-57-59](https://github.com/user-attachments/assets/4faf4c44-c549-44a6-bcdd-72990d48deee)


![image](https://github.com/user-attachments/assets/886ec35a-330b-4f0a-8b73-09e5e3bb18c7)


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
