### PR TITLE
fix(Tooltip): remove asChild on TooltipTrigger

### DIFF
--- a/src/runtime/components/Tooltip.vue
+++ b/src/runtime/components/Tooltip.vue
@@ -70,7 +70,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.tooltip || {
 
 <template>
   <TooltipRoot v-slot="{ open }" v-bind="rootProps">
-    <TooltipTrigger v-if="!!slots.default" v-bind="$attrs" as-child :class="props.class">
+    <TooltipTrigger v-if="!!slots.default" v-bind="$attrs" :class="props.class">
       <slot :open="open" />
     </TooltipTrigger>
 

--- a/test/components/__snapshots__/Tooltip-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Tooltip-vue.spec.ts.snap
@@ -47,7 +47,7 @@ exports[`Tooltip > renders with content slot correctly 1`] = `
 `;
 
 exports[`Tooltip > renders with default slot correctly 1`] = `
-"Default slot
+"<button aria-describedby="reka-tooltip-content-v-0" data-state="instant-open" data-grace-area-trigger="">Default slot</button>
 <!--teleport start-->
 
 

--- a/test/components/__snapshots__/Tooltip.spec.ts.snap
+++ b/test/components/__snapshots__/Tooltip.spec.ts.snap
@@ -47,7 +47,7 @@ exports[`Tooltip > renders with content slot correctly 1`] = `
 `;
 
 exports[`Tooltip > renders with default slot correctly 1`] = `
-"Default slot
+"<button aria-describedby="reka-tooltip-content-v-0-0" data-state="instant-open" data-grace-area-trigger="">Default slot</button>
 <!--teleport start-->
 
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #3599

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Removed the `asChild` prop from `TooltipTrigger` to prevent accessibility issues when changing the element type (see [Reka UI’s warning](https://reka-ui.com/docs/guides/composition#changing-the-element-type)). By default, it now renders a native `<button>`. 

If advanced use cases arise, we can safely reintroduce an `as` prop with proper guidance.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
