### PR TITLE
fix(InputMenu+SelectMenu): ignore `undefined` filter field values

### DIFF
--- a/playground/app/pages/components/input-menu.vue
+++ b/playground/app/pages/components/input-menu.vue
@@ -20,6 +20,7 @@ const statuses = [{
   icon: 'i-lucide-circle-help'
 }, {
   label: 'Todo',
+  alias: 'To-do',
   icon: 'i-lucide-circle-plus'
 }, {
   label: 'In Progress',
@@ -103,6 +104,7 @@ const { data: users, status } = await useFetch('https://jsonplaceholder.typicode
         v-for="size in sizes"
         :key="size"
         :items="statuses"
+        :filter-fields="['label', 'alias']"
         placeholder="Search status..."
         icon="i-lucide-search"
         trailing-icon="i-lucide-chevrons-up-down"

--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -267,7 +267,10 @@ const filteredGroups = computed(() => {
       return true
     }
 
-    return fields.some(field => contains(get(item, field), searchTerm.value))
+    return fields.some((field) => {
+      const value = get(item, field)
+      return value !== undefined && contains(String(value), searchTerm.value)
+    })
   })).filter(group => group.filter(item =>
     !isInputItem(item) || (!item.type || !['label', 'separator'].includes(item.type))
   ).length > 0)

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -268,7 +268,10 @@ const filteredGroups = computed(() => {
       return true
     }
 
-    return fields.some(field => contains(get(item, field), searchTerm.value))
+    return fields.some((field) => {
+      const value = get(item, field)
+      return value !== undefined && contains(String(value), searchTerm.value)
+    })
   })).filter(group => group.filter(item =>
     !isSelectItem(item) || (!item.type || !['label', 'separator'].includes(item.type))
   ).length > 0)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

Resolves #4509 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

To solve the issue we have to check if a filter key value is not `undefined` and cast it to `string` before passing it to `contains`. 

This ensures that `contains` is not called with a non-string value (nor a stringified `'undefined'`).
It also maintains the the same behavior as if the item where raw values (`[1, 'something', null]`), where `'null'` is searchable).

I've updated `SelectMenu` as well, since it shares the same logic. (Is there a refactoring opportunity? It seems like `InputMenu` and `SelectMenu` have identical code for handling item filtering).

Let me know if you want to keep the playground changes. Happy to revert them as well.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
