### PR TITLE
feat(overlays): Add support for event emitters when using overlays

### DIFF
--- a/src/runtime/components/OverlayProvider.vue
+++ b/src/runtime/components/OverlayProvider.vue
@@ -25,5 +25,6 @@ const onClose = (id: symbol, value: any) => {
     v-model:open="overlay.isOpen"
     @close="(value:any) => onClose(overlay.id, value)"
     @after:leave="onAfterLeave(overlay.id)"
+    v-on="overlay.emits"
   />
 </template>

--- a/src/runtime/composables/useOverlay.ts
+++ b/src/runtime/composables/useOverlay.ts
@@ -10,6 +10,7 @@ export type OverlayOptions<OverlayAttrs = Record<string, any>> = {
   defaultOpen?: boolean
   props?: OverlayAttrs
   destroyOnClose?: boolean
+  emits?: Record<string, (...args: any[]) => void>
 }
 
 interface ManagedOverlayOptionsPrivate<T extends Component> {
@@ -24,16 +25,17 @@ export type Overlay = OverlayOptions<Component> & ManagedOverlayOptionsPrivate<C
 interface OverlayInstance<T extends Component> extends Omit<ManagedOverlayOptionsPrivate<T>, 'component'> {
   id: symbol
   result: Promise<CloseEventArgType<ComponentEmit<T>>>
-  open: (props?: ComponentProps<T>) => Omit<OverlayInstance<T>, 'open' | 'close' | 'patch' | 'modelValue' | 'resolvePromise'>
+  open: (props?: ComponentProps<T>) => Omit<OverlayInstance<T>, 'open' | 'close' | 'patch' | 'on' | 'modelValue' | 'resolvePromise'>
   close: (value?: any) => void
   patch: (props: Partial<ComponentProps<T>>) => void
+  on: <K extends string>(event: K, handler: (...args: any[]) => void) => void
 }
 
 function _useOverlay() {
   const overlays = shallowReactive<Overlay[]>([])
 
   const create = <T extends Component>(component: T, _options?: OverlayOptions<ComponentProps<T>>): OverlayInstance<T> => {
-    const { props: props, defaultOpen, destroyOnClose } = _options || {}
+    const { props: props, defaultOpen, destroyOnClose, emits } = _options || {}
 
     const options = reactive<Overlay>({
       id: Symbol(import.meta.dev ? 'useOverlay' : ''),
@@ -41,7 +43,8 @@ function _useOverlay() {
       component: markRaw(component!),
       isMounted: !!defaultOpen,
       destroyOnClose: !!destroyOnClose,
-      props: props || {}
+      props: props || {},
+      emits: emits || {}
     })
 
     overlays.push(options)
@@ -51,16 +54,22 @@ function _useOverlay() {
       result: new Promise(() => {}),
       open: <T extends Component>(props?: ComponentProps<T>) => open(options.id, props),
       close: value => close(options.id, value),
-      patch: <T extends Component>(props: Partial<ComponentProps<T>>) => patch(options.id, props)
+      patch: <T extends Component>(props: Partial<ComponentProps<T>>) => patch(options.id, props),
+      on: <K extends string>(event: K, handler: (...args: any[]) => void) => {
+        if (!options.emits) {
+          options.emits = {}
+        }
+        options.emits[event] = handler
+      }
     }
   }
 
-  const open = <T extends Component>(id: symbol, props?: ComponentProps<T>) => {
+  const open = <T extends Component>(id: symbol, props?: ComponentProps<T>, emits?: Record<string, (...args: any[]) => void>) => {
     const overlay = getOverlay(id)
 
     // If props are provided, update the overlay's props
-    if (props) {
-      patch(overlay.id, props)
+    if (props || emits) {
+      patch(overlay.id, props, emits)
     }
 
     overlay.isOpen = true
@@ -99,12 +108,20 @@ function _useOverlay() {
     }
   }
 
-  const patch = <T extends Component>(id: symbol, props: Partial<ComponentProps<T>>): void => {
+  const patch = <T extends Component>(id: symbol, props?: Partial<ComponentProps<T>>, emits?: Partial<Record<string, (...args: any[]) => void>>): void => {
     const overlay = getOverlay(id)
 
-    Object.entries(props!).forEach(([key, value]) => {
-      (overlay.props as any)[key] = value
-    })
+    if (props) {
+      Object.entries(props).forEach(([key, value]) => {
+        (overlay.props as any)[key] = value
+      })
+    }
+
+    if (emits) {
+      Object.entries(emits).forEach(([key, value]) => {
+        (overlay.emits as any)[key] = value
+      })
+    }
   }
 
   const getOverlay = (id: symbol): Overlay => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
Resolves #3842

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
This change adds an `emits` property to the `OverlayOptions` type. It also adds an `on` method to the `OverlayInstance` type which registers an event emitter callback for the specified event name. Finally this PR adds new optional properties to the `create` and `patch` methods of the type returned by `useOverlay` to allow for updating event emitters.

<!-- Why is this change required? What problem does it solve? -->
It allows reactivity to be implemented with overlays and their parent components.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
