### PR TITLE
chore: use workspace to run `vite` commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -99,7 +99,7 @@
     "dev": "nuxt dev playground --uiDev",
     "dev:build": "nuxt build playground",
     "dev:vue": "pnpm --filter playground-vue dev -- --uiDev",
-    "dev:vue:build": "pnpm --filter playground-vue build playground-vue",
+    "dev:vue:build": "pnpm --filter playground-vue build",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxt prepare playground && nuxt prepare docs && vite build playground-vue",
     "docs": "nuxt dev docs --uiDev",
     "docs:build": "nuxt build docs",

--- a/package.json
+++ b/package.json
@@ -98,8 +98,8 @@
     "prepack": "pnpm build",
     "dev": "nuxt dev playground --uiDev",
     "dev:build": "nuxt build playground",
-    "dev:vue": "vite playground-vue -- --uiDev",
-    "dev:vue:build": "vite build playground-vue",
+    "dev:vue": "pnpm --filter playground-vue dev -- --uiDev",
+    "dev:vue:build": "pnpm --filter playground-vue build playground-vue",
     "dev:prepare": "nuxt-module-build build --stub && nuxt-module-build prepare && nuxt prepare playground && nuxt prepare docs && vite build playground-vue",
     "docs": "nuxt dev docs --uiDev",
     "docs:build": "nuxt build docs",
@@ -165,7 +165,6 @@
     "happy-dom": "^18.0.1",
     "nuxt": "^3.17.5",
     "release-it": "^19.0.3",
-    "vite": "^6.3.5",
     "vitest": "^3.2.4",
     "vitest-environment-nuxt": "^1.0.1",
     "vue-tsc": "^2.2.10"

--- a/package.json
+++ b/package.json
@@ -165,6 +165,7 @@
     "happy-dom": "^18.0.1",
     "nuxt": "^3.17.5",
     "release-it": "^19.0.3",
+    "vite": "^6.3.5",
     "vitest": "^3.2.4",
     "vitest-environment-nuxt": "^1.0.1",
     "vue-tsc": "^2.2.10"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,6 +197,9 @@ importers:
       release-it:
         specifier: ^19.0.3
         version: 19.0.3(@types/node@24.0.3)(magicast@0.3.5)
+      vite:
+        specifier: ^6.3.5
+        version: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -197,9 +197,6 @@ importers:
       release-it:
         specifier: ^19.0.3
         version: 19.0.3(@types/node@24.0.3)(magicast@0.3.5)
-      vite:
-        specifier: ^6.3.5
-        version: 6.3.5(@types/node@24.0.3)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@24.0.3)(happy-dom@18.0.1)(jiti@2.4.2)(lightningcss@1.30.1)(terser@5.43.1)(yaml@2.8.0)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

we are running `vite` as a binary in the workspace, but it's only available within the vue playground. this updates the scripts to run `vite` from within the workspace....

spotted in https://github.com/nuxt/ecosystem-ci/actions/runs/15886239757/job/44798790062

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
