### PR TITLE
docs(toast): improve examples for global App settings

### DIFF
--- a/docs/content/3.components/toast.md
+++ b/docs/content/3.components/toast.md
@@ -188,9 +188,25 @@ name: 'toast-orientation-example'
 
 ## Examples
 
+::note{to="/components/app"}
+Nuxt UI provides an **App** component that wraps your app to provide global configurations.
+::
+
 ### Change global position
 
 Change the `toaster.position` prop on the [App](/components/app#props) component to change the position of the toasts.
+
+```vue [app.vue]
+<script setup lang="ts">
+const toaster = { position: 'bottom-right' }
+</script>
+
+<template>
+  <UApp :toaster="toaster">
+    <NuxtPage />
+  </UApp>
+</template>
+```
 
 ::component-example
 ---
@@ -209,6 +225,18 @@ In this example, we use the `AppConfig` to configure the `position` prop of the 
 ### Change global duration
 
 Change the `toaster.duration` prop on the [App](/components/app#props) component to change the duration of the toasts.
+
+```vue [app.vue]
+<script setup lang="ts">
+const toaster = { duration: 5000 }
+</script>
+
+<template>
+  <UApp :toaster="toaster">
+    <NuxtPage />
+  </UApp>
+</template>
+```
 
 ::component-example
 ---
@@ -231,6 +259,18 @@ Set the `toaster.expand` prop to `false` on the [App](/components/app#props) com
 ::tip
 You can hover over the toasts to expand them. This will also pause the timer of the toasts.
 ::
+
+```vue [app.vue]
+<script setup lang="ts">
+const toaster = { expand: true }
+</script>
+
+<template>
+  <UApp :toaster="toaster">
+    <NuxtPage />
+  </UApp>
+</template>
+```
 
 ::component-example
 ---


### PR DESCRIPTION
### ❓ Type of Change

- [x] 📖 Documentation (updates to the documentation or README)

### 📚 Description

I encountered some difficulties while trying to configure the `toaster` global position.
Specifically, in [this section](https://ui.nuxt.com/components/toast#change-global-position), the code example doesn't provide any valuable information, and the note below redirects to the `app.config.ts`, which I found misleading.

I found [this issue](https://github.com/nuxt/ui/issues/4104), which guided me to the correct solution: setting the configuration directly in the `UApp` component.

To improve the documentation, I have made the following changes inspired by [the i18n documentation page](https://ui.nuxt.com/getting-started/i18n):

    - Added a note reminding users that "Nuxt UI provides an App component."
    - Adding some examples of `app.vue`.

Considerations:

    - Maybe one example is sufficient?
    - Should we remove the note below each example, as it might be misleading?