### PR TITLE
fix(Pagination): match default button `size`

### DIFF
--- a/src/runtime/components/Pagination.vue
+++ b/src/runtime/components/Pagination.vue
@@ -111,7 +111,6 @@ import { tv } from '../utils/tv'
 import UButton from './Button.vue'
 
 const props = withDefaults(defineProps<PaginationProps>(), {
-  size: 'md',
   color: 'neutral',
   variant: 'outline',
   activeColor: 'primary',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
Hello 👋,

Currently, the pagination size can only be set using the `size` prop. At the same time, it's possible to change the `defaultVariants.size` for the `Button` component. Imagine a scenario where you want a smaller UI: you update the `defaultVariants.size` for the `Button` component, but the pagination still uses the default size of `md`, which is hardcoded in the component and cannot be changed globally, even through the config file.

This PR removes the default size for the `Pagination` component, allowing it to inherit the size from the `Button` component, as the documentation suggests.

> The Pagination component uses some Button to display the pages, use color, variant and size props to style them.


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
