### PR TITLE
feat(i18n): add en_US locale file for US English support

### DIFF
--- a/src/runtime/locale/en_us.ts
+++ b/src/runtime/locale/en_us.ts
@@ -1,0 +1,61 @@
+import type { Messages } from '../types'
+import { defineLocale } from '../composables/defineLocale'
+
+export default defineLocale<Messages>({
+  name: 'English (US)',
+  code: 'en-US',
+  messages: {
+    inputMenu: {
+      noMatch: 'No matching data',
+      noData: 'No data',
+      create: 'Create "{label}"'
+    },
+    calendar: {
+      prevYear: 'Previous year',
+      nextYear: 'Next year',
+      prevMonth: 'Previous month',
+      nextMonth: 'Next month'
+    },
+    inputNumber: {
+      increment: 'Increment',
+      decrement: 'Decrement'
+    },
+    commandPalette: {
+      placeholder: 'Type a command or search...',
+      noMatch: 'No matching data',
+      noData: 'No data',
+      close: 'Close',
+      back: 'Back'
+    },
+    selectMenu: {
+      noMatch: 'No matching data',
+      noData: 'No data',
+      create: 'Create "{label}"',
+      search: 'Search...'
+    },
+    toast: {
+      close: 'Close'
+    },
+    carousel: {
+      prev: 'Prev',
+      next: 'Next',
+      dots: 'Choose slide to display',
+      goto: 'Go to slide {slide}'
+    },
+    modal: {
+      close: 'Close'
+    },
+    slideover: {
+      close: 'Close'
+    },
+    alert: {
+      close: 'Close'
+    },
+    table: {
+      noData: 'No data'
+    },
+    fileUpload: {
+      removeFile: 'Remove {filename}'
+    }
+  }
+})


### PR DESCRIPTION
Adding specific United States version of English to support toggling between US and British terminology and spellings.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added a new `en_US.ts` locale file to allow explicit differentiation between US English and GB English.  
This supports projects that require alignment with US spelling, terminology, and usage conventions.  
No breaking changes introduced. Existing `en_GB` remains the default where appropriate.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
