### PR TITLE
docs(input): add missing id attributes on input examples.

### DIFF
--- a/docs/app/components/content/examples/input/InputPasswordStrengthIndicatorExample.vue
+++ b/docs/app/components/content/examples/input/InputPasswordStrengthIndicatorExample.vue
@@ -44,6 +44,7 @@ const text = computed(() => {
         :aria-invalid="score < 4"
         aria-describedby="password-strength"
         class="w-full"
+        id="password"
       >
         <template #trailing>
           <UButton

--- a/docs/app/components/content/examples/input/InputPasswordToggleExample.vue
+++ b/docs/app/components/content/examples/input/InputPasswordToggleExample.vue
@@ -9,6 +9,7 @@ const password = ref('')
     placeholder="Password"
     :type="show ? 'text' : 'password'"
     :ui="{ trailing: 'pe-1' }"
+    id="password"
   >
     <template #trailing>
       <UButton


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)

### 📚 Description

`aria-controls` attributes must contain a list of id attributes.
These attributes are missing in the input documentation for [password toggle](https://ui.nuxt.com/components/input#with-password-toggle) and [password strength indicator](https://ui.nuxt.com/components/input#with-password-strength-indicator).

### 📝 Checklist

- [x] I have updated the documentation accordingly.
