### PR TITLE
fix(Link): ensure target `_blank` is flagged as external for Inertia

### DIFF
--- a/src/runtime/inertia/components/Link.vue
+++ b/src/runtime/inertia/components/Link.vue
@@ -100,6 +100,10 @@ const ui = computed(() => tv({
 const href = computed(() => props.to ?? props.href)
 
 const isExternal = computed(() => {
+  if (props.target === '_blank') {
+    return true
+  }
+
   if (props.external) {
     return true
   }


### PR DESCRIPTION
Hello 👋,

This PR fixes a bug where the following button:

```vue
<template>
  <UButton
    href="/admin"
    target="_blank"
  />
</template>
```

triggers an Inertia request, opening the link in an Inertia modal instead of a new tab.

This happens because a blank target is not treated as an external link, and Inertia ignores the `target` prop. As a result, Inertia fetches the URL, returns HTML, and displays it in the modal.
