### PR TITLE
fix(Table): pass header `colspan` to `th`

### DIFF
--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -322,7 +322,7 @@ defineExpose({
             v-for="header in headerGroup.headers"
             :key="header.id"
             :data-pinned="header.column.getIsPinned()"
-            :colspan="header.colSpan"
+            :colspan="header.colSpan > 1 ? header.colSpan : undefined"
             :class="ui.th({ class: [props.ui?.th, header.column.columnDef.meta?.class?.th], pinned: !!header.column.getIsPinned() })"
           >
             <slot :name="`${header.id}-header`" v-bind="header.getContext()">

--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -322,6 +322,7 @@ defineExpose({
             v-for="header in headerGroup.headers"
             :key="header.id"
             :data-pinned="header.column.getIsPinned()"
+            :colspan="header.colSpan"
             :class="ui.th({ class: [props.ui?.th, header.column.columnDef.meta?.class?.th], pinned: !!header.column.getIsPinned() })"
           >
             <slot :name="`${header.id}-header`" v-bind="header.getContext()">


### PR DESCRIPTION
### 🔗 Linked issue

Related to #3296

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Currently it is possible to create multi-level table headers, but colspan is not applied to th elements. This functionality is implemented in tanstack table and relies on it's internal mechanics.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
