### PR TITLE
docs: don't import color mode from vueuse

### DIFF
--- a/docs/app/composables/useFaviconFromTheme.ts
+++ b/docs/app/composables/useFaviconFromTheme.ts
@@ -1,4 +1,3 @@
-import { useColorMode } from '@vueuse/core'
 import { onMounted, watch } from 'vue'
 import FaviconSvg from 'public/icon.svg?raw'
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

useColorMode() is auto imported from @nuxtjs/color-mode, importing from vueuse create unexcepted issues