### PR TITLE
docs: add tip for when using auto imports

### DIFF
--- a/docs/content/1.getting-started/2.installation/2.vue.md
+++ b/docs/content/1.getting-started/2.installation/2.vue.md
@@ -78,6 +78,18 @@ components.d.ts
 
 ::
 
+::tip
+If your project was initialized with the official Vue.js starter, you want to make sure that the build command performs type-checking *after* the type declaration files are generated.
+Otherwise, your build script will fail in fresh environments, such as CI pipelines.
+
+
+```json [package.json]
+- "build": "run-p type-check \"build-only {@}\" --",
++ "build": "run-s \"build-only {@}\" type-check --",
+```
+
+::
+
 #### Use the Nuxt UI Vue plugin in your `main.ts`
 
 ```ts [main.ts]{3,14}


### PR DESCRIPTION
### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

To streamline on-boarding when using the official Vue.js starter, I added a tip to the docs to prevent others from encountering an issue that I tackled recently.

The problem I encountered was:

- Vue.js official starter uses `run-p type-check \"build-only {@}\" --` as the build step. This builds the application in parallel with type-checking.
- That sounds nice, but the type declaration files that `unplugin-auto-import` generates are only generated in the `build-only` script, so when building in a fresh environment, type checking fails.
- I resolved it by replacing `run-p type-check \"build-only {@}\" --` with `run-s \"build-only {@}\" type-check --`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
