### PR TITLE
chore: remove legacy github silent in `vercel.json`

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,8 +1,5 @@
 {
   "git": {
     "deploymentEnabled": false
-  },
-  "github": {
-    "silent": true
   }
 }


### PR DESCRIPTION
GitHub silent option is now deprecated in `vercel.json`
https://vercel.com/docs/project-configuration/git-configuration#github.silent