### PR TITLE
feat(Button): add ui to slots leading and trailing

### DIFF
--- a/src/runtime/components/Button.vue
+++ b/src/runtime/components/Button.vue
@@ -35,9 +35,9 @@ export interface ButtonProps extends UseComponentIconsProps, Omit<LinkProps, 'ra
 }
 
 export interface ButtonSlots {
-  leading(props?: {}): any
+  leading(props?: { ui: Button['slots'] }): any
   default(props?: {}): any
-  trailing(props?: {}): any
+  trailing(props?: { ui: Button['slots'] }): any
 }
 </script>
 
@@ -132,7 +132,7 @@ const ui = computed(() => tv({
       })"
       @click="onClickWrapper"
     >
-      <slot name="leading">
+      <slot name="leading" :ui="ui">
         <UIcon v-if="isLeading && leadingIconName" :name="leadingIconName" :class="ui.leadingIcon({ class: props.ui?.leadingIcon, active })" />
         <UAvatar v-else-if="!!avatar" :size="((props.ui?.leadingAvatarSize || ui.leadingAvatarSize()) as AvatarProps['size'])" v-bind="avatar" :class="ui.leadingAvatar({ class: props.ui?.leadingAvatar, active })" />
       </slot>
@@ -143,7 +143,7 @@ const ui = computed(() => tv({
         </span>
       </slot>
 
-      <slot name="trailing">
+      <slot name="trailing" :ui="ui">
         <UIcon v-if="isTrailing && trailingIconName" :name="trailingIconName" :class="ui.trailingIcon({ class: props.ui?.trailingIcon, active })" />
       </slot>
     </ULinkBase>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Hello 👋,

When I want to add animations to the leading or the trailing icons, I have to use slots but it would be more convenient to easily access the `ui` object to apply them.

This will makes 

<img width="1069" height="155" alt="Screenshot 2025-09-07 at 15 58 09" src="https://github.com/user-attachments/assets/b2d52c10-532b-4a49-b264-b4754e756817" />

easier. Currently, the `links` are used so I can't use real `links`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
