### PR TITLE
feat(InputMenu): added pretext for the createItem dropdown

### DIFF
--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -111,6 +111,7 @@ export interface InputMenuProps<T extends ArrayOrNested<InputMenuItem> = ArrayOr
    * @defaultValue false
    */
   createItem?: boolean | 'always' | { position?: 'top' | 'bottom', when?: 'empty' | 'always' }
+  createItemPreText?: string
   /**
    * Fields to filter items by.
    * @defaultValue [labelKey]
@@ -393,7 +394,7 @@ defineExpose({
       >
         <span :class="ui.itemLabel({ class: props.ui?.itemLabel })">
           <slot name="create-item-label" :item="searchTerm">
-            {{ t('inputMenu.create', { label: searchTerm }) }}
+            {{ createItemPreText ? `${createItemPreText} "${searchTerm}"` : t('inputMenu.create', { label: searchTerm }) }}
           </slot>
         </span>
       </ComboboxItem>


### PR DESCRIPTION


### 🔗 Linked issue

Didn't find one.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added a new prop for the InputMenu component. 
The prop changes the text that appears in the dropdown when createItem is true.

The default word is "Create", which makes sense in terms of props and such but may communicate wrong meaning to a potential user. 
For example what if the input's purpose is to fill out items that need to be deleted from somewhere? Or perhaps the items should be "added' to some list and not "created". 

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

Unsure if I am supposed to update the docs for the InputMenu component, let me know if I should.
