### PR TITLE
fix(usePortal): adjust portal target resolution logic

### DIFF
--- a/src/runtime/composables/usePortal.ts
+++ b/src/runtime/composables/usePortal.ts
@@ -6,11 +6,11 @@ export function usePortal(portal: Ref<string | HTMLElement | boolean | undefined
   const portalTarget = inject(portalTargetInjectionKey, undefined)
 
   const to = computed(() => {
-    if (typeof portal.value === 'string' || portal.value instanceof HTMLElement) {
-      return portal.value
+    if (typeof portal.value === 'boolean' || portal.value === undefined) {
+      return portalTarget?.value ?? 'body'
     }
 
-    return portalTarget?.value ?? 'body'
+    return portal.value
   })
 
   const disabled = computed(() => typeof portal.value === 'boolean' ? !portal.value : false)


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #3688

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Refactor the logic to correctly handle boolean and undefined portal values. Ensures the default target is used when the portal is not explicitly defined or is set as a boolean. This fix the instanceof HTMLElement check.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
