### PR TITLE
fix(Toast): Make toast description text selectable by default

### DIFF
--- a/src/theme/toast.ts
+++ b/src/theme/toast.ts
@@ -5,7 +5,7 @@ export default (options: Required<ModuleOptions>) => ({
     root: 'relative group overflow-hidden bg-default shadow-lg rounded-lg ring ring-default p-4 flex gap-2.5 focus:outline-none',
     wrapper: 'w-0 flex-1 flex flex-col',
     title: 'text-sm font-medium text-highlighted',
-    description: 'text-sm text-muted',
+    description: 'text-sm text-muted select-text',
     icon: 'shrink-0 size-5',
     avatar: 'shrink-0',
     avatarSize: '2xl',

--- a/test/components/__snapshots__/Toast-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Toast-vue.spec.ts.snap
@@ -229,7 +229,7 @@ exports[`Toast > renders with description correctly 1`] = `
       <!--v-if-->
       <div class="w-0 flex-1 flex flex-col">
         <div class="text-sm font-medium text-highlighted">Toast</div>
-        <div class="text-sm text-muted mt-1">This is a toast</div>
+        <div class="text-sm text-muted select-text mt-1">This is a toast</div>
         <!--v-if-->
       </div>
       <div class="flex gap-1.5 shrink-0 items-center">
@@ -260,7 +260,7 @@ exports[`Toast > renders with description slot correctly 1`] = `
       <!--v-if-->
       <div class="w-0 flex-1 flex flex-col">
         <div class="text-sm font-medium text-highlighted">Toast</div>
-        <div class="text-sm text-muted mt-1">Description slot</div>
+        <div class="text-sm text-muted select-text mt-1">Description slot</div>
         <!--v-if-->
       </div>
       <div class="flex gap-1.5 shrink-0 items-center">
@@ -349,7 +349,7 @@ exports[`Toast > renders with orientation horizontal correctly 1`] = `
     <li data-reka-collection-item="" role="alert" aria-live="off" aria-atomic="true" tabindex="0" data-orientation="horizontal" class="relative group overflow-hidden bg-default shadow-lg rounded-lg ring ring-default p-4 flex gap-2.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary items-center" style="--height: 0; user-select: none; touch-action: none;" data-state="open" data-swipe-direction="right"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="shrink-0 size-5 text-primary"></svg>
       <div class="w-0 flex-1 flex flex-col">
         <div class="text-sm font-medium text-highlighted">Toast</div>
-        <div class="text-sm text-muted mt-1">This is a toast</div>
+        <div class="text-sm text-muted select-text mt-1">This is a toast</div>
         <!--v-if-->
       </div>
       <div class="flex gap-1.5 shrink-0 items-center"><button type="button" data-reka-toast-announce-exclude="" data-reka-toast-announce-alt="Action" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-inverted bg-primary hover:bg-primary/75 active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary">
@@ -380,7 +380,7 @@ exports[`Toast > renders with orientation vertical correctly 1`] = `
     <li data-reka-collection-item="" role="alert" aria-live="off" aria-atomic="true" tabindex="0" data-orientation="vertical" class="relative group overflow-hidden bg-default shadow-lg rounded-lg ring ring-default p-4 flex gap-2.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary items-start" style="--height: 0; user-select: none; touch-action: none;" data-state="open" data-swipe-direction="right"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="shrink-0 size-5 text-primary"></svg>
       <div class="w-0 flex-1 flex flex-col">
         <div class="text-sm font-medium text-highlighted">Toast</div>
-        <div class="text-sm text-muted mt-1">This is a toast</div>
+        <div class="text-sm text-muted select-text mt-1">This is a toast</div>
         <div class="flex gap-1.5 shrink-0 items-start mt-2.5"><button type="button" data-reka-toast-announce-exclude="" data-reka-toast-announce-alt="Action" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-inverted bg-primary hover:bg-primary/75 active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary">
             <!--v-if--><span class="truncate">Action</span>
             <!--v-if-->

--- a/test/components/__snapshots__/Toast.spec.ts.snap
+++ b/test/components/__snapshots__/Toast.spec.ts.snap
@@ -229,7 +229,7 @@ exports[`Toast > renders with description correctly 1`] = `
       <!--v-if-->
       <div class="w-0 flex-1 flex flex-col">
         <div class="text-sm font-medium text-highlighted">Toast</div>
-        <div class="text-sm text-muted mt-1">This is a toast</div>
+        <div class="text-sm text-muted select-text mt-1">This is a toast</div>
         <!--v-if-->
       </div>
       <div class="flex gap-1.5 shrink-0 items-center">
@@ -260,7 +260,7 @@ exports[`Toast > renders with description slot correctly 1`] = `
       <!--v-if-->
       <div class="w-0 flex-1 flex flex-col">
         <div class="text-sm font-medium text-highlighted">Toast</div>
-        <div class="text-sm text-muted mt-1">Description slot</div>
+        <div class="text-sm text-muted select-text mt-1">Description slot</div>
         <!--v-if-->
       </div>
       <div class="flex gap-1.5 shrink-0 items-center">
@@ -349,7 +349,7 @@ exports[`Toast > renders with orientation horizontal correctly 1`] = `
     <li data-reka-collection-item="" role="alert" aria-live="off" aria-atomic="true" tabindex="0" data-orientation="horizontal" class="relative group overflow-hidden bg-default shadow-lg rounded-lg ring ring-default p-4 flex gap-2.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary items-center" style="--height: 0; user-select: none; touch-action: none;" data-state="open" data-swipe-direction="right"><span class="iconify i-lucide:rocket shrink-0 size-5 text-primary" aria-hidden="true"></span>
       <div class="w-0 flex-1 flex flex-col">
         <div class="text-sm font-medium text-highlighted">Toast</div>
-        <div class="text-sm text-muted mt-1">This is a toast</div>
+        <div class="text-sm text-muted select-text mt-1">This is a toast</div>
         <!--v-if-->
       </div>
       <div class="flex gap-1.5 shrink-0 items-center"><button type="button" data-reka-toast-announce-exclude="" data-reka-toast-announce-alt="Action" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-inverted bg-primary hover:bg-primary/75 active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary">
@@ -380,7 +380,7 @@ exports[`Toast > renders with orientation vertical correctly 1`] = `
     <li data-reka-collection-item="" role="alert" aria-live="off" aria-atomic="true" tabindex="0" data-orientation="vertical" class="relative group overflow-hidden bg-default shadow-lg rounded-lg ring ring-default p-4 flex gap-2.5 focus:outline-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-primary items-start" style="--height: 0; user-select: none; touch-action: none;" data-state="open" data-swipe-direction="right"><span class="iconify i-lucide:rocket shrink-0 size-5 text-primary" aria-hidden="true"></span>
       <div class="w-0 flex-1 flex flex-col">
         <div class="text-sm font-medium text-highlighted">Toast</div>
-        <div class="text-sm text-muted mt-1">This is a toast</div>
+        <div class="text-sm text-muted select-text mt-1">This is a toast</div>
         <div class="flex gap-1.5 shrink-0 items-start mt-2.5"><button type="button" data-reka-toast-announce-exclude="" data-reka-toast-announce-alt="Action" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-inverted bg-primary hover:bg-primary/75 active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-primary">
             <!--v-if--><span class="truncate">Action</span>
             <!--v-if-->


### PR DESCRIPTION
For error notifications, users may want to copy the text to investigate what went wrong. 

For informational notifications, users may want to copy the text to report an issue or use it to better understand the notification content.

I really like Nuxt UI, and I have a Nuxt UI Pro license.
Yes, I can easily patch the style in my config, but doing so would increase maintenance costs due to a custom setup.
Also, I want to be sure that Nuxt UI is truly the best it can be :) 