### PR TITLE
docs(llms): make links directly point to the raw content

### DIFF
--- a/docs/server/plugins/llms.ts
+++ b/docs/server/plugins/llms.ts
@@ -8,11 +8,9 @@ export default defineNitroPlugin((nitroApp) => {
 
   nitroApp.hooks.hook('llms:generate', (_, { sections }) => {
     // Transform links except for "Documentation Sets"
-    sections.map((section) => {
-      if (section.title === 'Documentation Sets') return section
-      return {
-        ...section,
-        links: section.links.map(link => ({
+    sections.forEach((section) => {
+      if (section.title !== 'Documentation Sets') {
+        section.links = section.links.map(link => ({
           ...link,
           href: transformRawLink(link.href)
         }))

--- a/docs/server/plugins/llms.ts
+++ b/docs/server/plugins/llms.ts
@@ -7,6 +7,7 @@ export default defineNitroPlugin((nitroApp) => {
   })
 
   nitroApp.hooks.hook('llms:generate', (_, { sections }) => {
+    // Transform links except for "Documentation Sets"
     sections.map((section) => {
       if (section.title === 'Documentation Sets') return section
       return {
@@ -17,6 +18,13 @@ export default defineNitroPlugin((nitroApp) => {
         }))
       }
     })
+
+    // Move "Documentation Sets" to the end
+    const docSetIdx = sections.findIndex(s => s.title === 'Documentation Sets')
+    if (docSetIdx !== -1) {
+      const [docSet] = sections.splice(docSetIdx, 1)
+      sections.push(docSet)
+    }
   })
 })
 

--- a/docs/server/plugins/llms.ts
+++ b/docs/server/plugins/llms.ts
@@ -5,4 +5,21 @@ export default defineNitroPlugin((nitroApp) => {
   nitroApp.hooks.hook('content:llms:generate:document', async (_: H3Event, doc: PageCollectionItemBase) => {
     transformMDC(doc as any)
   })
+
+  nitroApp.hooks.hook('llms:generate', (_, { sections }) => {
+    sections.map((section) => {
+      if (section.title === 'Documentation Sets') return section
+      return {
+        ...section,
+        links: section.links.map(link => ({
+          ...link,
+          href: transformRawLink(link.href)
+        }))
+      }
+    })
+  })
 })
+
+function transformRawLink(href: string) {
+  return `${href.replace(/^https:\/\/ui.nuxt.com/, 'https://ui.nuxt.com/raw')}.md`
+}


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Followup for the changes made in https://github.com/nuxt/ui/pull/4369, but applied to `llms.txt`

This makes sure that LLMs will lose less context while using the `llms.txt` to navigate the docs.

I've also noticed that various models do tend to open the first link available regardless of its content, which is the `llms-full.txt`. This causes an useless fillup of the model's context ending up hallucinating even in basic tasks. I took the liberty to move it always as the last section.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
