### PR TITLE
docs(Form): mention of `nuxt-auto-form` for `AutoForm` functionality

### DIFF
--- a/docs/content/3.components/form.md
+++ b/docs/content/3.components/form.md
@@ -13,6 +13,11 @@ Use the Form component to validate form data using validation libraries such as 
 
 It works with the [FormField](/components/form-field) component to display error messages around form elements automatically.
 
+::tip
+Nuxt UI currently doesn’t provide a component similar to [`AutoForm`](https://www.shadcn-vue.com/docs/components/auto-form) from shadcn-vue.
+For this functionality, you can use the community-maintained module [@norbiros/nuxt-auto-form](https://github.com/Norbiros/nuxt-auto-form)
+::
+
 ### Schema Validation
 
 It requires two props:


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

There is an increasing demand for generating custom Nuxt UI forms from
schemas. While projects like `shadcn-vue` and `formkit` offer similar
features, they do not integrate directly with Nuxt UI.

To address this issue, I created a `nuxt-auto-form`, module providing
`AutoForm` functionality until it is maybe natively supported in Nuxt UI
(hopefully in v4).

This commit adds a short note to the Form docs, that briefly mentions
the module, which can be a valuable resource for the community.

Related issues: https://github.com/nuxt/ui/issues/3876, https://github.com/nuxt/ui/issues/4653

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
