### PR TITLE
fix(useOverlay): set props to original props when `defaultOpen` is set

### DIFF
--- a/src/runtime/composables/useOverlay.ts
+++ b/src/runtime/composables/useOverlay.ts
@@ -110,9 +110,7 @@ function _useOverlay() {
   const patch = <T extends Component>(id: symbol, props: Partial<ComponentProps<T>>): void => {
     const overlay = getOverlay(id)
 
-    Object.entries(props!).forEach(([key, value]) => {
-      (overlay.props as any)[key] = value
-    })
+    overlay.props = { ...props }
   }
 
   const getOverlay = (id: symbol): Overlay => {

--- a/src/runtime/composables/useOverlay.ts
+++ b/src/runtime/composables/useOverlay.ts
@@ -46,7 +46,7 @@ function _useOverlay() {
       isMounted: !!defaultOpen,
       destroyOnClose: !!destroyOnClose,
       originalProps: props || {},
-      props: {}
+      props: { ...(props || {}) }
     })
 
     overlays.push(options)


### PR DESCRIPTION
### 🔗 Linked issue

This is an extension of the this PR: #4269. Specifically [this](https://github.com/nuxt/ui/pull/4269#issuecomment-2949325493) comment

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Ensures that when `defaultOpen` is true, we are properly setting the `props` to the `originalProps` that are passed it.

This PR also includes a different strategy for `patch`. We now spread props instead of updating each one individually. There shouldn't be any impact in this particular change, but its necessary to allow clearing props.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.