### PR TITLE
fix(Tabs): add missing Badge import

### DIFF
--- a/src/runtime/components/Tabs.vue
+++ b/src/runtime/components/Tabs.vue
@@ -93,6 +93,7 @@ import { get } from '../utils'
 import { tv } from '../utils/tv'
 import UIcon from './Icon.vue'
 import UAvatar from './Avatar.vue'
+import UBadge from "./Badge.vue";
 
 const props = withDefaults(defineProps<TabsProps<T>>(), {
   content: true,

--- a/src/runtime/components/Tabs.vue
+++ b/src/runtime/components/Tabs.vue
@@ -93,7 +93,7 @@ import { get } from '../utils'
 import { tv } from '../utils/tv'
 import UIcon from './Icon.vue'
 import UAvatar from './Avatar.vue'
-import UBadge from "./Badge.vue";
+import UBadge from './Badge.vue';
 
 const props = withDefaults(defineProps<TabsProps<T>>(), {
   content: true,

--- a/src/runtime/components/Tabs.vue
+++ b/src/runtime/components/Tabs.vue
@@ -93,7 +93,7 @@ import { get } from '../utils'
 import { tv } from '../utils/tv'
 import UIcon from './Icon.vue'
 import UAvatar from './Avatar.vue'
-import UBadge from './Badge.vue';
+import UBadge from './Badge.vue'
 
 const props = withDefaults(defineProps<TabsProps<T>>(), {
   content: true,


### PR DESCRIPTION

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

After updating to @nuxt/ui 3.3.0 we got a `Failed to resolve component: UBadge` error for the Tabs component (Badge support was added to Tabs in #4553. We're using a custom prefix for the components. This PR explicitly imports UBadge to fix this.

