### PR TITLE
fix(useOverlay)!: correct spelling of `unmount` function

### DIFF
--- a/docs/content/2.composables/use-overlay.md
+++ b/docs/content/2.composables/use-overlay.md
@@ -9,12 +9,12 @@ Use the auto-imported `useOverlay` composable to programmatically control [Modal
 
 ```vue
 <script setup lang="ts">
-const overlay = useOverlay()
+const overlay = useOverlay();
 
-const modal = overlay.create(MyModal)
+const modal = overlay.create(MyModal);
 
 async function openModal() {
-  modal.open()
+  modal.open();
 }
 </script>
 ```
@@ -62,7 +62,7 @@ Update an overlay using its `id`
   - `id`: The identifier of the overlay
   - `props`: An object of props to update on the rendered component.
 
-### `unMount(id: symbol): void`
+### `unmount(id: symbol): void`
 
 Removes the overlay from the DOM using its `id`
 
@@ -91,14 +91,14 @@ Opens the overlay
 
 ```vue
 <script setup lang="ts">
-const overlay = useOverlay()
+const overlay = useOverlay();
 
-const modal = overlay.create(MyModalContent)
+const modal = overlay.create(MyModalContent);
 
 function openModal() {
   modal.open({
-    title: 'Welcome'
-  })
+    title: "Welcome",
+  });
 }
 </script>
 ```
@@ -119,18 +119,18 @@ Updates the props of the overlay.
 
 ```vue
 <script setup lang="ts">
-const overlay = useOverlay()
+const overlay = useOverlay();
 
 const modal = overlay.create(MyModal, {
-  title: 'Welcome'
-})
+  title: "Welcome",
+});
 
 function openModal() {
-  modal.open()
+  modal.open();
 }
 
 function updateModalTitle() {
-  modal.patch({ title: 'Updated Title' })
+  modal.patch({ title: "Updated Title" });
 }
 </script>
 ```
@@ -141,28 +141,28 @@ Here's a complete example of how to use the `useOverlay` composable:
 
 ```vue
 <script setup lang="ts">
-const overlay = useOverlay()
+const overlay = useOverlay();
 
 // Create with default props
-const modalA = overlay.create(ModalA, { title: 'Welcome' })
-const modalB = overlay.create(ModalB)
+const modalA = overlay.create(ModalA, { title: "Welcome" });
+const modalB = overlay.create(ModalB);
 
-const slideoverA = overlay.create(SlideoverA)
+const slideoverA = overlay.create(SlideoverA);
 
 const openModalA = () => {
   // Open  Modal A, but override the title prop
-  modalA.open({ title: 'Hello' })
-}
+  modalA.open({ title: "Hello" });
+};
 
 const openModalB = async () => {
   // Open modalB, and wait for its result
-  const modalBInstance = modalB.open()
+  const modalBInstance = modalB.open();
 
-  const input = await modalBInstance.result
+  const input = await modalBInstance.result;
 
   // Pass the result from modalB to the slideover, and open it.
-  slideoverA.open({ input })
-}
+  slideoverA.open({ input });
+};
 </script>
 
 <template>

--- a/docs/content/2.composables/use-overlay.md
+++ b/docs/content/2.composables/use-overlay.md
@@ -9,12 +9,12 @@ Use the auto-imported `useOverlay` composable to programmatically control [Modal
 
 ```vue
 <script setup lang="ts">
-const overlay = useOverlay();
+const overlay = useOverlay()
 
-const modal = overlay.create(MyModal);
+const modal = overlay.create(MyModal)
 
 async function openModal() {
-  modal.open();
+  modal.open()
 }
 </script>
 ```
@@ -62,7 +62,7 @@ Update an overlay using its `id`
   - `id`: The identifier of the overlay
   - `props`: An object of props to update on the rendered component.
 
-### `unmount(id: symbol): void`
+### `unount(id: symbol): void`
 
 Removes the overlay from the DOM using its `id`
 
@@ -91,14 +91,14 @@ Opens the overlay
 
 ```vue
 <script setup lang="ts">
-const overlay = useOverlay();
+const overlay = useOverlay()
 
-const modal = overlay.create(MyModalContent);
+const modal = overlay.create(MyModalContent)
 
 function openModal() {
   modal.open({
-    title: "Welcome",
-  });
+    title: 'Welcome'
+  })
 }
 </script>
 ```
@@ -119,18 +119,18 @@ Updates the props of the overlay.
 
 ```vue
 <script setup lang="ts">
-const overlay = useOverlay();
+const overlay = useOverlay()
 
 const modal = overlay.create(MyModal, {
-  title: "Welcome",
-});
+  title: 'Welcome'
+})
 
 function openModal() {
-  modal.open();
+  modal.open()
 }
 
 function updateModalTitle() {
-  modal.patch({ title: "Updated Title" });
+  modal.patch({ title: 'Updated Title' })
 }
 </script>
 ```
@@ -141,28 +141,28 @@ Here's a complete example of how to use the `useOverlay` composable:
 
 ```vue
 <script setup lang="ts">
-const overlay = useOverlay();
+const overlay = useOverlay()
 
 // Create with default props
-const modalA = overlay.create(ModalA, { title: "Welcome" });
-const modalB = overlay.create(ModalB);
+const modalA = overlay.create(ModalA, { title: 'Welcome' })
+const modalB = overlay.create(ModalB)
 
-const slideoverA = overlay.create(SlideoverA);
+const slideoverA = overlay.create(SlideoverA)
 
 const openModalA = () => {
   // Open  Modal A, but override the title prop
-  modalA.open({ title: "Hello" });
-};
+  modalA.open({ title: 'Hello' })
+}
 
 const openModalB = async () => {
   // Open modalB, and wait for its result
-  const modalBInstance = modalB.open();
+  const modalBInstance = modalB.open()
 
-  const input = await modalBInstance.result;
+  const input = await modalBInstance.result
 
   // Pass the result from modalB to the slideover, and open it.
-  slideoverA.open({ input });
-};
+  slideoverA.open({ input })
+}
 </script>
 
 <template>

--- a/docs/content/2.composables/use-overlay.md
+++ b/docs/content/2.composables/use-overlay.md
@@ -62,7 +62,7 @@ Update an overlay using its `id`
   - `id`: The identifier of the overlay
   - `props`: An object of props to update on the rendered component.
 
-### `unount(id: symbol): void`
+### `unmount(id: symbol): void`
 
 Removes the overlay from the DOM using its `id`
 

--- a/src/runtime/components/OverlayProvider.vue
+++ b/src/runtime/components/OverlayProvider.vue
@@ -2,13 +2,13 @@
 import { computed } from 'vue'
 import { useOverlay, type Overlay } from '../composables/useOverlay'
 
-const { overlays, unMount, close } = useOverlay()
+const { overlays, unmount, close } = useOverlay()
 
 const mountedOverlays = computed(() => overlays.filter((overlay: Overlay) => overlay.isMounted))
 
 const onAfterLeave = (id: symbol) => {
   close(id)
-  unMount(id)
+  unmount(id)
 }
 
 const onClose = (id: symbol, value: any) => {

--- a/src/runtime/composables/useOverlay.ts
+++ b/src/runtime/composables/useOverlay.ts
@@ -93,7 +93,7 @@ function _useOverlay() {
     overlays.forEach(overlay => close(overlay.id))
   }
 
-  const unMount = (id: symbol): void => {
+  const unmount = (id: symbol): void => {
     const overlay = getOverlay(id)
 
     overlay.isMounted = false
@@ -135,7 +135,7 @@ function _useOverlay() {
     closeAll,
     create,
     patch,
-    unMount,
+    unmount,
     isOpen
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This fixes typo in method name. `unMount` should be `unmount`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
