### PR TITLE
feat(Form): expose loading state to default slot

### DIFF
--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -240,7 +240,7 @@ async function onSubmitWrapper(payload: Event) {
 
   try {
     event.data = await _validate({ nested: true, transform: props.transform })
-    const result = await props.onSubmit?.(event)
+    await props.onSubmit?.(event)
     dirtyFields.clear()
   } catch (error) {
     if (!(error instanceof FormValidationException)) {

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -59,7 +59,7 @@ export interface FormEmits<S extends FormSchema, T extends boolean = true> {
 }
 
 export interface FormSlots {
-  default(props?: { errors: FormError[] }): any
+  default(props?: { errors: FormError[], loading: boolean }): any
 }
 </script>
 
@@ -240,7 +240,7 @@ async function onSubmitWrapper(payload: Event) {
 
   try {
     event.data = await _validate({ nested: true, transform: props.transform })
-    await props.onSubmit?.(event)
+    const result = await props.onSubmit?.(event)
     dirtyFields.clear()
   } catch (error) {
     if (!(error instanceof FormValidationException)) {
@@ -315,6 +315,6 @@ defineExpose<Form<S>>({
     :class="ui({ class: props.class })"
     @submit.prevent="onSubmitWrapper"
   >
-    <slot :errors="errors" />
+    <slot :errors="errors" :loading />
   </component>
 </template>

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -315,6 +315,6 @@ defineExpose<Form<S>>({
     :class="ui({ class: props.class })"
     @submit.prevent="onSubmitWrapper"
   >
-    <slot :errors="errors" :loading />
+    <slot :errors="errors" :loading="loading" />
   </component>
 </template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Loading state for onSubmit should be exposed to form slot to enable displaying loading states while submission is pending.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
