### PR TITLE
fix(useOverlay): support infering close argument from complex emits

### DIFF
--- a/src/runtime/composables/useOverlay.ts
+++ b/src/runtime/composables/useOverlay.ts
@@ -6,7 +6,7 @@ import type { ComponentProps, ComponentEmit } from 'vue-component-type-helpers'
 /**
  * This is a workaround for a design limitation in TypeScript.
  *
- * Conditional types only match the last function overload. Not a union of all possible
+ * Conditional types only match the last function overload, not a union of all possible
  * parameter types. This workaround forces TypeScript to properly extract the 'close'
  * event argument type from component emit with multiple event signatures.
  *

--- a/src/runtime/composables/useOverlay.ts
+++ b/src/runtime/composables/useOverlay.ts
@@ -3,11 +3,17 @@ import { reactive, markRaw, shallowReactive } from 'vue'
 import { createSharedComposable } from '@vueuse/core'
 import type { ComponentProps, ComponentEmit } from 'vue-component-type-helpers'
 
-// Extracts the first argument of the close event from emit function overloads
+/**
+ * This is a workaround for a design limitation in TypeScript.
+ *
+ * Conditional types only match the last function overload. Not a union of all possible
+ * parameter types. This workaround forces TypeScript to properly extract the 'close'
+ * event argument type from component emit with multiple event signatures.
+ *
+ * @see https://github.com/microsoft/TypeScript/issues/32164
+ */
 type CloseEventArgType<T> = T extends {
   (event: 'close', arg_0: infer Arg, ...args: any[]): void
-
-  // so that we can support up to 16 overloads
   (...args: any[]): void
   (...args: any[]): void
   (...args: any[]): void
@@ -25,7 +31,6 @@ type CloseEventArgType<T> = T extends {
   (...args: any[]): void
   (...args: any[]): void
 } ? Arg : never
-
 export type OverlayOptions<OverlayAttrs = Record<string, any>> = {
   defaultOpen?: boolean
   props?: OverlayAttrs

--- a/src/runtime/composables/useOverlay.ts
+++ b/src/runtime/composables/useOverlay.ts
@@ -8,7 +8,7 @@ import type { ComponentProps, ComponentEmit } from 'vue-component-type-helpers'
  *
  * Conditional types only match the last function overload, not a union of all possible
  * parameter types. This workaround forces TypeScript to properly extract the 'close'
- * event argument type from component emit with multiple event signatures.
+ * event argument type from component emits with multiple event signatures.
  *
  * @see https://github.com/microsoft/TypeScript/issues/32164
  */

--- a/src/runtime/composables/useOverlay.ts
+++ b/src/runtime/composables/useOverlay.ts
@@ -3,8 +3,28 @@ import { reactive, markRaw, shallowReactive } from 'vue'
 import { createSharedComposable } from '@vueuse/core'
 import type { ComponentProps, ComponentEmit } from 'vue-component-type-helpers'
 
-// Extracts the first argument of the close event
-type CloseEventArgType<T> = T extends (event: 'close', args_0: infer R) => void ? R : never
+// Extracts the first argument of the close event from emit function overloads
+type CloseEventArgType<T> = T extends {
+  (event: 'close', arg_0: infer Arg, ...args: any[]): void
+
+  // so that we can support up to 16 overloads
+  (...args: any[]): void
+  (...args: any[]): void
+  (...args: any[]): void
+  (...args: any[]): void
+  (...args: any[]): void
+  (...args: any[]): void
+  (...args: any[]): void
+  (...args: any[]): void
+  (...args: any[]): void
+  (...args: any[]): void
+  (...args: any[]): void
+  (...args: any[]): void
+  (...args: any[]): void
+  (...args: any[]): void
+  (...args: any[]): void
+  (...args: any[]): void
+} ? Arg : never
 
 export type OverlayOptions<OverlayAttrs = Record<string, any>> = {
   defaultOpen?: boolean


### PR DESCRIPTION
### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

Resolves #4413 

upstream issue: https://github.com/microsoft/TypeScript/issues/32164

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

The PR added the support of infering close argument from complex emits, so that we can get the result type of lazy components.

```ts

const lazyDialog = overlay.create(LazyDialog)
const dialog = lazyDialog.open()
const result = await dialog.result
//    ^ now it is not `never`
```

Verify the changes in [TypeScript Playground](https://www.typescriptlang.org/play/?#code/PTAEFEA8BcCcEMDG0DOpoAsCmoBmBLWFaUeWAcwFcBbLAOxIHtd1tREAbRlHLAN3rQAUNACeABxwBhLj3ACGAQQoAVCVgA8KgHygAvKBWgsMegBM0AbyGhQACn6CAXKADknbllcAaUhQD6AAwu+HS4WLCgyuS+AHTxZOQoLvB0ogDaALoAlClpQjagIKAojKzwJADuOIipJZTi4oywJA3oZQCMAGygjAKwXPAWhXbxsYnJpGlZuaB8jPhmI2MTeRk5LvOLywkUk6nrs1tLtqO7SWszmwtLAL6gAPxRFKAudI6wBWKSoADK+NRxBwsOBqPgSHoRg4FNAXO5ZF5fIkgi4AEaMRjA1LZfS6A7ZETqUAAJSwKAA8rh-oDgfoIJBJMgNOAAI6UeAcDQyTzyQTRNSSDTUoEgsHQbS+dGYrCpbTaArFDHiFBjQk-KSMGkmUHg-RQxwMOEeHg+PzkFGgKVYug4vR4tI4gBk+phcIwojMCGgWDMrlt9tEBLVOFJFNwGq1kDpUEZ0GZbI5XIRvKUqnUXM1IsgOvFkox1rlBSExUo0HwHBQwYgCc5AA1fABNXSQ05abR2f2GYymOgWUC1x6gDqvUAAJhxJm9vcrrZ0HdxXcn5jQDcHw5c48HcEoOBcuA5PCrMawTKMS+n6FgO+bhiEQA)

The PR supports 16 more overloads, I think that is enough.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly. (N/A)

