### PR TITLE
docs(input-number): add normal currency step size

### DIFF
--- a/docs/app/components/content/examples/input-number/InputNumberCurrencyExample.vue
+++ b/docs/app/components/content/examples/input-number/InputNumberCurrencyExample.vue
@@ -11,5 +11,6 @@ const value = ref(1500)
       currencyDisplay: 'code',
       currencySign: 'accounting'
     }"
+    :step="0.01"
   />
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

kinda Resolves https://github.com/nuxt/ui/issues/1722

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It's kind of confusing that by default, this example doesn't allow you to input cents at all, so I changed that.
The UX of the +/- buttons is a bit worse with this step size, but at least it works now.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
