### PR TITLE
docs(use-overlay): add caveats section regarding provide/inject limit

### DIFF
--- a/docs/content/2.composables/use-overlay.md
+++ b/docs/content/2.composables/use-overlay.md
@@ -25,6 +25,25 @@ async function openModal() {
 In order to return a value from the overlay, the `overlay.open().instance.result` can be awaited. In order for this to work, however, the **overlay component must emit a `close` event**. See example below for details.
 ::
 
+## Caveats
+### Provide/Inject
+When opening overlays programmatically (e.g. modals, slideovers, etc), the overlay component can only access injected values from the component containing `UApp` (typically app.vue or layout components). This is because overlays are mounted outside of the page context by the `UApp` component.
+
+As such, using `provide()` in pages or parent components isn't supported directly. To pass provided values to overlays, the recommended approach is to use props instead:
+
+```vue
+<script setup lang="ts">
+const providedValue = inject("valueProvidedInPage")
+
+const modal = overlay.create(LazyModalExample, {
+  props: {
+    providedValue,
+    otherData: someValue
+  }
+})
+</script>
+```
+
 ## API
 
 ### `create(component: T, options: OverlayOptions): OverlayInstance`

--- a/docs/content/2.composables/use-overlay.md
+++ b/docs/content/2.composables/use-overlay.md
@@ -15,7 +15,7 @@ const overlay = useOverlay()
 
 const modal = overlay.create(LazyModalExample)
 
-async function open() {
+async function openModal() {
   modal.open()
 }
 </script>
@@ -31,62 +31,62 @@ In order to return a value from the overlay, the `overlay.open().instance.result
 
 ### `create(component: T, options: OverlayOptions): OverlayInstance`
 
-Creates an overlay, and returns a factory instance
+Create an overlay, and return a factory instance.
 
 - Parameters:
-  - `component`: The overlay component
-  - `options` The overlay options
-    - `defaultOpen?: boolean` Opens the overlay immediately after being created `default: false`
+  - `component`: The overlay component.
+  - `options`:
+    - `defaultOpen?: boolean` Open the overlay immediately after being created. Defaults to `false`.
     - `props?: ComponentProps`: An optional object of props to pass to the rendered component.
-    - `destroyOnClose?: boolean` Removes the overlay from memory when closed `default: false`
+    - `destroyOnClose?: boolean` Removes the overlay from memory when closed. Defaults to `false`.
 
 ### `open(id: symbol, props?: ComponentProps<T>): OpenedOverlay<T>`
 
-Opens the overlay using its `id`
+Open an overlay by its `id`.
 
 - Parameters:
-  - `id`: The identifier of the overlay
+  - `id`: The identifier of the overlay.
   - `props`: An optional object of props to pass to the rendered component.
 
 ### `close(id: symbol, value?: any): void`
 
-Close an overlay using its `id`
+Close an overlay by its `id`.
 
 - Parameters:
-  - `id`: The identifier of the overlay
-  - `value`: A value to resolve the overlay promise with
+  - `id`: The identifier of the overlay.
+  - `value`: A value to resolve the overlay promise with.
 
 ### `patch(id: symbol, props: ComponentProps<T>): void`
 
-Update an overlay using its `id`
+Update an overlay by its `id`.
 
 - Parameters:
-  - `id`: The identifier of the overlay
+  - `id`: The identifier of the overlay.
   - `props`: An object of props to update on the rendered component.
 
 ### `unmount(id: symbol): void`
 
-Removes the overlay from the DOM using its `id`
+Remove an overlay from the DOM by its `id`.
 
 - Parameters:
-  - `id`: The identifier of the overlay
+  - `id`: The identifier of the overlay.
 
 ### `isOpen(id: symbol): boolean`
 
-Checks if an overlay its open using its `id`
+Check if an overlay is open using its `id`.
 
 - Parameters:
-  - `id`: The identifier of the overlay
+  - `id`: The identifier of the overlay.
 
 ### `overlays: Overlay[]`
 
-In-memory list of overlays that were created
+In-memory list of all overlays that were created.
 
-## Overlay Instance API
+## Instance API
 
 ### `open(props?: ComponentProps<T>): Promise<OpenedOverlay<T>>`
 
-Opens the overlay
+Open the overlay.
 
 - Parameters:
   - `props`: An optional object of props to pass to the rendered component.
@@ -109,14 +109,14 @@ function openModal() {
 
 ### `close(value?: any): void`
 
-Close the overlay
+Close the overlay.
 
 - Parameters:
-  - `value`: A value to resolve the overlay promise with
+  - `value`: A value to resolve the overlay promise with.
 
 ### `patch(props: ComponentProps<T>)`
 
-Updates the props of the overlay.
+Update the props of the overlay.
 
 - Parameters:
   - `props`: An object of props to update on the rendered component.
@@ -158,7 +158,7 @@ const modalB = overlay.create(ModalB)
 const slideoverA = overlay.create(SlideoverA)
 
 const openModalA = () => {
-  // Open  Modal A, but override the title prop
+  // Open modalA, but override the title prop
   modalA.open({ title: 'Hello' })
 }
 
@@ -168,15 +168,13 @@ const openModalB = async () => {
 
   const input = await modalBInstance.result
 
-  // Pass the result from modalB to the slideover, and open it.
+  // Pass the result from modalB to the slideover, and open it
   slideoverA.open({ input })
 }
 </script>
 
 <template>
-  <div>
-    <button @click="openModalA">Open Modal</button>
-  </div>
+  <button @click="openModalA">Open Modal</button>
 </template>
 ```
 
@@ -186,7 +184,7 @@ In this example, we're using the `useOverlay` composable to control multiple mod
 
 ### Provide / Inject
 
-When opening overlays programmatically (e.g. modals, slideovers, etc), the overlay component can only access injected values from the component containing `UApp` (typically app.vue or layout components). This is because overlays are mounted outside of the page context by the `UApp` component.
+When opening overlays programmatically (e.g. modals, slideovers, etc), the overlay component can only access injected values from the component containing `UApp` (typically `app.vue` or layout components). This is because overlays are mounted outside of the page context by the `UApp` component.
 
 As such, using `provide()` in pages or parent components isn't supported directly. To pass provided values to overlays, the recommended approach is to use props instead:
 

--- a/docs/content/2.composables/use-overlay.md
+++ b/docs/content/2.composables/use-overlay.md
@@ -1,6 +1,6 @@
 ---
 title: useOverlay
-description: "A composable to programmatically control overlays."
+description: 'A composable to programmatically control overlays.'
 ---
 
 ## Usage
@@ -9,11 +9,13 @@ Use the auto-imported `useOverlay` composable to programmatically control [Modal
 
 ```vue
 <script setup lang="ts">
+import { LazyModalExample } from '#components'
+
 const overlay = useOverlay()
 
-const modal = overlay.create(MyModal)
+const modal = overlay.create(LazyModalExample)
 
-async function openModal() {
+async function open() {
   modal.open()
 }
 </script>
@@ -24,25 +26,6 @@ async function openModal() {
 ::note
 In order to return a value from the overlay, the `overlay.open().instance.result` can be awaited. In order for this to work, however, the **overlay component must emit a `close` event**. See example below for details.
 ::
-
-## Caveats
-### Provide/Inject
-When opening overlays programmatically (e.g. modals, slideovers, etc), the overlay component can only access injected values from the component containing `UApp` (typically app.vue or layout components). This is because overlays are mounted outside of the page context by the `UApp` component.
-
-As such, using `provide()` in pages or parent components isn't supported directly. To pass provided values to overlays, the recommended approach is to use props instead:
-
-```vue
-<script setup lang="ts">
-const providedValue = inject("valueProvidedInPage")
-
-const modal = overlay.create(LazyModalExample, {
-  props: {
-    providedValue,
-    otherData: someValue
-  }
-})
-</script>
-```
 
 ## API
 
@@ -110,9 +93,11 @@ Opens the overlay
 
 ```vue
 <script setup lang="ts">
+import { LazyModalExample } from '#components'
+
 const overlay = useOverlay()
 
-const modal = overlay.create(MyModalContent)
+const modal = overlay.create(LazyModalExample)
 
 function openModal() {
   modal.open({
@@ -138,9 +123,11 @@ Updates the props of the overlay.
 
 ```vue
 <script setup lang="ts">
+import { LazyModalExample } from '#components'
+
 const overlay = useOverlay()
 
-const modal = overlay.create(MyModal, {
+const modal = overlay.create(LazyModalExample, {
   title: 'Welcome'
 })
 
@@ -160,6 +147,8 @@ Here's a complete example of how to use the `useOverlay` composable:
 
 ```vue
 <script setup lang="ts">
+import { ModalA, ModalB, SlideoverA } from '#components'
+
 const overlay = useOverlay()
 
 // Create with default props
@@ -186,9 +175,32 @@ const openModalB = async () => {
 
 <template>
   <div>
-    <button @click="openModal">Open Modal</button>
+    <button @click="openModalA">Open Modal</button>
   </div>
 </template>
 ```
 
 In this example, we're using the `useOverlay` composable to control multiple modals and slideovers.
+
+## Caveats
+
+### Provide / Inject
+
+When opening overlays programmatically (e.g. modals, slideovers, etc), the overlay component can only access injected values from the component containing `UApp` (typically app.vue or layout components). This is because overlays are mounted outside of the page context by the `UApp` component.
+
+As such, using `provide()` in pages or parent components isn't supported directly. To pass provided values to overlays, the recommended approach is to use props instead:
+
+```vue
+<script setup lang="ts">
+import { LazyModalExample } from '#components'
+
+const providedValue = inject('valueProvidedInPage')
+
+const modal = overlay.create(LazyModalExample, {
+  props: {
+    providedValue,
+    otherData: someValue
+  }
+})
+</script>
+```


### PR DESCRIPTION
### 🔗 Linked issue

Adds note based on the conversation in #4209 

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add a `Caveats` section to the `useOverlay` documentation to make users aware of the `provide/inject` behavior

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
