### PR TITLE
feat(Slider): Add slot to pass through tooltip content

### DIFF
--- a/src/runtime/components/Slider.vue
+++ b/src/runtime/components/Slider.vue
@@ -42,6 +42,10 @@ export interface SliderEmits<T extends number | number[] = number | number[]> {
   (e: 'update:modelValue', payload: T): void
   (e: 'change', payload: Event): void
 }
+
+export interface SliderSlots {
+  default(props?: {text: string | number}): any
+}
 </script>
 
 <script setup lang="ts" generic="T extends number | number[]">
@@ -129,6 +133,9 @@ function onChange(value: any) {
         v-bind="(typeof tooltip === 'object' ? tooltip : {})"
       >
         <SliderThumb :class="ui.thumb({ class: props.ui?.thumb })" />
+        <template name="content" v-if="$slots.tooltip">
+          <slot :text="thumbs > 1 ? String(sliderValue?.[thumb - 1]) : String(sliderValue)" />
+        </template>
       </UTooltip>
       <SliderThumb v-else :class="ui.thumb({ class: props.ui?.thumb })" />
     </template>


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Customize appearence of value in slider tooltip, such as with NumberFlow:

```vue
<USlider v-model="selected" tooltip v-slot="text">
  <NumberFlow :value="text" :format="{ style: 'decimal', trailingZeroDisplay: 'stripIfInteger' }" />
</USlider>
```

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

### Concerns
1. I'm not sure what steps are necessary to properly add this to the documentation
2. On lines 136-138, I place the slot in template with v-if. I'm unsure if this is the best way to do this. I'm trying ensure when no slot is passed, the default tooltip content is used.

