### PR TITLE
fix(FileUpload): handle wildcard in dropzone `dataTypes`

### DIFF
--- a/src/runtime/composables/useFileUpload.ts
+++ b/src/runtime/composables/useFileUpload.ts
@@ -22,7 +22,14 @@ function parseAcceptToDataTypes(accept: string): string[] | undefined {
 
   const types = accept
     .split(',')
-    .map(type => type.trim())
+    .map((type) => {
+      const trimmedType = type.trim()
+
+      if (trimmedType.includes('/') && trimmedType.endsWith('/*')) {
+        return trimmedType.split('/')[0] || trimmedType
+      }
+      return trimmedType
+    })
     .filter((type) => {
       return !type.startsWith('.')
     })

--- a/src/runtime/composables/useFileUpload.ts
+++ b/src/runtime/composables/useFileUpload.ts
@@ -67,9 +67,31 @@ export function useFileUpload(options: UseFileUploadOptions) {
   }
 
   onMounted(() => {
-    const { isOverDropZone } = dropzone
-      ? useDropZone(dropzoneRef, { dataTypes: dataTypes.value, onDrop })
-      : { isOverDropZone: ref(false) }
+    const { isOverDropZone } = useDropZone(dropzoneRef, {
+      dataTypes: (types) => {
+        if (dataTypes.value === undefined || accept === '*') {
+          return true
+        }
+
+        return types.some((type) => {
+          return dataTypes.value?.some((acceptedType) => {
+            if (acceptedType.endsWith('/*')) {
+              const base = acceptedType.slice(0, acceptedType.indexOf('/'))
+              return type.startsWith(base + '/')
+            } else {
+              return type === acceptedType
+            }
+          })
+        })
+      }, onDrop: (files, event) => {
+        if (!dropzone) {
+          event.preventDefault()
+          return
+        }
+
+        onDrop(files)
+      }
+    })
 
     watch(isOverDropZone, (value) => {
       isDragging.value = value

--- a/src/runtime/composables/useFileUpload.ts
+++ b/src/runtime/composables/useFileUpload.ts
@@ -67,31 +67,9 @@ export function useFileUpload(options: UseFileUploadOptions) {
   }
 
   onMounted(() => {
-    const { isOverDropZone } = useDropZone(dropzoneRef, {
-      dataTypes: (types) => {
-        if (dataTypes.value === undefined || accept === '*') {
-          return true
-        }
-
-        return types.some((type) => {
-          return dataTypes.value?.some((acceptedType) => {
-            if (acceptedType.endsWith('/*')) {
-              const base = acceptedType.slice(0, acceptedType.indexOf('/'))
-              return type.startsWith(base + '/')
-            } else {
-              return type === acceptedType
-            }
-          })
-        })
-      }, onDrop: (files, event) => {
-        if (!dropzone) {
-          event.preventDefault()
-          return
-        }
-
-        onDrop(files)
-      }
-    })
+    const { isOverDropZone } = dropzone
+      ? useDropZone(dropzoneRef, { dataTypes: dataTypes.value, onDrop })
+      : { isOverDropZone: ref(false) }
 
     watch(isOverDropZone, (value) => {
       isDragging.value = value


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
Resolves: https://github.com/nuxt/ui/issues/4638
<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
The FileUpload component now works with wildcard accept attributes such as `image/*`.
### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
