### PR TITLE
fix(Form): exposed meta forms like dirtyFields not reactive

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,0 @@
-{
-    "i18n-ally.localesPaths": [
-        "src/runtime/locale"
-    ]
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,5 @@
 {
-  "i18n-ally.localesPaths": ["src/runtime/locale"]
+    "i18n-ally.localesPaths": [
+        "src/runtime/locale"
+    ]
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "i18n-ally.localesPaths": ["src/runtime/locale"]
+}

--- a/src/runtime/components/Button.vue
+++ b/src/runtime/components/Button.vue
@@ -56,6 +56,7 @@ import UIcon from './Icon.vue'
 import UAvatar from './Avatar.vue'
 import ULink from './Link.vue'
 import ULinkBase from './LinkBase.vue'
+import { useComponentUiTheme } from '../components/Theme.vue'
 
 const props = withDefaults(defineProps<ButtonProps>(), {
   active: undefined,
@@ -65,6 +66,7 @@ const props = withDefaults(defineProps<ButtonProps>(), {
 const slots = defineSlots<ButtonSlots>()
 
 const appConfig = useAppConfig() as Button['AppConfig']
+const uiTheme = useComponentUiTheme('button', () => ({ slots: props.ui }))
 const { orientation, size: buttonSize } = useButtonGroup<ButtonProps>(props)
 
 const linkProps = useForwardProps(pickLinkProps(props))
@@ -128,7 +130,7 @@ const ui = computed(() => tv({
     <ULinkBase
       v-bind="slotProps"
       :class="ui.base({
-        class: [props.ui?.base, props.class],
+        class: [uiTheme?.slots?.base, props.class],
         active,
         ...(active && activeVariant ? { variant: activeVariant } : {}),
         ...(active && activeColor ? { color: activeColor } : {})
@@ -136,18 +138,18 @@ const ui = computed(() => tv({
       @click="onClickWrapper"
     >
       <slot name="leading">
-        <UIcon v-if="isLeading && leadingIconName" :name="leadingIconName" :class="ui.leadingIcon({ class: props.ui?.leadingIcon, active })" />
-        <UAvatar v-else-if="!!avatar" :size="((props.ui?.leadingAvatarSize || ui.leadingAvatarSize()) as AvatarProps['size'])" v-bind="avatar" :class="ui.leadingAvatar({ class: props.ui?.leadingAvatar, active })" />
+        <UIcon v-if="isLeading && leadingIconName" :name="leadingIconName" :class="ui.leadingIcon({ class: uiTheme?.slots?.leadingIcon, active })" />
+        <UAvatar v-else-if="!!avatar" :size="((uiTheme?.slots?.leadingAvatarSize || ui.leadingAvatarSize()) as AvatarProps['size'])" v-bind="avatar" :class="ui.leadingAvatar({ class: uiTheme?.slots?.leadingAvatar, active })" />
       </slot>
 
       <slot>
-        <span v-if="label !== undefined && label !== null" :class="ui.label({ class: props.ui?.label, active })">
+        <span v-if="label !== undefined && label !== null" :class="ui.label({ class: uiTheme?.slots?.label, active })">
           {{ label }}
         </span>
       </slot>
 
       <slot name="trailing">
-        <UIcon v-if="isTrailing && trailingIconName" :name="trailingIconName" :class="ui.trailingIcon({ class: props.ui?.trailingIcon, active })" />
+        <UIcon v-if="isTrailing && trailingIconName" :name="trailingIconName" :class="ui.trailingIcon({ class: uiTheme?.slots?.trailingIcon, active })" />
       </slot>
     </ULinkBase>
   </ULink>

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -1,31 +1,8 @@
 <script lang="ts">
-import {
-  provide,
-  inject,
-  nextTick,
-  ref,
-  onUnmounted,
-  onMounted,
-  computed,
-  useId,
-  readonly,
-  type Ref
-} from 'vue'
+import type { DeepReadonly } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/form'
-import type {
-  FormSchema,
-  FormError,
-  FormInputEvents,
-  FormErrorEvent,
-  FormSubmitEvent,
-  FormEvent,
-  Form,
-  FormErrorWithId,
-  InferInput,
-  InferOutput,
-  FormData
-} from '../types/form'
+import type { FormSchema, FormError, FormInputEvents, FormErrorEvent, FormSubmitEvent, FormEvent, Form, FormErrorWithId, InferInput, InferOutput, FormData } from '../types/form'
 import type { ComponentConfig } from '../types/utils'
 
 type FormConfig = ComponentConfig<typeof theme, AppConfig, 'form'>
@@ -41,9 +18,7 @@ export interface FormProps<S extends FormSchema, T extends boolean = true> {
    * @param state - The current state of the form.
    * @returns A promise that resolves to an array of FormError objects, or an array of FormError objects directly.
    */
-  validate?: (
-    state: Partial<InferInput<S>>,
-  ) => Promise<FormError[]> | FormError[]
+  validate?: (state: Partial<InferInput<S>>) => Promise<FormError[]> | FormError[]
   /**
    * The list of input events that trigger the form validation.
    * @defaultValue `['blur', 'change', 'input']`
@@ -75,9 +50,7 @@ export interface FormProps<S extends FormSchema, T extends boolean = true> {
    */
   loadingAuto?: boolean
   class?: any
-  onSubmit?:
-    | ((event: FormSubmitEvent<FormData<S, T>>) => void | Promise<void>)
-    | (() => void | Promise<void>)
+  onSubmit?: ((event: FormSubmitEvent<FormData<S, T>>) => void | Promise<void>) | (() => void | Promise<void>)
 }
 
 export interface FormEmits<S extends FormSchema, T extends boolean = true> {
@@ -90,19 +63,11 @@ export interface FormSlots {
 }
 </script>
 
-<script
-  lang="ts"
-  setup
-  generic="S extends FormSchema, T extends boolean = true"
->
+<script lang="ts" setup generic="S extends FormSchema, T extends boolean = true">
+import { provide, inject, nextTick, ref, onUnmounted, onMounted, computed, useId, readonly, type Ref } from 'vue'
 import { useEventBus } from '@vueuse/core'
 import { useAppConfig } from '#imports'
-import {
-  formOptionsInjectionKey,
-  formInputsInjectionKey,
-  formBusInjectionKey,
-  formLoadingInjectionKey
-} from '../composables/useFormField'
+import { formOptionsInjectionKey, formInputsInjectionKey, formBusInjectionKey, formLoadingInjectionKey } from '../composables/useFormField'
 import { tv } from '../utils/tv'
 import { validateSchema } from '../utils/form'
 import { FormValidationException } from '../types/form'
@@ -125,20 +90,19 @@ defineSlots<FormSlots>()
 
 const appConfig = useAppConfig() as FormConfig['AppConfig']
 
-const ui = computed(() =>
-  tv({ extend: tv(theme), ...(appConfig.ui?.form || {}) })
-)
+const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.form || {}) }))
 
-const formId = props.id ?? (useId() as string)
+const formId = props.id ?? useId() as string
 
 const bus = useEventBus<FormEvent<I>>(`form-${formId}`)
-const parentBus = props.attach && inject(formBusInjectionKey, undefined)
+const parentBus = props.attach && inject(
+  formBusInjectionKey,
+  undefined
+)
 
 provide(formBusInjectionKey, bus)
 
-const nestedForms = ref<Map<string | number, { validate: typeof _validate }>>(
-  new Map()
-)
+const nestedForms = ref<Map<string | number, { validate: typeof _validate }>>(new Map())
 
 onMounted(async () => {
   bus.on(async (event) => {
@@ -158,12 +122,7 @@ onMounted(async () => {
       blurredFields.value.add(event.name)
     }
 
-    if (
-      event.type === 'change'
-      || event.type === 'input'
-      || event.type === 'blur'
-      || event.type === 'focus'
-    ) {
+    if (event.type === 'change' || event.type === 'input' || event.type === 'blur' || event.type === 'focus') {
       touchedFields.value.add(event.name)
     }
 
@@ -210,13 +169,10 @@ function resolveErrorIds(errs: FormError[]): FormErrorWithId[] {
 const transformedState = ref<O | null>(null)
 
 async function getErrors(): Promise<FormErrorWithId[]> {
-  let errs = props.validate ? ((await props.validate(props.state)) ?? []) : []
+  let errs = props.validate ? (await props.validate(props.state)) ?? [] : []
 
   if (props.schema) {
-    const { errors, result } = await validateSchema(
-      props.state,
-      props.schema as FormSchema<typeof props.state>
-    )
+    const { errors, result } = await validateSchema(props.state, props.schema as FormSchema<typeof props.state>)
     if (errors) {
       errs = errs.concat(errors)
     } else {
@@ -227,68 +183,40 @@ async function getErrors(): Promise<FormErrorWithId[]> {
   return resolveErrorIds(errs)
 }
 
-type ValidateOpts<Silent extends boolean, Transform extends boolean> = {
-  name?: keyof I | (keyof I)[]
-  silent?: Silent
-  nested?: boolean
-  transform?: Transform
-}
-async function _validate<T extends boolean>(
-  opts: ValidateOpts<false, T>,
-): Promise<FormData<S, T>>
-async function _validate<T extends boolean>(
-  opts: ValidateOpts<true, T>,
-): Promise<FormData<S, T> | false>
-async function _validate<T extends boolean>(
-  opts: ValidateOpts<boolean, boolean> = {
-    silent: false,
-    nested: true,
-    transform: false
-  }
-): Promise<FormData<S, T> | false> {
-  const names
-    = opts.name && !Array.isArray(opts.name)
-      ? [opts.name]
-      : (opts.name as (keyof O)[])
+type ValidateOpts<Silent extends boolean, Transform extends boolean> = { name?: keyof I | (keyof I)[], silent?: Silent, nested?: boolean, transform?: Transform }
+async function _validate<T extends boolean>(opts: ValidateOpts<false, T>): Promise<FormData<S, T>>
+async function _validate<T extends boolean>(opts: ValidateOpts<true, T>): Promise<FormData<S, T> | false>
+async function _validate<T extends boolean>(opts: ValidateOpts<boolean, boolean> = { silent: false, nested: true, transform: false }): Promise<FormData<S, T> | false> {
+  const names = opts.name && !Array.isArray(opts.name) ? [opts.name] : opts.name as (keyof O)[]
 
-  const nestedValidatePromises
-    = !names && opts.nested
-      ? Array.from(nestedForms.value.values()).map(({ validate }) =>
-          validate(opts as any)
-            .then(() => undefined)
-            .catch((error: Error) => {
-              if (!(error instanceof FormValidationException)) {
-                throw error
-              }
-              return error
-            })
-        )
-      : []
+  const nestedValidatePromises = !names && opts.nested
+    ? Array.from(nestedForms.value.values()).map(
+        ({ validate }) => validate(opts as any).then(() => undefined).catch((error: Error) => {
+          if (!(error instanceof FormValidationException)) {
+            throw error
+          }
+          return error
+        })
+      )
+    : []
 
   if (names) {
-    const otherErrors = errors.value.filter(
-      error =>
-        !names.some((name) => {
-          const pattern = inputs.value?.[name]?.pattern
-          return name === error.name || (pattern && error.name?.match(pattern))
-        })
-    )
+    const otherErrors = errors.value.filter(error => !names.some((name) => {
+      const pattern = inputs.value?.[name]?.pattern
+      return name === error.name || (pattern && error.name?.match(pattern))
+    }))
 
-    const pathErrors = (await getErrors()).filter(error =>
-      names.some((name) => {
-        const pattern = inputs.value?.[name]?.pattern
-        return name === error.name || (pattern && error.name?.match(pattern))
-      })
-    )
+    const pathErrors = (await getErrors()).filter(error => names.some((name) => {
+      const pattern = inputs.value?.[name]?.pattern
+      return name === error.name || (pattern && error.name?.match(pattern))
+    }))
 
     errors.value = otherErrors.concat(pathErrors)
   } else {
     errors.value = await getErrors()
   }
 
-  const childErrors = (await Promise.all(nestedValidatePromises)).filter(
-    val => val !== undefined
-  )
+  const childErrors = (await Promise.all(nestedValidatePromises)).filter(val => val !== undefined)
 
   if (errors.value.length + childErrors.length > 0) {
     if (opts.silent) return false
@@ -332,13 +260,10 @@ async function onSubmitWrapper(payload: Event) {
 
 const disabled = computed(() => props.disabled || loading.value)
 
-provide(
-  formOptionsInjectionKey,
-  computed(() => ({
-    disabled: disabled.value,
-    validateOnInputDelay: props.validateOnInputDelay
-  }))
-)
+provide(formOptionsInjectionKey, computed(() => ({
+  disabled: disabled.value,
+  validateOnInputDelay: props.validateOnInputDelay
+})))
 
 defineExpose<Form<S>>({
   validate: _validate,
@@ -376,6 +301,7 @@ defineExpose<Form<S>>({
   disabled,
   loading,
   dirty: computed(() => !!dirtyFields.value.size),
+
   dirtyFields: computed(() => dirtyFields.value),
   blurredFields: computed(() => blurredFields.value),
   touchedFields: computed(() => touchedFields.value)

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -1,31 +1,8 @@
 <script lang="ts">
-import {
-  provide,
-  inject,
-  nextTick,
-  ref,
-  onUnmounted,
-  onMounted,
-  computed,
-  useId,
-  readonly,
-  type Ref
-} from 'vue'
+import type { DeepReadonly } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/form'
-import type {
-  FormSchema,
-  FormError,
-  FormInputEvents,
-  FormErrorEvent,
-  FormSubmitEvent,
-  FormEvent,
-  Form,
-  FormErrorWithId,
-  InferInput,
-  InferOutput,
-  FormData
-} from '../types/form'
+import type { FormSchema, FormError, FormInputEvents, FormErrorEvent, FormSubmitEvent, FormEvent, Form, FormErrorWithId, InferInput, InferOutput, FormData } from '../types/form'
 import type { ComponentConfig } from '../types/utils'
 
 type FormConfig = ComponentConfig<typeof theme, AppConfig, 'form'>
@@ -41,9 +18,7 @@ export interface FormProps<S extends FormSchema, T extends boolean = true> {
    * @param state - The current state of the form.
    * @returns A promise that resolves to an array of FormError objects, or an array of FormError objects directly.
    */
-  validate?: (
-    state: Partial<InferInput<S>>,
-  ) => Promise<FormError[]> | FormError[]
+  validate?: (state: Partial<InferInput<S>>) => Promise<FormError[]> | FormError[]
   /**
    * The list of input events that trigger the form validation.
    * @defaultValue `['blur', 'change', 'input']`
@@ -75,9 +50,7 @@ export interface FormProps<S extends FormSchema, T extends boolean = true> {
    */
   loadingAuto?: boolean
   class?: any
-  onSubmit?:
-    | ((event: FormSubmitEvent<FormData<S, T>>) => void | Promise<void>)
-    | (() => void | Promise<void>)
+  onSubmit?: ((event: FormSubmitEvent<FormData<S, T>>) => void | Promise<void>) | (() => void | Promise<void>)
 }
 
 export interface FormEmits<S extends FormSchema, T extends boolean = true> {
@@ -90,19 +63,11 @@ export interface FormSlots {
 }
 </script>
 
-<script
-  lang="ts"
-  setup
-  generic="S extends FormSchema, T extends boolean = true"
->
+<script lang="ts" setup generic="S extends FormSchema, T extends boolean = true">
+import { provide, inject, nextTick, ref, onUnmounted, onMounted, computed, useId, readonly, type Ref } from 'vue'
 import { useEventBus } from '@vueuse/core'
 import { useAppConfig } from '#imports'
-import {
-  formOptionsInjectionKey,
-  formInputsInjectionKey,
-  formBusInjectionKey,
-  formLoadingInjectionKey
-} from '../composables/useFormField'
+import { formOptionsInjectionKey, formInputsInjectionKey, formBusInjectionKey, formLoadingInjectionKey } from '../composables/useFormField'
 import { tv } from '../utils/tv'
 import { validateSchema } from '../utils/form'
 import { FormValidationException } from '../types/form'
@@ -125,20 +90,19 @@ defineSlots<FormSlots>()
 
 const appConfig = useAppConfig() as FormConfig['AppConfig']
 
-const ui = computed(() =>
-  tv({ extend: tv(theme), ...(appConfig.ui?.form || {}) })
-)
+const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.form || {}) }))
 
-const formId = props.id ?? (useId() as string)
+const formId = props.id ?? useId() as string
 
 const bus = useEventBus<FormEvent<I>>(`form-${formId}`)
-const parentBus = props.attach && inject(formBusInjectionKey, undefined)
+const parentBus = props.attach && inject(
+  formBusInjectionKey,
+  undefined
+)
 
 provide(formBusInjectionKey, bus)
 
-const nestedForms = ref<Map<string | number, { validate: typeof _validate }>>(
-  new Map()
-)
+const nestedForms = ref<Map<string | number, { validate: typeof _validate }>>(new Map())
 
 onMounted(async () => {
   bus.on(async (event) => {
@@ -158,12 +122,7 @@ onMounted(async () => {
       blurredFields.value.add(event.name)
     }
 
-    if (
-      event.type === 'change'
-      || event.type === 'input'
-      || event.type === 'blur'
-      || event.type === 'focus'
-    ) {
+    if (event.type === 'change' || event.type === 'input' || event.type === 'blur' || event.type === 'focus') {
       touchedFields.value.add(event.name)
     }
 
@@ -210,13 +169,10 @@ function resolveErrorIds(errs: FormError[]): FormErrorWithId[] {
 const transformedState = ref<O | null>(null)
 
 async function getErrors(): Promise<FormErrorWithId[]> {
-  let errs = props.validate ? ((await props.validate(props.state)) ?? []) : []
+  let errs = props.validate ? (await props.validate(props.state)) ?? [] : []
 
   if (props.schema) {
-    const { errors, result } = await validateSchema(
-      props.state,
-      props.schema as FormSchema<typeof props.state>
-    )
+    const { errors, result } = await validateSchema(props.state, props.schema as FormSchema<typeof props.state>)
     if (errors) {
       errs = errs.concat(errors)
     } else {
@@ -227,68 +183,40 @@ async function getErrors(): Promise<FormErrorWithId[]> {
   return resolveErrorIds(errs)
 }
 
-type ValidateOpts<Silent extends boolean, Transform extends boolean> = {
-  name?: keyof I | (keyof I)[]
-  silent?: Silent
-  nested?: boolean
-  transform?: Transform
-}
-async function _validate<T extends boolean>(
-  opts: ValidateOpts<false, T>,
-): Promise<FormData<S, T>>
-async function _validate<T extends boolean>(
-  opts: ValidateOpts<true, T>,
-): Promise<FormData<S, T> | false>
-async function _validate<T extends boolean>(
-  opts: ValidateOpts<boolean, boolean> = {
-    silent: false,
-    nested: true,
-    transform: false
-  }
-): Promise<FormData<S, T> | false> {
-  const names
-    = opts.name && !Array.isArray(opts.name)
-      ? [opts.name]
-      : (opts.name as (keyof O)[])
+type ValidateOpts<Silent extends boolean, Transform extends boolean> = { name?: keyof I | (keyof I)[], silent?: Silent, nested?: boolean, transform?: Transform }
+async function _validate<T extends boolean>(opts: ValidateOpts<false, T>): Promise<FormData<S, T>>
+async function _validate<T extends boolean>(opts: ValidateOpts<true, T>): Promise<FormData<S, T> | false>
+async function _validate<T extends boolean>(opts: ValidateOpts<boolean, boolean> = { silent: false, nested: true, transform: false }): Promise<FormData<S, T> | false> {
+  const names = opts.name && !Array.isArray(opts.name) ? [opts.name] : opts.name as (keyof O)[]
 
-  const nestedValidatePromises
-    = !names && opts.nested
-      ? Array.from(nestedForms.value.values()).map(({ validate }) =>
-          validate(opts as any)
-            .then(() => undefined)
-            .catch((error: Error) => {
-              if (!(error instanceof FormValidationException)) {
-                throw error
-              }
-              return error
-            })
-        )
-      : []
+  const nestedValidatePromises = !names && opts.nested
+    ? Array.from(nestedForms.value.values()).map(
+        ({ validate }) => validate(opts as any).then(() => undefined).catch((error: Error) => {
+          if (!(error instanceof FormValidationException)) {
+            throw error
+          }
+          return error
+        })
+      )
+    : []
 
   if (names) {
-    const otherErrors = errors.value.filter(
-      error =>
-        !names.some((name) => {
-          const pattern = inputs.value?.[name]?.pattern
-          return name === error.name || (pattern && error.name?.match(pattern))
-        })
-    )
+    const otherErrors = errors.value.filter(error => !names.some((name) => {
+      const pattern = inputs.value?.[name]?.pattern
+      return name === error.name || (pattern && error.name?.match(pattern))
+    }))
 
-    const pathErrors = (await getErrors()).filter(error =>
-      names.some((name) => {
-        const pattern = inputs.value?.[name]?.pattern
-        return name === error.name || (pattern && error.name?.match(pattern))
-      })
-    )
+    const pathErrors = (await getErrors()).filter(error => names.some((name) => {
+      const pattern = inputs.value?.[name]?.pattern
+      return name === error.name || (pattern && error.name?.match(pattern))
+    }))
 
     errors.value = otherErrors.concat(pathErrors)
   } else {
     errors.value = await getErrors()
   }
 
-  const childErrors = (await Promise.all(nestedValidatePromises)).filter(
-    val => val !== undefined
-  )
+  const childErrors = (await Promise.all(nestedValidatePromises)).filter(val => val !== undefined)
 
   if (errors.value.length + childErrors.length > 0) {
     if (opts.silent) return false
@@ -332,13 +260,10 @@ async function onSubmitWrapper(payload: Event) {
 
 const disabled = computed(() => props.disabled || loading.value)
 
-provide(
-  formOptionsInjectionKey,
-  computed(() => ({
-    disabled: disabled.value,
-    validateOnInputDelay: props.validateOnInputDelay
-  }))
-)
+provide(formOptionsInjectionKey, computed(() => ({
+  disabled: disabled.value,
+  validateOnInputDelay: props.validateOnInputDelay
+})))
 
 defineExpose<Form<S>>({
   validate: _validate,

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -1,8 +1,31 @@
 <script lang="ts">
-import type { DeepReadonly } from 'vue'
+import {
+  provide,
+  inject,
+  nextTick,
+  ref,
+  onUnmounted,
+  onMounted,
+  computed,
+  useId,
+  readonly,
+  type Ref
+} from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/form'
-import type { FormSchema, FormError, FormInputEvents, FormErrorEvent, FormSubmitEvent, FormEvent, Form, FormErrorWithId, InferInput, InferOutput, FormData } from '../types/form'
+import type {
+  FormSchema,
+  FormError,
+  FormInputEvents,
+  FormErrorEvent,
+  FormSubmitEvent,
+  FormEvent,
+  Form,
+  FormErrorWithId,
+  InferInput,
+  InferOutput,
+  FormData
+} from '../types/form'
 import type { ComponentConfig } from '../types/utils'
 
 type FormConfig = ComponentConfig<typeof theme, AppConfig, 'form'>
@@ -18,7 +41,9 @@ export interface FormProps<S extends FormSchema, T extends boolean = true> {
    * @param state - The current state of the form.
    * @returns A promise that resolves to an array of FormError objects, or an array of FormError objects directly.
    */
-  validate?: (state: Partial<InferInput<S>>) => Promise<FormError[]> | FormError[]
+  validate?: (
+    state: Partial<InferInput<S>>,
+  ) => Promise<FormError[]> | FormError[]
   /**
    * The list of input events that trigger the form validation.
    * @defaultValue `['blur', 'change', 'input']`
@@ -50,7 +75,9 @@ export interface FormProps<S extends FormSchema, T extends boolean = true> {
    */
   loadingAuto?: boolean
   class?: any
-  onSubmit?: ((event: FormSubmitEvent<FormData<S, T>>) => void | Promise<void>) | (() => void | Promise<void>)
+  onSubmit?:
+    | ((event: FormSubmitEvent<FormData<S, T>>) => void | Promise<void>)
+    | (() => void | Promise<void>)
 }
 
 export interface FormEmits<S extends FormSchema, T extends boolean = true> {
@@ -63,11 +90,19 @@ export interface FormSlots {
 }
 </script>
 
-<script lang="ts" setup generic="S extends FormSchema, T extends boolean = true">
-import { provide, inject, nextTick, ref, onUnmounted, onMounted, computed, useId, readonly, type Ref } from 'vue'
+<script
+  lang="ts"
+  setup
+  generic="S extends FormSchema, T extends boolean = true"
+>
 import { useEventBus } from '@vueuse/core'
 import { useAppConfig } from '#imports'
-import { formOptionsInjectionKey, formInputsInjectionKey, formBusInjectionKey, formLoadingInjectionKey } from '../composables/useFormField'
+import {
+  formOptionsInjectionKey,
+  formInputsInjectionKey,
+  formBusInjectionKey,
+  formLoadingInjectionKey
+} from '../composables/useFormField'
 import { tv } from '../utils/tv'
 import { validateSchema } from '../utils/form'
 import { FormValidationException } from '../types/form'
@@ -90,19 +125,20 @@ defineSlots<FormSlots>()
 
 const appConfig = useAppConfig() as FormConfig['AppConfig']
 
-const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.form || {}) }))
+const ui = computed(() =>
+  tv({ extend: tv(theme), ...(appConfig.ui?.form || {}) })
+)
 
-const formId = props.id ?? useId() as string
+const formId = props.id ?? (useId() as string)
 
 const bus = useEventBus<FormEvent<I>>(`form-${formId}`)
-const parentBus = props.attach && inject(
-  formBusInjectionKey,
-  undefined
-)
+const parentBus = props.attach && inject(formBusInjectionKey, undefined)
 
 provide(formBusInjectionKey, bus)
 
-const nestedForms = ref<Map<string | number, { validate: typeof _validate }>>(new Map())
+const nestedForms = ref<Map<string | number, { validate: typeof _validate }>>(
+  new Map()
+)
 
 onMounted(async () => {
   bus.on(async (event) => {
@@ -122,7 +158,12 @@ onMounted(async () => {
       blurredFields.value.add(event.name)
     }
 
-    if (event.type === 'change' || event.type === 'input' || event.type === 'blur' || event.type === 'focus') {
+    if (
+      event.type === 'change'
+      || event.type === 'input'
+      || event.type === 'blur'
+      || event.type === 'focus'
+    ) {
       touchedFields.value.add(event.name)
     }
 
@@ -169,10 +210,13 @@ function resolveErrorIds(errs: FormError[]): FormErrorWithId[] {
 const transformedState = ref<O | null>(null)
 
 async function getErrors(): Promise<FormErrorWithId[]> {
-  let errs = props.validate ? (await props.validate(props.state)) ?? [] : []
+  let errs = props.validate ? ((await props.validate(props.state)) ?? []) : []
 
   if (props.schema) {
-    const { errors, result } = await validateSchema(props.state, props.schema as FormSchema<typeof props.state>)
+    const { errors, result } = await validateSchema(
+      props.state,
+      props.schema as FormSchema<typeof props.state>
+    )
     if (errors) {
       errs = errs.concat(errors)
     } else {
@@ -183,40 +227,68 @@ async function getErrors(): Promise<FormErrorWithId[]> {
   return resolveErrorIds(errs)
 }
 
-type ValidateOpts<Silent extends boolean, Transform extends boolean> = { name?: keyof I | (keyof I)[], silent?: Silent, nested?: boolean, transform?: Transform }
-async function _validate<T extends boolean>(opts: ValidateOpts<false, T>): Promise<FormData<S, T>>
-async function _validate<T extends boolean>(opts: ValidateOpts<true, T>): Promise<FormData<S, T> | false>
-async function _validate<T extends boolean>(opts: ValidateOpts<boolean, boolean> = { silent: false, nested: true, transform: false }): Promise<FormData<S, T> | false> {
-  const names = opts.name && !Array.isArray(opts.name) ? [opts.name] : opts.name as (keyof O)[]
+type ValidateOpts<Silent extends boolean, Transform extends boolean> = {
+  name?: keyof I | (keyof I)[]
+  silent?: Silent
+  nested?: boolean
+  transform?: Transform
+}
+async function _validate<T extends boolean>(
+  opts: ValidateOpts<false, T>,
+): Promise<FormData<S, T>>
+async function _validate<T extends boolean>(
+  opts: ValidateOpts<true, T>,
+): Promise<FormData<S, T> | false>
+async function _validate<T extends boolean>(
+  opts: ValidateOpts<boolean, boolean> = {
+    silent: false,
+    nested: true,
+    transform: false
+  }
+): Promise<FormData<S, T> | false> {
+  const names
+    = opts.name && !Array.isArray(opts.name)
+      ? [opts.name]
+      : (opts.name as (keyof O)[])
 
-  const nestedValidatePromises = !names && opts.nested
-    ? Array.from(nestedForms.value.values()).map(
-        ({ validate }) => validate(opts as any).then(() => undefined).catch((error: Error) => {
-          if (!(error instanceof FormValidationException)) {
-            throw error
-          }
-          return error
-        })
-      )
-    : []
+  const nestedValidatePromises
+    = !names && opts.nested
+      ? Array.from(nestedForms.value.values()).map(({ validate }) =>
+          validate(opts as any)
+            .then(() => undefined)
+            .catch((error: Error) => {
+              if (!(error instanceof FormValidationException)) {
+                throw error
+              }
+              return error
+            })
+        )
+      : []
 
   if (names) {
-    const otherErrors = errors.value.filter(error => !names.some((name) => {
-      const pattern = inputs.value?.[name]?.pattern
-      return name === error.name || (pattern && error.name?.match(pattern))
-    }))
+    const otherErrors = errors.value.filter(
+      error =>
+        !names.some((name) => {
+          const pattern = inputs.value?.[name]?.pattern
+          return name === error.name || (pattern && error.name?.match(pattern))
+        })
+    )
 
-    const pathErrors = (await getErrors()).filter(error => names.some((name) => {
-      const pattern = inputs.value?.[name]?.pattern
-      return name === error.name || (pattern && error.name?.match(pattern))
-    }))
+    const pathErrors = (await getErrors()).filter(error =>
+      names.some((name) => {
+        const pattern = inputs.value?.[name]?.pattern
+        return name === error.name || (pattern && error.name?.match(pattern))
+      })
+    )
 
     errors.value = otherErrors.concat(pathErrors)
   } else {
     errors.value = await getErrors()
   }
 
-  const childErrors = (await Promise.all(nestedValidatePromises)).filter(val => val !== undefined)
+  const childErrors = (await Promise.all(nestedValidatePromises)).filter(
+    val => val !== undefined
+  )
 
   if (errors.value.length + childErrors.length > 0) {
     if (opts.silent) return false
@@ -260,10 +332,13 @@ async function onSubmitWrapper(payload: Event) {
 
 const disabled = computed(() => props.disabled || loading.value)
 
-provide(formOptionsInjectionKey, computed(() => ({
-  disabled: disabled.value,
-  validateOnInputDelay: props.validateOnInputDelay
-})))
+provide(
+  formOptionsInjectionKey,
+  computed(() => ({
+    disabled: disabled.value,
+    validateOnInputDelay: props.validateOnInputDelay
+  }))
+)
 
 defineExpose<Form<S>>({
   validate: _validate,
@@ -301,7 +376,6 @@ defineExpose<Form<S>>({
   disabled,
   loading,
   dirty: computed(() => !!dirtyFields.value.size),
-
   dirtyFields: computed(() => dirtyFields.value),
   blurredFields: computed(() => blurredFields.value),
   touchedFields: computed(() => touchedFields.value)

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -1,8 +1,31 @@
 <script lang="ts">
-import type { DeepReadonly } from 'vue'
+import {
+  provide,
+  inject,
+  nextTick,
+  ref,
+  onUnmounted,
+  onMounted,
+  computed,
+  useId,
+  readonly,
+  type Ref
+} from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/form'
-import type { FormSchema, FormError, FormInputEvents, FormErrorEvent, FormSubmitEvent, FormEvent, Form, FormErrorWithId, InferInput, InferOutput, FormData } from '../types/form'
+import type {
+  FormSchema,
+  FormError,
+  FormInputEvents,
+  FormErrorEvent,
+  FormSubmitEvent,
+  FormEvent,
+  Form,
+  FormErrorWithId,
+  InferInput,
+  InferOutput,
+  FormData
+} from '../types/form'
 import type { ComponentConfig } from '../types/utils'
 
 type FormConfig = ComponentConfig<typeof theme, AppConfig, 'form'>
@@ -18,7 +41,9 @@ export interface FormProps<S extends FormSchema, T extends boolean = true> {
    * @param state - The current state of the form.
    * @returns A promise that resolves to an array of FormError objects, or an array of FormError objects directly.
    */
-  validate?: (state: Partial<InferInput<S>>) => Promise<FormError[]> | FormError[]
+  validate?: (
+    state: Partial<InferInput<S>>,
+  ) => Promise<FormError[]> | FormError[]
   /**
    * The list of input events that trigger the form validation.
    * @defaultValue `['blur', 'change', 'input']`
@@ -50,7 +75,9 @@ export interface FormProps<S extends FormSchema, T extends boolean = true> {
    */
   loadingAuto?: boolean
   class?: any
-  onSubmit?: ((event: FormSubmitEvent<FormData<S, T>>) => void | Promise<void>) | (() => void | Promise<void>)
+  onSubmit?:
+    | ((event: FormSubmitEvent<FormData<S, T>>) => void | Promise<void>)
+    | (() => void | Promise<void>)
 }
 
 export interface FormEmits<S extends FormSchema, T extends boolean = true> {
@@ -63,11 +90,19 @@ export interface FormSlots {
 }
 </script>
 
-<script lang="ts" setup generic="S extends FormSchema, T extends boolean = true">
-import { provide, inject, nextTick, ref, onUnmounted, onMounted, computed, useId, readonly } from 'vue'
+<script
+  lang="ts"
+  setup
+  generic="S extends FormSchema, T extends boolean = true"
+>
 import { useEventBus } from '@vueuse/core'
 import { useAppConfig } from '#imports'
-import { formOptionsInjectionKey, formInputsInjectionKey, formBusInjectionKey, formLoadingInjectionKey } from '../composables/useFormField'
+import {
+  formOptionsInjectionKey,
+  formInputsInjectionKey,
+  formBusInjectionKey,
+  formLoadingInjectionKey
+} from '../composables/useFormField'
 import { tv } from '../utils/tv'
 import { validateSchema } from '../utils/form'
 import { FormValidationException } from '../types/form'
@@ -90,19 +125,20 @@ defineSlots<FormSlots>()
 
 const appConfig = useAppConfig() as FormConfig['AppConfig']
 
-const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.form || {}) }))
+const ui = computed(() =>
+  tv({ extend: tv(theme), ...(appConfig.ui?.form || {}) })
+)
 
-const formId = props.id ?? useId() as string
+const formId = props.id ?? (useId() as string)
 
 const bus = useEventBus<FormEvent<I>>(`form-${formId}`)
-const parentBus = props.attach && inject(
-  formBusInjectionKey,
-  undefined
-)
+const parentBus = props.attach && inject(formBusInjectionKey, undefined)
 
 provide(formBusInjectionKey, bus)
 
-const nestedForms = ref<Map<string | number, { validate: typeof _validate }>>(new Map())
+const nestedForms = ref<Map<string | number, { validate: typeof _validate }>>(
+  new Map()
+)
 
 onMounted(async () => {
   bus.on(async (event) => {
@@ -113,21 +149,26 @@ onMounted(async () => {
     } else if (props.validateOn?.includes(event.type) && !loading.value) {
       if (event.type !== 'input') {
         await _validate({ name: event.name, silent: true, nested: false })
-      } else if (event.eager || blurredFields.has(event.name)) {
+      } else if (event.eager || blurredFields.value.has(event.name)) {
         await _validate({ name: event.name, silent: true, nested: false })
       }
     }
 
     if (event.type === 'blur') {
-      blurredFields.add(event.name)
+      blurredFields.value.add(event.name)
     }
 
-    if (event.type === 'change' || event.type === 'input' || event.type === 'blur' || event.type === 'focus') {
-      touchedFields.add(event.name)
+    if (
+      event.type === 'change'
+      || event.type === 'input'
+      || event.type === 'blur'
+      || event.type === 'focus'
+    ) {
+      touchedFields.value.add(event.name)
     }
 
     if (event.type === 'change' || event.type === 'input') {
-      dirtyFields.add(event.name)
+      dirtyFields.value.add(event.name)
     }
   })
 })
@@ -155,9 +196,9 @@ provide('form-errors', errors)
 const inputs = ref<{ [P in keyof I]?: { id?: string, pattern?: RegExp } }>({})
 provide(formInputsInjectionKey, inputs as any)
 
-const dirtyFields = new Set<keyof I>()
-const touchedFields = new Set<keyof I>()
-const blurredFields = new Set<keyof I>()
+const dirtyFields: Ref<Set<keyof I>> = ref(new Set<keyof I>())
+const touchedFields: Ref<Set<keyof I>> = ref(new Set<keyof I>())
+const blurredFields: Ref<Set<keyof I>> = ref(new Set<keyof I>())
 
 function resolveErrorIds(errs: FormError[]): FormErrorWithId[] {
   return errs.map(err => ({
@@ -169,10 +210,13 @@ function resolveErrorIds(errs: FormError[]): FormErrorWithId[] {
 const transformedState = ref<O | null>(null)
 
 async function getErrors(): Promise<FormErrorWithId[]> {
-  let errs = props.validate ? (await props.validate(props.state)) ?? [] : []
+  let errs = props.validate ? ((await props.validate(props.state)) ?? []) : []
 
   if (props.schema) {
-    const { errors, result } = await validateSchema(props.state, props.schema as FormSchema<typeof props.state>)
+    const { errors, result } = await validateSchema(
+      props.state,
+      props.schema as FormSchema<typeof props.state>
+    )
     if (errors) {
       errs = errs.concat(errors)
     } else {
@@ -183,40 +227,68 @@ async function getErrors(): Promise<FormErrorWithId[]> {
   return resolveErrorIds(errs)
 }
 
-type ValidateOpts<Silent extends boolean, Transform extends boolean> = { name?: keyof I | (keyof I)[], silent?: Silent, nested?: boolean, transform?: Transform }
-async function _validate<T extends boolean>(opts: ValidateOpts<false, T>): Promise<FormData<S, T>>
-async function _validate<T extends boolean>(opts: ValidateOpts<true, T>): Promise<FormData<S, T> | false>
-async function _validate<T extends boolean>(opts: ValidateOpts<boolean, boolean> = { silent: false, nested: true, transform: false }): Promise<FormData<S, T> | false> {
-  const names = opts.name && !Array.isArray(opts.name) ? [opts.name] : opts.name as (keyof O)[]
+type ValidateOpts<Silent extends boolean, Transform extends boolean> = {
+  name?: keyof I | (keyof I)[]
+  silent?: Silent
+  nested?: boolean
+  transform?: Transform
+}
+async function _validate<T extends boolean>(
+  opts: ValidateOpts<false, T>,
+): Promise<FormData<S, T>>
+async function _validate<T extends boolean>(
+  opts: ValidateOpts<true, T>,
+): Promise<FormData<S, T> | false>
+async function _validate<T extends boolean>(
+  opts: ValidateOpts<boolean, boolean> = {
+    silent: false,
+    nested: true,
+    transform: false
+  }
+): Promise<FormData<S, T> | false> {
+  const names
+    = opts.name && !Array.isArray(opts.name)
+      ? [opts.name]
+      : (opts.name as (keyof O)[])
 
-  const nestedValidatePromises = !names && opts.nested
-    ? Array.from(nestedForms.value.values()).map(
-        ({ validate }) => validate(opts as any).then(() => undefined).catch((error: Error) => {
-          if (!(error instanceof FormValidationException)) {
-            throw error
-          }
-          return error
-        })
-      )
-    : []
+  const nestedValidatePromises
+    = !names && opts.nested
+      ? Array.from(nestedForms.value.values()).map(({ validate }) =>
+          validate(opts as any)
+            .then(() => undefined)
+            .catch((error: Error) => {
+              if (!(error instanceof FormValidationException)) {
+                throw error
+              }
+              return error
+            })
+        )
+      : []
 
   if (names) {
-    const otherErrors = errors.value.filter(error => !names.some((name) => {
-      const pattern = inputs.value?.[name]?.pattern
-      return name === error.name || (pattern && error.name?.match(pattern))
-    }))
+    const otherErrors = errors.value.filter(
+      error =>
+        !names.some((name) => {
+          const pattern = inputs.value?.[name]?.pattern
+          return name === error.name || (pattern && error.name?.match(pattern))
+        })
+    )
 
-    const pathErrors = (await getErrors()).filter(error => names.some((name) => {
-      const pattern = inputs.value?.[name]?.pattern
-      return name === error.name || (pattern && error.name?.match(pattern))
-    }))
+    const pathErrors = (await getErrors()).filter(error =>
+      names.some((name) => {
+        const pattern = inputs.value?.[name]?.pattern
+        return name === error.name || (pattern && error.name?.match(pattern))
+      })
+    )
 
     errors.value = otherErrors.concat(pathErrors)
   } else {
     errors.value = await getErrors()
   }
 
-  const childErrors = (await Promise.all(nestedValidatePromises)).filter(val => val !== undefined)
+  const childErrors = (await Promise.all(nestedValidatePromises)).filter(
+    val => val !== undefined
+  )
 
   if (errors.value.length + childErrors.length > 0) {
     if (opts.silent) return false
@@ -241,7 +313,7 @@ async function onSubmitWrapper(payload: Event) {
   try {
     event.data = await _validate({ nested: true, transform: props.transform })
     await props.onSubmit?.(event)
-    dirtyFields.clear()
+    dirtyFields.value.clear()
   } catch (error) {
     if (!(error instanceof FormValidationException)) {
       throw error
@@ -260,10 +332,13 @@ async function onSubmitWrapper(payload: Event) {
 
 const disabled = computed(() => props.disabled || loading.value)
 
-provide(formOptionsInjectionKey, computed(() => ({
-  disabled: disabled.value,
-  validateOnInputDelay: props.validateOnInputDelay
-})))
+provide(
+  formOptionsInjectionKey,
+  computed(() => ({
+    disabled: disabled.value,
+    validateOnInputDelay: props.validateOnInputDelay
+  }))
+)
 
 defineExpose<Form<S>>({
   validate: _validate,
@@ -300,11 +375,11 @@ defineExpose<Form<S>>({
 
   disabled,
   loading,
-  dirty: computed(() => !!dirtyFields.size),
+  dirty: computed(() => !!dirtyFields.value.size),
 
-  dirtyFields: readonly(dirtyFields) as DeepReadonly<Set<keyof I>>,
-  blurredFields: readonly(blurredFields) as DeepReadonly<Set<keyof I>>,
-  touchedFields: readonly(touchedFields) as DeepReadonly<Set<keyof I>>
+  dirtyFields: computed(() => dirtyFields.value),
+  blurredFields: computed(() => blurredFields.value),
+  touchedFields: computed(() => touchedFields.value)
 })
 </script>
 

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -1,5 +1,4 @@
 <script lang="ts">
-import type { DeepReadonly } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/form'
 import type { FormSchema, FormError, FormInputEvents, FormErrorEvent, FormSubmitEvent, FormEvent, Form, FormErrorWithId, InferInput, InferOutput, FormData } from '../types/form'

--- a/src/runtime/components/Theme.vue
+++ b/src/runtime/components/Theme.vue
@@ -1,0 +1,44 @@
+<script lang="ts">
+import { createContext } from 'reka-ui'
+import type * as ui from '#build/ui'
+import type { TVConfig } from '../types/tv'
+import { type ComputedRef, computed, toValue } from 'vue'
+import defu from 'defu'
+import type { RefOrGetter } from '../types/utils'
+
+type UIConfig = TVConfig<typeof ui>
+
+type ThemeRootContext = {
+  theme: ComputedRef<UIConfig>
+}
+
+export interface ThemeProps {
+  theme: UIConfig
+}
+
+export interface ThemeSlots {
+  default(props?: {}): any
+}
+
+const [inject, provide] = createContext<ThemeRootContext>('UTheme', 'RootContext')
+
+export function useComponentUiTheme<TName extends keyof UIConfig>(name: TName, ui: RefOrGetter<UIConfig[TName]>): ComputedRef<UIConfig[TName]> {
+  const { theme } = inject({ theme: computed(() => ({})) })
+  return computed(() => {
+    return defu(toValue(ui) ?? {}, theme.value[name] || {})
+  })
+}
+</script>
+
+<script setup lang="ts">
+const props = defineProps<ThemeProps>()
+
+const rootContext = computed(() => props.theme)
+provide({
+  theme: rootContext
+})
+</script>
+
+<template>
+  <slot />
+</template>

--- a/src/runtime/types/form.ts
+++ b/src/runtime/types/form.ts
@@ -1,24 +1,29 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
-import type { ComputedRef, DeepReadonly, Ref } from 'vue'
+import type { ComputedRef, Ref } from 'vue'
 import type { Schema as JoiSchema } from 'joi'
 import type { ObjectSchema as YupObjectSchema } from 'yup'
 import type { GetObjectField } from './utils'
 import type { Struct as SuperstructSchema } from 'superstruct'
 
 export interface Form<S extends FormSchema> {
-  validate<T extends boolean>(opts?: { name?: keyof FormData<S, false> | (keyof FormData<S, false>)[], silent?: boolean, nested?: boolean, transform?: T }): Promise<FormData<S, T> | false>
-  clear (path?: string): void
+  validate<T extends boolean>(opts?: {
+    name?: keyof FormData<S, false> | (keyof FormData<S, false>)[]
+    silent?: boolean
+    nested?: boolean
+    transform?: T
+  }): Promise<FormData<S, T> | false>
+  clear(path?: string): void
   errors: Ref<FormError[]>
-  setErrors (errs: FormError[], name?: keyof FormData<S, false>): void
-  getErrors (name?: keyof FormData<S, false>): FormError[]
-  submit (): Promise<void>
+  setErrors(errs: FormError[], name?: keyof FormData<S, false>): void
+  getErrors(name?: keyof FormData<S, false>): FormError[]
+  submit(): Promise<void>
   disabled: ComputedRef<boolean>
   dirty: ComputedRef<boolean>
   loading: Ref<boolean>
 
-  dirtyFields: DeepReadonly<Set<keyof FormData<S, false>>>
-  touchedFields: DeepReadonly<Set<keyof FormData<S, false>>>
-  blurredFields: DeepReadonly<Set<keyof FormData<S, false>>>
+  dirtyFields: ComputedRef<Set<keyof FormData<S, false>>>
+  touchedFields: ComputedRef<Set<keyof FormData<S, false>>>
+  blurredFields: ComputedRef<Set<keyof FormData<S, false>>>
 }
 
 export type FormSchema<I extends object = object, O extends object = I> =
@@ -28,21 +33,33 @@ export type FormSchema<I extends object = object, O extends object = I> =
   | StandardSchemaV1<I, O>
 
 // Define a utility type to infer the input type based on the schema type
-export type InferInput<Schema> = Schema extends StandardSchemaV1 ? StandardSchemaV1.InferInput<Schema>
-  : Schema extends YupObjectSchema<infer I> ? I
-    : Schema extends JoiSchema<infer I> ? I
-      : Schema extends SuperstructSchema<infer I, any> ? I
-        : Schema extends StandardSchemaV1 ? StandardSchemaV1.InferInput<Schema>
+export type InferInput<Schema> = Schema extends StandardSchemaV1
+  ? StandardSchemaV1.InferInput<Schema>
+  : Schema extends YupObjectSchema<infer I>
+    ? I
+    : Schema extends JoiSchema<infer I>
+      ? I
+      : Schema extends SuperstructSchema<infer I, any>
+        ? I
+        : Schema extends StandardSchemaV1
+          ? StandardSchemaV1.InferInput<Schema>
           : never
 
 // Define a utility type to infer the output type based on the schema type
-export type InferOutput<Schema> = Schema extends StandardSchemaV1 ? StandardSchemaV1.InferOutput<Schema>
-  : Schema extends YupObjectSchema<infer O> ? O
-    : Schema extends JoiSchema<infer O> ? O
-      : Schema extends SuperstructSchema<infer O, any> ? O
+export type InferOutput<Schema> = Schema extends StandardSchemaV1
+  ? StandardSchemaV1.InferOutput<Schema>
+  : Schema extends YupObjectSchema<infer O>
+    ? O
+    : Schema extends JoiSchema<infer O>
+      ? O
+      : Schema extends SuperstructSchema<infer O, any>
+        ? O
         : never
 
-export type FormData<S extends FormSchema, T extends boolean = true> = T extends true ? InferOutput<S> : InferInput<S>
+export type FormData<
+  S extends FormSchema,
+  T extends boolean = true
+> = T extends true ? InferOutput<S> : InferInput<S>
 
 export type FormInputEvents = 'input' | 'blur' | 'change' | 'focus'
 
@@ -116,7 +133,11 @@ export class FormValidationException extends Error {
   errors: FormErrorWithId[]
   children?: FormValidationException[]
 
-  constructor(formId: string | number, errors: FormErrorWithId[], childErrors?: FormValidationException[]) {
+  constructor(
+    formId: string | number,
+    errors: FormErrorWithId[],
+    childErrors?: FormValidationException[]
+  ) {
     super('Form validation exception')
     this.formId = formId
     this.errors = errors

--- a/src/runtime/types/form.ts
+++ b/src/runtime/types/form.ts
@@ -1,5 +1,5 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
-import type { ComputedRef, DeepReadonly, Ref } from 'vue'
+import type { ComputedRef, Ref } from 'vue'
 import type { Schema as JoiSchema } from 'joi'
 import type { ObjectSchema as YupObjectSchema } from 'yup'
 import type { GetObjectField } from './utils'

--- a/src/runtime/types/form.ts
+++ b/src/runtime/types/form.ts
@@ -1,22 +1,17 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
-import type { ComputedRef, Ref } from 'vue'
+import type { ComputedRef, DeepReadonly, Ref } from 'vue'
 import type { Schema as JoiSchema } from 'joi'
 import type { ObjectSchema as YupObjectSchema } from 'yup'
 import type { GetObjectField } from './utils'
 import type { Struct as SuperstructSchema } from 'superstruct'
 
 export interface Form<S extends FormSchema> {
-  validate<T extends boolean>(opts?: {
-    name?: keyof FormData<S, false> | (keyof FormData<S, false>)[]
-    silent?: boolean
-    nested?: boolean
-    transform?: T
-  }): Promise<FormData<S, T> | false>
-  clear(path?: string): void
+  validate<T extends boolean>(opts?: { name?: keyof FormData<S, false> | (keyof FormData<S, false>)[], silent?: boolean, nested?: boolean, transform?: T }): Promise<FormData<S, T> | false>
+  clear (path?: string): void
   errors: Ref<FormError[]>
-  setErrors(errs: FormError[], name?: keyof FormData<S, false>): void
-  getErrors(name?: keyof FormData<S, false>): FormError[]
-  submit(): Promise<void>
+  setErrors (errs: FormError[], name?: keyof FormData<S, false>): void
+  getErrors (name?: keyof FormData<S, false>): FormError[]
+  submit (): Promise<void>
   disabled: ComputedRef<boolean>
   dirty: ComputedRef<boolean>
   loading: Ref<boolean>
@@ -33,33 +28,21 @@ export type FormSchema<I extends object = object, O extends object = I> =
   | StandardSchemaV1<I, O>
 
 // Define a utility type to infer the input type based on the schema type
-export type InferInput<Schema> = Schema extends StandardSchemaV1
-  ? StandardSchemaV1.InferInput<Schema>
-  : Schema extends YupObjectSchema<infer I>
-    ? I
-    : Schema extends JoiSchema<infer I>
-      ? I
-      : Schema extends SuperstructSchema<infer I, any>
-        ? I
-        : Schema extends StandardSchemaV1
-          ? StandardSchemaV1.InferInput<Schema>
+export type InferInput<Schema> = Schema extends StandardSchemaV1 ? StandardSchemaV1.InferInput<Schema>
+  : Schema extends YupObjectSchema<infer I> ? I
+    : Schema extends JoiSchema<infer I> ? I
+      : Schema extends SuperstructSchema<infer I, any> ? I
+        : Schema extends StandardSchemaV1 ? StandardSchemaV1.InferInput<Schema>
           : never
 
 // Define a utility type to infer the output type based on the schema type
-export type InferOutput<Schema> = Schema extends StandardSchemaV1
-  ? StandardSchemaV1.InferOutput<Schema>
-  : Schema extends YupObjectSchema<infer O>
-    ? O
-    : Schema extends JoiSchema<infer O>
-      ? O
-      : Schema extends SuperstructSchema<infer O, any>
-        ? O
+export type InferOutput<Schema> = Schema extends StandardSchemaV1 ? StandardSchemaV1.InferOutput<Schema>
+  : Schema extends YupObjectSchema<infer O> ? O
+    : Schema extends JoiSchema<infer O> ? O
+      : Schema extends SuperstructSchema<infer O, any> ? O
         : never
 
-export type FormData<
-  S extends FormSchema,
-  T extends boolean = true
-> = T extends true ? InferOutput<S> : InferInput<S>
+export type FormData<S extends FormSchema, T extends boolean = true> = T extends true ? InferOutput<S> : InferInput<S>
 
 export type FormInputEvents = 'input' | 'blur' | 'change' | 'focus'
 
@@ -133,11 +116,7 @@ export class FormValidationException extends Error {
   errors: FormErrorWithId[]
   children?: FormValidationException[]
 
-  constructor(
-    formId: string | number,
-    errors: FormErrorWithId[],
-    childErrors?: FormValidationException[]
-  ) {
+  constructor(formId: string | number, errors: FormErrorWithId[], childErrors?: FormValidationException[]) {
     super('Form validation exception')
     this.formId = formId
     this.errors = errors

--- a/src/runtime/types/utils.ts
+++ b/src/runtime/types/utils.ts
@@ -1,4 +1,4 @@
-import type { VNode } from 'vue'
+import type { Ref, VNode } from 'vue'
 import type { AcceptableValue as _AcceptableValue } from 'reka-ui'
 
 export type DeepPartial<T> = {
@@ -80,5 +80,7 @@ export type EmitsToProps<T> = {
     ? (...args: Args) => void
     : never
 }
+
+export type RefOrGetter<T> = Ref<T> | (() => T)
 
 export * from './tv'

--- a/test/components/Form.spec.ts
+++ b/test/components/Form.spec.ts
@@ -358,6 +358,7 @@ describe('Form', () => {
       expect(form.value.dirtyFields.size).toBe(0)
     })
   })
+  
 
   describe('nested', async () => {
     let wrapper: any

--- a/test/components/Form.spec.ts
+++ b/test/components/Form.spec.ts
@@ -16,6 +16,7 @@ import {
   UFormField
 } from '#components'
 import { flushPromises } from '@vue/test-utils'
+import { watch } from 'vue'
 
 describe('Form', () => {
   it.each([
@@ -272,93 +273,68 @@ describe('Form', () => {
       ])
     })
 
-    test('touchedFields works', async () => {
+    test('touchedFields works on focus', async () => {
       const emailInput = wrapper.find('#emailInput')
+
+      const mockWatchCallback = vi.fn()
+      watch(() => form.value.touchedFields, mockWatchCallback, { deep: true })
 
       emailInput.trigger('focus')
       await flushPromises()
-
-      expect(form.value.touchedFields.has('email')).toBe(true)
-      expect(form.value.touchedFields.has('password')).toBe(false)
+      expect(mockWatchCallback).toHaveBeenCalledTimes(1)
+      expect(mockWatchCallback.mock.calls[0][0].has('email')).toBe(true)
+      expect(mockWatchCallback.mock.calls[0][0].has('password')).toBe(false)
     })
 
-    test('touchedFields works', async () => {
+    test('touchedFields works on change', async () => {
       const emailInput = wrapper.find('#emailInput')
+
+      const mockWatchCallback = vi.fn()
+      watch(() => form.value.touchedFields, mockWatchCallback, { deep: true })
 
       emailInput.trigger('change')
       await flushPromises()
-
-      expect(form.value.dirtyFields.has('email')).toBe(true)
-      expect(form.value.touchedFields.has('email')).toBe(true)
-
-      expect(form.value.dirtyFields.has('password')).toBe(false)
-      expect(form.value.touchedFields.has('password')).toBe(false)
+      expect(mockWatchCallback).toHaveBeenCalledTimes(1)
+      expect(mockWatchCallback.mock.calls[0][0].has('email')).toBe(true)
+      expect(mockWatchCallback.mock.calls[0][0].has('password')).toBe(false)
     })
 
     test('blurredFields works', async () => {
       const emailInput = wrapper.find('#emailInput')
 
+      const mockWatchCallback = vi.fn()
+      watch(() => form.value.blurredFields, mockWatchCallback, { deep: true })
+
       emailInput.trigger('blur')
       await flushPromises()
-
-      expect(form.value.blurredFields.has('email')).toBe(true)
-      expect(form.value.blurredFields.has('password')).toBe(false)
+      expect(mockWatchCallback).toHaveBeenCalledTimes(1)
+      expect(mockWatchCallback.mock.calls[0][0].has('email')).toBe(true)
+      expect(mockWatchCallback.mock.calls[0][0].has('password')).toBe(false)
     })
 
-    test.only('exposed field meta data is reactive', async () => {
-      // Initial state checks
-      expect(form.value.dirty).toBe(false)
-      expect(form.value.dirtyFields.size).toBe(0)
-      expect(form.value.touchedFields.size).toBe(0)
-      expect(form.value.blurredFields.size).toBe(0)
+    test('dirtyFields works', async () => {
+       const emailInput = wrapper.find('#emailInput')
 
+      const mockWatchCallback = vi.fn()
+      watch(() => form.value.dirtyFields, mockWatchCallback, { deep: true })
+
+      emailInput.trigger('change')
+      await flushPromises()
+      expect(mockWatchCallback).toHaveBeenCalledTimes(1)
+      expect(mockWatchCallback.mock.calls[0][0].has('email')).toBe(true)
+      expect(mockWatchCallback.mock.calls[0][0].has('password')).toBe(false)
+    })
+
+    test('dirty works', async () => {
       const emailInput = wrapper.find('#emailInput')
-      const passwordInput = wrapper.find('#passwordInput')
-
-      // Test touchedFields reactivity
-      await emailInput.trigger('focus')
-      await flushPromises()
-      expect(form.value.touchedFields.has('email')).toBe(true)
-      expect(form.value.touchedFields.size).toBe(1)
-
-      // Test dirtyFields and dirty reactivity
-      await emailInput.setValue('test@example.com')
-      await emailInput.trigger('change')
-      await flushPromises()
-
-      expect(form.value.dirtyFields.has('email')).toBe(true)
-      expect(form.value.dirtyFields.size).toBe(1)
-      expect(form.value.dirty).toBe(true)
-
-      // Test blurredFields reactivity
-      await emailInput.trigger('blur')
-      await flushPromises()
-      expect(form.value.blurredFields.has('email')).toBe(true)
-      expect(form.value.blurredFields.size).toBe(1)
-
-      // Test multiple fields
-      await passwordInput.trigger('focus')
-      await passwordInput.setValue('password')
-      await passwordInput.trigger('change')
-      await passwordInput.trigger('blur')
-      await flushPromises()
-
-      expect(form.value.touchedFields.has('password')).toBe(true)
-      expect(form.value.touchedFields.size).toBe(2)
-      expect(form.value.dirtyFields.has('password')).toBe(true)
-      expect(form.value.dirtyFields.size).toBe(2)
-      expect(form.value.blurredFields.has('password')).toBe(true)
-      expect(form.value.blurredFields.size).toBe(2)
-      expect(form.value.dirty).toBe(true)
-
-      // Test that dirty becomes false after successful submit
-      await wrapper.setupState.form.value.submit()
-      await flushPromises()
       expect(form.value.dirty).toBe(false)
-      expect(form.value.dirtyFields.size).toBe(0)
+
+      emailInput.trigger('change')
+      await flushPromises()
+
+      expect(form.value.dirty).toBe(true)
     })
   })
-  
 
   describe('nested', async () => {
     let wrapper: any

--- a/test/components/Form.spec.ts
+++ b/test/components/Form.spec.ts
@@ -1,4 +1,4 @@
-import { reactive, ref, nextTick } from 'vue'
+import { reactive, ref, nextTick, watch } from 'vue'
 import { describe, it, expect, test, beforeEach, vi } from 'vitest'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import * as z from 'zod'
@@ -16,7 +16,6 @@ import {
   UFormField
 } from '#components'
 import { flushPromises } from '@vue/test-utils'
-import { watch } from 'vue'
 
 describe('Form', () => {
   it.each([
@@ -313,8 +312,7 @@ describe('Form', () => {
     })
 
     test('dirtyFields works', async () => {
-       const emailInput = wrapper.find('#emailInput')
-
+      const emailInput = wrapper.find('#emailInput')
       const mockWatchCallback = vi.fn()
       watch(() => form.value.dirtyFields, mockWatchCallback, { deep: true })
 

--- a/test/components/Form.spec.ts
+++ b/test/components/Form.spec.ts
@@ -304,6 +304,59 @@ describe('Form', () => {
       expect(form.value.blurredFields.has('email')).toBe(true)
       expect(form.value.blurredFields.has('password')).toBe(false)
     })
+
+    test.only('exposed field meta data is reactive', async () => {
+      // Initial state checks
+      expect(form.value.dirty).toBe(false)
+      expect(form.value.dirtyFields.size).toBe(0)
+      expect(form.value.touchedFields.size).toBe(0)
+      expect(form.value.blurredFields.size).toBe(0)
+
+      const emailInput = wrapper.find('#emailInput')
+      const passwordInput = wrapper.find('#passwordInput')
+
+      // Test touchedFields reactivity
+      await emailInput.trigger('focus')
+      await flushPromises()
+      expect(form.value.touchedFields.has('email')).toBe(true)
+      expect(form.value.touchedFields.size).toBe(1)
+
+      // Test dirtyFields and dirty reactivity
+      await emailInput.setValue('test@example.com')
+      await emailInput.trigger('change')
+      await flushPromises()
+
+      expect(form.value.dirtyFields.has('email')).toBe(true)
+      expect(form.value.dirtyFields.size).toBe(1)
+      expect(form.value.dirty).toBe(true)
+
+      // Test blurredFields reactivity
+      await emailInput.trigger('blur')
+      await flushPromises()
+      expect(form.value.blurredFields.has('email')).toBe(true)
+      expect(form.value.blurredFields.size).toBe(1)
+
+      // Test multiple fields
+      await passwordInput.trigger('focus')
+      await passwordInput.setValue('password')
+      await passwordInput.trigger('change')
+      await passwordInput.trigger('blur')
+      await flushPromises()
+
+      expect(form.value.touchedFields.has('password')).toBe(true)
+      expect(form.value.touchedFields.size).toBe(2)
+      expect(form.value.dirtyFields.has('password')).toBe(true)
+      expect(form.value.dirtyFields.size).toBe(2)
+      expect(form.value.blurredFields.has('password')).toBe(true)
+      expect(form.value.blurredFields.size).toBe(2)
+      expect(form.value.dirty).toBe(true)
+
+      // Test that dirty becomes false after successful submit
+      await wrapper.setupState.form.value.submit()
+      await flushPromises()
+      expect(form.value.dirty).toBe(false)
+      expect(form.value.dirtyFields.size).toBe(0)
+    })
   })
 
   describe('nested', async () => {

--- a/test/components/Theme.spec.ts
+++ b/test/components/Theme.spec.ts
@@ -1,0 +1,41 @@
+import { describe, it, expect } from 'vitest'
+import Theme, { type ThemeProps, type ThemeSlots } from '../../src/runtime/components/Theme.vue'
+import ComponentRender from '../component-render'
+import { h } from 'vue'
+import Button from '../../src/runtime/components/Button.vue'
+
+type CaseOptions = { props?: ThemeProps, slots?: ThemeSlots }
+
+describe('Theme', () => {
+  it.each([
+    // Props
+    [
+      'with theme',
+        {
+          props: { theme: { button: { slots: { label: 'text-[#ff0]', base: 'px-[1.234rem]' } } } },
+          slots: { default: () => h(Button, { label: 'Button' }) }
+        } satisfies CaseOptions,
+        ['px-[1.234rem]', 'text-[#ff0]']
+    ],
+    [
+      'with ui prop taking priority',
+        {
+          props: { theme: { button: { slots: { label: 'text-[#ff0]', base: 'px-[1.234rem]' } } } },
+          slots: { default: () => h(Button, { label: 'Button', ui: { base: 'px-[2.234rem]' } }) }
+        } satisfies CaseOptions,
+        ['px-[2.234rem]']
+    ],
+    [
+      'with nested theme (most recent theme wins)',
+        {
+          props: { theme: { button: { slots: { label: 'text-[#ff0]', base: 'px-[1.234rem]' } } } },
+          slots: { default: () => h(Theme, { theme: { button: { slots: { label: 'text-[#000]', base: 'px-[2.234rem]' } } } }, () => h(Button, { label: 'Button' })) }
+        } satisfies CaseOptions,
+        ['px-[2.234rem]', 'text-[#000]']
+    ]
+  ])('renders %s correctly', async (nameOrHtml: string, options: CaseOptions, contains: string[] = []) => {
+    const html = await ComponentRender(nameOrHtml, options, Theme)
+    expect(html).toMatchSnapshot()
+    contains.forEach(c => expect(html).toContain(c))
+  })
+})

--- a/test/components/__snapshots__/Theme.spec.ts.snap
+++ b/test/components/__snapshots__/Theme.spec.ts.snap
@@ -1,0 +1,22 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`Theme > renders with nested theme (most recent theme wins) correctly 1`] = `
+"<button type="button" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors py-1.5 text-sm gap-1.5 text-inverted bg-primary hover:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary px-[2.234rem]">
+  <!--v-if--><span class="truncate text-[#000]">Button</span>
+  <!--v-if-->
+</button>"
+`;
+
+exports[`Theme > renders with theme correctly 1`] = `
+"<button type="button" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors py-1.5 text-sm gap-1.5 text-inverted bg-primary hover:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary px-[1.234rem]">
+  <!--v-if--><span class="truncate text-[#ff0]">Button</span>
+  <!--v-if-->
+</button>"
+`;
+
+exports[`Theme > renders with ui prop taking priority correctly 1`] = `
+"<button type="button" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors py-1.5 text-sm gap-1.5 text-inverted bg-primary hover:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary px-[2.234rem]">
+  <!--v-if--><span class="truncate text-[#ff0]">Button</span>
+  <!--v-if-->
+</button>"
+`;


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #4238 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
- Wrapped `dirtyFields`, `touchedFields`, and `blurredFields` in `ref`
- Returned a `computed` instead of a `readonly` of the given fields as it's effectively the same but much simpler types
- Fixed previously broken test cases that falsely tested reactivity of these fields. These changes can be validated by running the new tests with the old version of the component and seeing they change.
- Added test case for `dirtyFields` and `dirty`

**Wasn't sure if a type change counts as a breaking change which is why I have both checked.**

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
