### PR TITLE
fix(components): dot notation type support for `labelKey` and `valueKey`

### DIFF
--- a/src/runtime/components/Accordion.vue
+++ b/src/runtime/components/Accordion.vue
@@ -4,7 +4,7 @@ import type { AccordionRootProps, AccordionRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/accordion'
 import type { IconProps } from '../types'
-import type { DynamicSlots } from '../types/utils'
+import type { DynamicSlots, GetItemKeys } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Accordion = ComponentConfig<typeof theme, AppConfig, 'accordion'>
@@ -46,7 +46,7 @@ export interface AccordionProps<T extends AccordionItem = AccordionItem> extends
    * The key used to get the label from the item.
    * @defaultValue 'label'
    */
-  labelKey?: string
+  labelKey?: GetItemKeys<T>
   class?: any
   ui?: Accordion['slots']
 }
@@ -85,7 +85,7 @@ const slots = defineSlots<AccordionSlots<T>>()
 
 const appConfig = useAppConfig() as Accordion['AppConfig']
 
-const rootProps = useForwardPropsEmits(reactivePick(props, 'as', 'collapsible', 'defaultValue', 'disabled', 'modelValue', 'type', 'unmountOnHide'), emits)
+const rootProps = useForwardPropsEmits(reactivePick(props, 'as', 'collapsible', 'defaultValue', 'disabled', 'modelValue', 'unmountOnHide'), emits)
 
 const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.accordion || {}) })({
   disabled: props.disabled
@@ -93,7 +93,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.accordion ||
 </script>
 
 <template>
-  <AccordionRoot v-bind="rootProps" :class="ui.root({ class: [props.ui?.root, props.class] })">
+  <AccordionRoot v-bind="rootProps" :type="type" :class="ui.root({ class: [props.ui?.root, props.class] })">
     <AccordionItem
       v-for="(item, index) in props.items"
       v-slot="{ open }"

--- a/src/runtime/components/Breadcrumb.vue
+++ b/src/runtime/components/Breadcrumb.vue
@@ -3,7 +3,7 @@
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/breadcrumb'
 import type { AvatarProps, IconProps, LinkProps } from '../types'
-import type { DynamicSlots } from '../types/utils'
+import type { DynamicSlots, GetItemKeys } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Breadcrumb = ComponentConfig<typeof theme, AppConfig, 'breadcrumb'>
@@ -38,7 +38,7 @@ export interface BreadcrumbProps<T extends BreadcrumbItem = BreadcrumbItem> {
    * The key used to get the label from the item.
    * @defaultValue 'label'
    */
-  labelKey?: string
+  labelKey?: GetItemKeys<T>
   class?: any
   ui?: Breadcrumb['slots']
 }

--- a/src/runtime/components/CheckboxGroup.vue
+++ b/src/runtime/components/CheckboxGroup.vue
@@ -20,7 +20,7 @@ export type CheckboxGroupItem = {
   [key: string]: any
 } | CheckboxGroupValue
 
-export interface CheckboxGroupProps<T extends CheckboxGroupItem[] = CheckboxGroupItem[], VK extends GetItemKeys<T> = 'value', M extends boolean = false> extends Pick<CheckboxGroupRootProps, 'disabled' | 'loop' | 'name' | 'required'>, Pick<CheckboxProps, 'color' | 'indicator' | 'icon'> {
+export interface CheckboxGroupProps<T extends CheckboxGroupItem[] = CheckboxGroupItem[], VK extends GetItemKeys<T> = 'value'> extends Pick<CheckboxGroupRootProps, 'disabled' | 'loop' | 'name' | 'required'>, Pick<CheckboxProps, 'color' | 'indicator' | 'icon'> {
   /**
    * The element or component this component should render as.
    * @defaultValue 'div'
@@ -44,9 +44,9 @@ export interface CheckboxGroupProps<T extends CheckboxGroupItem[] = CheckboxGrou
   descriptionKey?: GetItemKeys<T>
   items?: T
   /** The controlled value of the Tree. Can be bind as `v-model`. */
-  modelValue?: GetModelValue<T, VK, M>
+  modelValue?: GetModelValue<T, VK, true>
   /** The value of the Tree when initially rendered. Use when you do not need to control the state of the Tree. */
-  defaultValue?: GetModelValue<T, VK, M>
+  defaultValue?: GetModelValue<T, VK, true>
   /**
    * @defaultValue 'md'
    */
@@ -70,14 +70,14 @@ export type CheckboxGroupEmits = CheckboxGroupRootEmits & {
 
 type SlotProps<T extends CheckboxGroupItem> = (props: { item: T & { id: string } }) => any
 
-export interface CheckboxGroupSlots<T extends CheckboxGroupItem = CheckboxGroupItem> {
+export interface CheckboxGroupSlots<T extends CheckboxGroupItem[] = CheckboxGroupItem[]> {
   legend(props?: {}): any
-  label: SlotProps<T>
-  description: SlotProps<T>
+  label: SlotProps<T[number]>
+  description: SlotProps<T[number]>
 }
 </script>
 
-<script setup lang="ts" generic="T extends CheckboxGroupItem[], VK extends GetItemKeys<T> = 'value', M extends boolean = false">
+<script setup lang="ts" generic="T extends CheckboxGroupItem[], VK extends GetItemKeys<T> = 'value'">
 import { computed, useId } from 'vue'
 import { CheckboxGroupRoot, useForwardProps, useForwardPropsEmits } from 'reka-ui'
 import { reactivePick } from '@vueuse/core'
@@ -87,7 +87,7 @@ import { get, omit } from '../utils'
 import { tv } from '../utils/tv'
 import UCheckbox from './Checkbox.vue'
 
-const props = withDefaults(defineProps<CheckboxGroupProps<T, VK, M>>(), {
+const props = withDefaults(defineProps<CheckboxGroupProps<T, VK>>(), {
   labelKey: 'label',
   descriptionKey: 'description',
   valueKey: 'value' as never,

--- a/src/runtime/components/CheckboxGroup.vue
+++ b/src/runtime/components/CheckboxGroup.vue
@@ -43,9 +43,9 @@ export interface CheckboxGroupProps<T extends CheckboxGroupItem[] = CheckboxGrou
    */
   descriptionKey?: GetItemKeys<T>
   items?: T
-  /** The controlled value of the Tree. Can be bind as `v-model`. */
+  /** The controlled value of the CheckboxGroup. Can be bind as `v-model`. */
   modelValue?: GetModelValue<T, VK, true>
-  /** The value of the Tree when initially rendered. Use when you do not need to control the state of the Tree. */
+  /** The value of the CheckboxGroup when initially rendered. Use when you do not need to control the state of the CheckboxGroup. */
   defaultValue?: GetModelValue<T, VK, true>
   /**
    * @defaultValue 'md'

--- a/src/runtime/components/CheckboxGroup.vue
+++ b/src/runtime/components/CheckboxGroup.vue
@@ -3,7 +3,7 @@ import type { CheckboxGroupRootProps, CheckboxGroupRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/checkbox-group'
 import type { CheckboxProps } from '../types'
-import type { AcceptableValue } from '../types/utils'
+import type { AcceptableValue, GetItemKeys, GetModelValue } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type CheckboxGroup = ComponentConfig<typeof theme, AppConfig, 'checkboxGroup'>
@@ -20,7 +20,7 @@ export type CheckboxGroupItem = {
   [key: string]: any
 } | CheckboxGroupValue
 
-export interface CheckboxGroupProps<T extends CheckboxGroupItem = CheckboxGroupItem> extends Pick<CheckboxGroupRootProps, 'defaultValue' | 'disabled' | 'loop' | 'modelValue' | 'name' | 'required'>, Pick<CheckboxProps, 'color' | 'indicator' | 'icon'> {
+export interface CheckboxGroupProps<T extends CheckboxGroupItem[] = CheckboxGroupItem[], VK extends GetItemKeys<T> = 'value', M extends boolean = false> extends Pick<CheckboxGroupRootProps, 'disabled' | 'loop' | 'name' | 'required'>, Pick<CheckboxProps, 'color' | 'indicator' | 'icon'> {
   /**
    * The element or component this component should render as.
    * @defaultValue 'div'
@@ -31,18 +31,22 @@ export interface CheckboxGroupProps<T extends CheckboxGroupItem = CheckboxGroupI
    * When `items` is an array of objects, select the field to use as the value.
    * @defaultValue 'value'
    */
-  valueKey?: string
+  valueKey?: VK
   /**
    * When `items` is an array of objects, select the field to use as the label.
    * @defaultValue 'label'
    */
-  labelKey?: string
+  labelKey?: GetItemKeys<T>
   /**
    * When `items` is an array of objects, select the field to use as the description.
    * @defaultValue 'description'
    */
-  descriptionKey?: string
-  items?: T[]
+  descriptionKey?: GetItemKeys<T>
+  items?: T
+  /** The controlled value of the Tree. Can be bind as `v-model`. */
+  modelValue?: GetModelValue<T, VK, M>
+  /** The value of the Tree when initially rendered. Use when you do not need to control the state of the Tree. */
+  defaultValue?: GetModelValue<T, VK, M>
   /**
    * @defaultValue 'md'
    */
@@ -73,7 +77,7 @@ export interface CheckboxGroupSlots<T extends CheckboxGroupItem = CheckboxGroupI
 }
 </script>
 
-<script setup lang="ts" generic="T extends CheckboxGroupItem">
+<script setup lang="ts" generic="T extends CheckboxGroupItem[], VK extends GetItemKeys<T> = 'value', M extends boolean = false">
 import { computed, useId } from 'vue'
 import { CheckboxGroupRoot, useForwardProps, useForwardPropsEmits } from 'reka-ui'
 import { reactivePick } from '@vueuse/core'
@@ -83,10 +87,10 @@ import { get, omit } from '../utils'
 import { tv } from '../utils/tv'
 import UCheckbox from './Checkbox.vue'
 
-const props = withDefaults(defineProps<CheckboxGroupProps<T>>(), {
-  valueKey: 'value',
+const props = withDefaults(defineProps<CheckboxGroupProps<T, VK, M>>(), {
   labelKey: 'label',
   descriptionKey: 'description',
+  valueKey: 'value' as never,
   orientation: 'vertical'
 })
 const emits = defineEmits<CheckboxGroupEmits>()

--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -7,6 +7,7 @@ import type { UseFuseOptions } from '@vueuse/integrations/useFuse'
 import theme from '#build/ui/command-palette'
 import type { UseComponentIconsProps } from '../composables/useComponentIcons'
 import type { AvatarProps, ButtonProps, ChipProps, KbdProps, InputProps, LinkProps, IconProps } from '../types'
+import type { GetItemKeys } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type CommandPalette = ComponentConfig<typeof theme, AppConfig, 'commandPalette'>
@@ -134,7 +135,7 @@ export interface CommandPaletteProps<G extends CommandPaletteGroup<T> = CommandP
    * The key used to get the label from the item.
    * @defaultValue 'label'
    */
-  labelKey?: string
+  labelKey?: GetItemKeys<T>
   class?: any
   ui?: CommandPalette['slots']
 }
@@ -193,8 +194,8 @@ const searchTerm = defineModel<string>('searchTerm', { default: '' })
 const { t } = useLocale()
 const appConfig = useAppConfig() as CommandPalette['AppConfig']
 
-const rootProps = useForwardPropsEmits(reactivePick(props, 'as', 'disabled', 'multiple', 'modelValue', 'defaultValue', 'highlightOnHover', 'selectionBehavior'), emits)
-const inputProps = useForwardProps(reactivePick(props, 'loading', 'loadingIcon'))
+const rootProps = useForwardPropsEmits(reactivePick(props, 'as', 'disabled', 'multiple', 'modelValue', 'defaultValue', 'highlightOnHover'), emits)
+const inputProps = useForwardProps(reactivePick(props, 'loading'))
 
 // eslint-disable-next-line vue/no-dupe-keys
 const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.commandPalette || {}) })())
@@ -207,7 +208,7 @@ const fuse = computed(() => defu({}, props.fuse, {
   },
   resultLimit: 12,
   matchAllWhenSearchEmpty: true
-}))
+}) as UseFuseOptions<T>)
 
 const history = ref<(CommandPaletteGroup & { placeholder?: string })[]>([])
 
@@ -329,13 +330,14 @@ function onSelect(e: Event, item: T) {
 
 <!-- eslint-disable vue/no-v-html -->
 <template>
-  <ListboxRoot v-bind="rootProps" ref="listboxRootRef" :class="ui.root({ class: [props.ui?.root, props.class] })">
+  <ListboxRoot v-bind="rootProps" ref="listboxRootRef" :selection-behavior="selectionBehavior" :class="ui.root({ class: [props.ui?.root, props.class] })">
     <ListboxFilter v-model="searchTerm" as-child>
       <UInput
         :placeholder="placeholder"
         variant="none"
         :autofocus="autofocus"
         v-bind="inputProps"
+        :loading-icon="loadingIcon"
         :icon="icon || appConfig.ui.icons.search"
         :class="ui.input({ class: props.ui?.input })"
         @keydown.backspace="onBackspace"

--- a/src/runtime/components/ContextMenu.vue
+++ b/src/runtime/components/ContextMenu.vue
@@ -4,7 +4,7 @@ import type { ContextMenuRootProps, ContextMenuRootEmits, ContextMenuContentProp
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/context-menu'
 import type { AvatarProps, IconProps, KbdProps, LinkProps } from '../types'
-import type { ArrayOrNested, DynamicSlots, MergeTypes, NestedItem, EmitsToProps } from '../types/utils'
+import type { ArrayOrNested, DynamicSlots, GetItemKeys, MergeTypes, NestedItem, EmitsToProps } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type ContextMenu = ComponentConfig<typeof theme, AppConfig, 'contextMenu'>
@@ -74,7 +74,7 @@ export interface ContextMenuProps<T extends ArrayOrNested<ContextMenuItem> = Arr
    * The key used to get the label from the item.
    * @defaultValue 'label'
    */
-  labelKey?: keyof NestedItem<T>
+  labelKey?: GetItemKeys<T>
   disabled?: boolean
   class?: any
   ui?: ContextMenu['slots']

--- a/src/runtime/components/ContextMenuContent.vue
+++ b/src/runtime/components/ContextMenuContent.vue
@@ -3,7 +3,7 @@ import type { ContextMenuContentProps as RekaContextMenuContentProps, ContextMen
 import type { AppConfig } from '@nuxt/schema'
 import type theme from '#build/ui/context-menu'
 import type { AvatarProps, ContextMenuItem, ContextMenuSlots, IconProps, KbdProps } from '../types'
-import type { ArrayOrNested, NestedItem } from '../types/utils'
+import type { ArrayOrNested, GetItemKeys } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type ContextMenu = ComponentConfig<typeof theme, AppConfig, 'contextMenu'>
@@ -12,7 +12,7 @@ interface ContextMenuContentProps<T extends ArrayOrNested<ContextMenuItem>> exte
   items?: T
   portal?: boolean | string | HTMLElement
   sub?: boolean
-  labelKey: keyof NestedItem<T>
+  labelKey: GetItemKeys<T>
   /**
    * @IconifyIcon
    */

--- a/src/runtime/components/DropdownMenu.vue
+++ b/src/runtime/components/DropdownMenu.vue
@@ -4,7 +4,7 @@ import type { DropdownMenuRootProps, DropdownMenuRootEmits, DropdownMenuContentP
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dropdown-menu'
 import type { AvatarProps, IconProps, KbdProps, LinkProps } from '../types'
-import type { ArrayOrNested, DynamicSlots, MergeTypes, NestedItem, EmitsToProps } from '../types/utils'
+import type { ArrayOrNested, DynamicSlots, GetItemKeys, MergeTypes, NestedItem, EmitsToProps } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type DropdownMenu = ComponentConfig<typeof theme, AppConfig, 'dropdownMenu'>
@@ -82,7 +82,7 @@ export interface DropdownMenuProps<T extends ArrayOrNested<DropdownMenuItem> = A
    * The key used to get the label from the item.
    * @defaultValue 'label'
    */
-  labelKey?: keyof NestedItem<T>
+  labelKey?: GetItemKeys<T>
   disabled?: boolean
   class?: any
   ui?: DropdownMenu['slots']

--- a/src/runtime/components/DropdownMenuContent.vue
+++ b/src/runtime/components/DropdownMenuContent.vue
@@ -4,7 +4,7 @@ import type { DropdownMenuContentProps as RekaDropdownMenuContentProps, Dropdown
 import type { AppConfig } from '@nuxt/schema'
 import type theme from '#build/ui/dropdown-menu'
 import type { KbdProps, AvatarProps, DropdownMenuItem, DropdownMenuSlots, IconProps } from '../types'
-import type { ArrayOrNested, NestedItem, DynamicSlots, MergeTypes } from '../types/utils'
+import type { ArrayOrNested, GetItemKeys, NestedItem, DynamicSlots, MergeTypes } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type DropdownMenu = ComponentConfig<typeof theme, AppConfig, 'dropdownMenu'>
@@ -13,7 +13,7 @@ interface DropdownMenuContentProps<T extends ArrayOrNested<DropdownMenuItem>> ex
   items?: T
   portal?: boolean | string | HTMLElement
   sub?: boolean
-  labelKey: keyof NestedItem<T>
+  labelKey: GetItemKeys<T>
   /**
    * @IconifyIcon
    */

--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -196,7 +196,7 @@ const props = withDefaults(defineProps<InputMenuProps<T, VK, M>>(), {
   type: 'text',
   autofocusDelay: 0,
   portal: true,
-  labelKey: 'label' as never,
+  labelKey: 'label',
   resetSearchTermOnBlur: true,
   resetSearchTermOnSelect: true
 })

--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -99,7 +99,7 @@ export interface InputMenuProps<T extends ArrayOrNested<InputMenuItem> = ArrayOr
    * When `items` is an array of objects, select the field to use as the label.
    * @defaultValue 'label'
    */
-  labelKey?: keyof NestedItem<T>
+  labelKey?: GetItemKeys<T>
   items?: T
   /** The value of the InputMenu when initially rendered. Use when you do not need to control the state of the InputMenu. */
   defaultValue?: GetModelValue<T, VK, M>
@@ -234,8 +234,11 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.inputMenu ||
   fieldGroup: orientation.value
 }))
 
+// eslint-disable-next-line vue/no-dupe-keys
+const items = computed(() => groups.value.flatMap(group => group) as T[])
+
 function displayValue(value: GetItemValue<T, VK>): string {
-  return getDisplayValue(items.value, value, {
+  return getDisplayValue<T[], GetItemValue<T, VK>>(items.value, value, {
     labelKey: props.labelKey,
     valueKey: props.valueKey
   }) ?? ''
@@ -248,8 +251,6 @@ const groups = computed<InputMenuItem[][]>(() =>
       : [props.items]
     : []
 )
-// eslint-disable-next-line vue/no-dupe-keys
-const items = computed(() => groups.value.flatMap(group => group) as T[])
 
 const filteredGroups = computed(() => {
   if (props.ignoreFilter || !searchTerm.value) {

--- a/src/runtime/components/InputNumber.vue
+++ b/src/runtime/components/InputNumber.vue
@@ -54,8 +54,6 @@ export interface InputNumberProps extends Pick<NumberFieldRootProps, 'modelValue
   decrementDisabled?: boolean
   autofocus?: boolean
   autofocusDelay?: number
-  modelValue?: number
-  defaultValue?: number
   modelModifiers?: Pick<ModelModifiers, 'optional'>
   /**
    * The locale to use for formatting and parsing numbers.

--- a/src/runtime/components/NavigationMenu.vue
+++ b/src/runtime/components/NavigationMenu.vue
@@ -4,7 +4,7 @@ import type { NavigationMenuRootProps, NavigationMenuRootEmits, NavigationMenuCo
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/navigation-menu'
 import type { AvatarProps, BadgeProps, IconProps, LinkProps, PopoverProps, TooltipProps } from '../types'
-import type { ArrayOrNested, DynamicSlots, MergeTypes, NestedItem, EmitsToProps } from '../types/utils'
+import type { ArrayOrNested, DynamicSlots, GetItemKeys, MergeTypes, NestedItem, EmitsToProps } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type NavigationMenu = ComponentConfig<typeof theme, AppConfig, 'navigationMenu'>
@@ -137,7 +137,7 @@ export interface NavigationMenuProps<T extends ArrayOrNested<NavigationMenuItem>
    * The key used to get the label from the item.
    * @defaultValue 'label'
    */
-  labelKey?: keyof NestedItem<T>
+  labelKey?: GetItemKeys<T>
   class?: any
   ui?: NavigationMenu['slots']
 }

--- a/src/runtime/components/RadioGroup.vue
+++ b/src/runtime/components/RadioGroup.vue
@@ -29,7 +29,7 @@ export interface RadioGroupProps<T extends RadioGroupItem[] = RadioGroupItem[], 
    * When `items` is an array of objects, select the field to use as the value.
    * @defaultValue 'value'
    */
-  valueKey?: string
+  valueKey?: VK
   /**
    * When `items` is an array of objects, select the field to use as the label.
    * @defaultValue 'label'

--- a/src/runtime/components/RadioGroup.vue
+++ b/src/runtime/components/RadioGroup.vue
@@ -2,7 +2,7 @@
 import type { RadioGroupRootProps, RadioGroupRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/radio-group'
-import type { AcceptableValue } from '../types/utils'
+import type { AcceptableValue, GetItemKeys, GetModelValue } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type RadioGroup = ComponentConfig<typeof theme, AppConfig, 'radioGroup'>
@@ -18,7 +18,7 @@ export type RadioGroupItem = {
   [key: string]: any
 } | RadioGroupValue
 
-export interface RadioGroupProps<T extends RadioGroupItem = RadioGroupItem> extends Pick<RadioGroupRootProps, 'defaultValue' | 'disabled' | 'loop' | 'modelValue' | 'name' | 'required'> {
+export interface RadioGroupProps<T extends RadioGroupItem[] = RadioGroupItem[], VK extends GetItemKeys<T> = 'value', M extends boolean = false> extends Pick<RadioGroupRootProps, 'disabled' | 'loop' | 'name' | 'required'> {
   /**
    * The element or component this component should render as.
    * @defaultValue 'div'
@@ -34,13 +34,17 @@ export interface RadioGroupProps<T extends RadioGroupItem = RadioGroupItem> exte
    * When `items` is an array of objects, select the field to use as the label.
    * @defaultValue 'label'
    */
-  labelKey?: string
+  labelKey?: GetItemKeys<T>
   /**
    * When `items` is an array of objects, select the field to use as the description.
    * @defaultValue 'description'
    */
-  descriptionKey?: string
-  items?: T[]
+  descriptionKey?: GetItemKeys<T>
+  items?: T
+  /** The controlled value of the Tree. Can be bind as `v-model`. */
+  modelValue?: GetModelValue<T, VK, M>
+  /** The value of the Tree when initially rendered. Use when you do not need to control the state of the Tree. */
+  defaultValue?: GetModelValue<T, VK, M>
   /**
    * @defaultValue 'md'
    */
@@ -75,14 +79,14 @@ type NormalizeItem<T extends RadioGroupItem> = Exclude<T & { id: string }, Radio
 
 type SlotProps<T extends RadioGroupItem> = (props: { item: NormalizeItem<T>, modelValue?: RadioGroupValue }) => any
 
-export interface RadioGroupSlots<T extends RadioGroupItem = RadioGroupItem> {
+export interface RadioGroupSlots<T extends RadioGroupItem[] = RadioGroupItem[]> {
   legend(props?: {}): any
-  label: SlotProps<T>
-  description: SlotProps<T>
+  label: SlotProps<T[number]>
+  description: SlotProps<T[number]>
 }
 </script>
 
-<script setup lang="ts" generic="T extends RadioGroupItem">
+<script setup lang="ts" generic="T extends RadioGroupItem[], VK extends GetItemKeys<T> = 'value', M extends boolean = false">
 import { computed, useId } from 'vue'
 import { RadioGroupRoot, RadioGroupItem, RadioGroupIndicator, Label, useForwardPropsEmits } from 'reka-ui'
 import { reactivePick } from '@vueuse/core'
@@ -102,7 +106,7 @@ const slots = defineSlots<RadioGroupSlots<T>>()
 
 const appConfig = useAppConfig() as RadioGroup['AppConfig']
 
-const rootProps = useForwardPropsEmits(reactivePick(props, 'as', 'modelValue', 'defaultValue', 'orientation', 'loop', 'required'), emits)
+const rootProps = useForwardPropsEmits(reactivePick(props, 'as', 'loop', 'required'), emits)
 
 const { emitFormChange, emitFormInput, color, name, size, id: _id, disabled, ariaAttrs } = useFormField<RadioGroupProps<T>>(props, { bind: false })
 const id = _id.value ?? useId()
@@ -117,13 +121,13 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.radioGroup |
   indicator: props.indicator
 }))
 
-function normalizeItem(item: T): NormalizeItem<T> {
+function normalizeItem(item: any) {
   if (item === null) {
     return {
       id: `${id}:null`,
       value: undefined,
       label: undefined
-    } as NormalizeItem<T>
+    }
   }
 
   if (typeof item === 'string' || typeof item === 'number' || typeof item === 'bigint') {
@@ -131,7 +135,7 @@ function normalizeItem(item: T): NormalizeItem<T> {
       id: `${id}:${item}`,
       value: String(item),
       label: String(item)
-    } as NormalizeItem<T>
+    }
   }
 
   const value = get(item, props.valueKey as string)
@@ -139,7 +143,7 @@ function normalizeItem(item: T): NormalizeItem<T> {
   const description = get(item, props.descriptionKey as string)
 
   return {
-    ...(item as NormalizeItem<T>),
+    ...(item),
     value,
     label,
     description,
@@ -167,8 +171,10 @@ function onUpdate(value: any) {
 <template>
   <RadioGroupRoot
     :id="id"
-    v-slot="{ modelValue }"
     v-bind="rootProps"
+    :model-value="modelValue"
+    :default-value="defaultValue"
+    :orientation="orientation"
     :name="name"
     :disabled="disabled"
     :class="ui.root({ class: [props.ui?.root, props.class] })"

--- a/src/runtime/components/RadioGroup.vue
+++ b/src/runtime/components/RadioGroup.vue
@@ -18,7 +18,7 @@ export type RadioGroupItem = {
   [key: string]: any
 } | RadioGroupValue
 
-export interface RadioGroupProps<T extends RadioGroupItem[] = RadioGroupItem[], VK extends GetItemKeys<T> = 'value', M extends boolean = false> extends Pick<RadioGroupRootProps, 'disabled' | 'loop' | 'name' | 'required'> {
+export interface RadioGroupProps<T extends RadioGroupItem[] = RadioGroupItem[], VK extends GetItemKeys<T> = 'value'> extends Pick<RadioGroupRootProps, 'disabled' | 'loop' | 'name' | 'required'> {
   /**
    * The element or component this component should render as.
    * @defaultValue 'div'
@@ -42,9 +42,9 @@ export interface RadioGroupProps<T extends RadioGroupItem[] = RadioGroupItem[], 
   descriptionKey?: GetItemKeys<T>
   items?: T
   /** The controlled value of the RadioGroup. Can be bind as `v-model`. */
-  modelValue?: GetModelValue<T, VK, M>
+  modelValue?: GetModelValue<T, VK, false>
   /** The value of the RadioGroup when initially rendered. Use when you do not need to control the state of the RadioGroup. */
-  defaultValue?: GetModelValue<T, VK, M>
+  defaultValue?: GetModelValue<T, VK, false>
   /**
    * @defaultValue 'md'
    */
@@ -86,7 +86,7 @@ export interface RadioGroupSlots<T extends RadioGroupItem[] = RadioGroupItem[]> 
 }
 </script>
 
-<script setup lang="ts" generic="T extends RadioGroupItem[], VK extends GetItemKeys<T> = 'value', M extends boolean = false">
+<script setup lang="ts" generic="T extends RadioGroupItem[], VK extends GetItemKeys<T> = 'value'">
 import { computed, useId } from 'vue'
 import { RadioGroupRoot, RadioGroupItem, RadioGroupIndicator, Label, useForwardPropsEmits } from 'reka-ui'
 import { reactivePick } from '@vueuse/core'
@@ -95,8 +95,8 @@ import { useFormField } from '../composables/useFormField'
 import { get } from '../utils'
 import { tv } from '../utils/tv'
 
-const props = withDefaults(defineProps<RadioGroupProps<T>>(), {
-  valueKey: 'value',
+const props = withDefaults(defineProps<RadioGroupProps<T, VK>>(), {
+  valueKey: 'value' as never,
   labelKey: 'label',
   descriptionKey: 'description',
   orientation: 'vertical'

--- a/src/runtime/components/RadioGroup.vue
+++ b/src/runtime/components/RadioGroup.vue
@@ -41,9 +41,9 @@ export interface RadioGroupProps<T extends RadioGroupItem[] = RadioGroupItem[], 
    */
   descriptionKey?: GetItemKeys<T>
   items?: T
-  /** The controlled value of the Tree. Can be bind as `v-model`. */
+  /** The controlled value of the RadioGroup. Can be bind as `v-model`. */
   modelValue?: GetModelValue<T, VK, M>
-  /** The value of the Tree when initially rendered. Use when you do not need to control the state of the Tree. */
+  /** The value of the RadioGroup when initially rendered. Use when you do not need to control the state of the RadioGroup. */
   defaultValue?: GetModelValue<T, VK, M>
   /**
    * @defaultValue 'md'

--- a/src/runtime/components/Select.vue
+++ b/src/runtime/components/Select.vue
@@ -83,7 +83,7 @@ export interface SelectProps<T extends ArrayOrNested<SelectItem> = ArrayOrNested
    * When `items` is an array of objects, select the field to use as the label.
    * @defaultValue 'label'
    */
-  labelKey?: keyof NestedItem<T>
+  labelKey?: GetItemKeys<T>
   items?: T
   /** The value of the Select when initially rendered. Use when you do not need to control the state of the Select. */
   defaultValue?: GetModelValue<T, VK, M>
@@ -200,7 +200,7 @@ const items = computed(() => groups.value.flatMap(group => group) as T[])
 function displayValue(value: GetItemValue<T, VK> | GetItemValue<T, VK>[]): string | undefined {
   if (props.multiple && Array.isArray(value)) {
     const displayedValues = value
-      .map(item => getDisplayValue(items.value, item, {
+      .map(item => getDisplayValue<T[], GetItemValue<T, VK>>(items.value, item, {
         labelKey: props.labelKey,
         valueKey: props.valueKey
       }))
@@ -209,7 +209,7 @@ function displayValue(value: GetItemValue<T, VK> | GetItemValue<T, VK>[]): strin
     return displayedValues.length > 0 ? displayedValues.join(', ') : undefined
   }
 
-  return getDisplayValue(items.value, value, {
+  return getDisplayValue<T[], GetItemValue<T, VK>>(items.value, value as GetItemValue<T, VK>, {
     labelKey: props.labelKey,
     valueKey: props.valueKey
   })

--- a/src/runtime/components/Select.vue
+++ b/src/runtime/components/Select.vue
@@ -156,7 +156,7 @@ defineOptions({ inheritAttrs: false })
 
 const props = withDefaults(defineProps<SelectProps<T, VK, M>>(), {
   valueKey: 'value' as never,
-  labelKey: 'label' as never,
+  labelKey: 'label',
   portal: true,
   autofocusDelay: 0
 })

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -190,7 +190,7 @@ defineOptions({ inheritAttrs: false })
 const props = withDefaults(defineProps<SelectMenuProps<T, VK, M>>(), {
   portal: true,
   searchInput: true,
-  labelKey: 'label' as never,
+  labelKey: 'label',
   resetSearchTermOnBlur: true,
   resetSearchTermOnSelect: true,
   autofocusDelay: 0

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -91,7 +91,7 @@ export interface SelectMenuProps<T extends ArrayOrNested<SelectMenuItem> = Array
    * When `items` is an array of objects, select the field to use as the label.
    * @defaultValue 'label'
    */
-  labelKey?: keyof NestedItem<T>
+  labelKey?: GetItemKeys<T>
   items?: T
   /** The value of the SelectMenu when initially rendered. Use when you do not need to control the state of the SelectMenu. */
   defaultValue?: GetModelValue<T, VK, M>
@@ -232,7 +232,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.selectMenu |
 function displayValue(value: GetItemValue<T, VK> | GetItemValue<T, VK>[]): string | undefined {
   if (props.multiple && Array.isArray(value)) {
     const displayedValues = value
-      .map(item => getDisplayValue(items.value, item, {
+      .map(item => getDisplayValue<T[], GetItemValue<T, VK>>(items.value, item, {
         labelKey: props.labelKey,
         valueKey: props.valueKey
       }))
@@ -241,7 +241,7 @@ function displayValue(value: GetItemValue<T, VK> | GetItemValue<T, VK>[]): strin
     return displayedValues.length > 0 ? displayedValues.join(', ') : undefined
   }
 
-  return getDisplayValue(items.value, value, {
+  return getDisplayValue<T[], GetItemValue<T, VK>>(items.value, value as GetItemValue<T, VK>, {
     labelKey: props.labelKey,
     valueKey: props.valueKey
   })

--- a/src/runtime/components/Tabs.vue
+++ b/src/runtime/components/Tabs.vue
@@ -4,7 +4,7 @@ import type { TabsRootProps, TabsRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/tabs'
 import type { AvatarProps, BadgeProps, IconProps } from '../types'
-import type { DynamicSlots } from '../types/utils'
+import type { DynamicSlots, GetItemKeys } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Tabs = ComponentConfig<typeof theme, AppConfig, 'tabs'>
@@ -64,7 +64,7 @@ export interface TabsProps<T extends TabsItem = TabsItem> extends Pick<TabsRootP
    * The key used to get the label from the item.
    * @defaultValue 'label'
    */
-  labelKey?: string
+  labelKey?: GetItemKeys<T>
   class?: any
   ui?: Tabs['slots']
 }
@@ -108,7 +108,7 @@ const slots = defineSlots<TabsSlots<T>>()
 
 const appConfig = useAppConfig() as Tabs['AppConfig']
 
-const rootProps = useForwardPropsEmits(reactivePick(props, 'as', 'modelValue', 'defaultValue', 'orientation', 'activationMode', 'unmountOnHide'), emits)
+const rootProps = useForwardPropsEmits(reactivePick(props, 'as', 'unmountOnHide'), emits)
 
 const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.tabs || {}) })({
   color: props.color,
@@ -125,7 +125,14 @@ defineExpose({
 </script>
 
 <template>
-  <TabsRoot v-bind="rootProps" :class="ui.root({ class: [props.ui?.root, props.class] })">
+  <TabsRoot
+    v-bind="rootProps"
+    :model-value="modelValue"
+    :default-value="defaultValue"
+    :orientation="orientation"
+    :activation-mode="activationMode"
+    :class="ui.root({ class: [props.ui?.root, props.class] })"
+  >
     <TabsList :class="ui.list({ class: props.ui?.list })">
       <TabsIndicator :class="ui.indicator({ class: props.ui?.indicator })" />
 

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -113,7 +113,7 @@ import UIcon from './Icon.vue'
 defineOptions({ inheritAttrs: false })
 
 const props = withDefaults(defineProps<TreeProps<T, VK, M>>(), {
-  labelKey: 'label' as never,
+  labelKey: 'label',
   valueKey: 'value' as never
 })
 const emits = defineEmits<TreeEmits<T, VK, M>>()

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -54,7 +54,7 @@ export interface TreeProps<T extends TreeItem[] = TreeItem[], VK extends GetItem
    * The key used to get the label from the item.
    * @defaultValue 'label'
    */
-  labelKey?: keyof NestedItem<T>
+  labelKey?: GetItemKeys<T>
   /**
    * The icon displayed on the right side of a parent node.
    * @defaultValue appConfig.ui.icons.chevronDown

--- a/src/runtime/types/utils.ts
+++ b/src/runtime/types/utils.ts
@@ -42,14 +42,32 @@ export type MergeTypes<T extends object> = {
   [k in NonCommonKeys<T>]?: PickTypeOf<T, k>;
 }
 
-export type GetItemKeys<I> = keyof Extract<NestedItem<I>, object>
+type DotPathKeys<T> = T extends object
+  ? {
+      [K in keyof T & string]:
+      T[K] extends Record<string, any>
+        ? K | `${K}.${DotPathKeys<T[K]>}`
+        : K
+    }[keyof T & string]
+  : never
+
+type DotPathValue<T, P extends DotPathKeys<T> | (string & {})>
+  = P extends `${infer K}.${infer Rest}`
+    ? K extends keyof T
+      ? DotPathValue<T[K], Rest>
+      : never
+    : P extends keyof T
+      ? T[P]
+      : never
+
+export type GetItemKeys<I> = keyof Extract<NestedItem<I>, object> | DotPathKeys<Extract<NestedItem<I>, object>>
 
 export type GetItemValue<I, VK extends GetItemKeys<I> | undefined, T extends NestedItem<I> = NestedItem<I>>
   = T extends object
     ? VK extends undefined
       ? T
-      : VK extends keyof T
-        ? T[VK]
+      : VK extends DotPathKeys<T>
+        ? DotPathValue<T, VK>
         : never
     : T
 

--- a/src/runtime/types/utils.ts
+++ b/src/runtime/types/utils.ts
@@ -42,14 +42,16 @@ export type MergeTypes<T extends object> = {
   [k in NonCommonKeys<T>]?: PickTypeOf<T, k>;
 }
 
-type DotPathKeys<T> = T extends object
-  ? {
-      [K in keyof T & string]:
-      T[K] extends Record<string, any>
-        ? K | `${K}.${DotPathKeys<T[K]>}`
-        : K
-    }[keyof T & string]
-  : never
+type DotPathKeys<T> = T extends Array<any>
+  ? never
+  : T extends object
+    ? {
+        [K in keyof T & string]:
+        T[K] extends Record<string, any>
+          ? K | `${K}.${DotPathKeys<T[K]>}`
+          : K
+      }[keyof T & string]
+    : never
 
 type DotPathValue<T, P extends DotPathKeys<T> | (string & {})>
   = P extends `${infer K}.${infer Rest}`

--- a/src/runtime/utils/fuse.ts
+++ b/src/runtime/utils/fuse.ts
@@ -1,4 +1,5 @@
 import type { FuseResult, FuseResultMatch } from 'fuse.js'
+import type { GetItemKeys } from '../types/utils'
 
 function truncateHTMLFromStart(html: string, maxLength: number) {
   let truncated = ''
@@ -32,7 +33,7 @@ function truncateHTMLFromStart(html: string, maxLength: number) {
   return truncated
 }
 
-export function highlight<T>(item: T & { matches?: FuseResult<T>['matches'] }, searchTerm: string, forceKey?: string, omitKeys?: string[]) {
+export function highlight<T>(item: T & { matches?: FuseResult<T>['matches'] }, searchTerm: string, forceKey?: GetItemKeys<T>, omitKeys?: GetItemKeys<T>[]) {
   function generateHighlightedText(value: FuseResultMatch['value'], indices: FuseResultMatch['indices'] = []) {
     value = value || ''
     let content = ''
@@ -75,7 +76,7 @@ export function highlight<T>(item: T & { matches?: FuseResult<T>['matches'] }, s
     if (forceKey && match.key !== forceKey) {
       continue
     }
-    if (omitKeys?.includes(match.key!)) {
+    if (omitKeys?.includes(match.key as GetItemKeys<T>)) {
       continue
     }
 

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -1,5 +1,5 @@
 import { isEqual } from 'ohash/utils'
-import type { GetItemKeys, NestedItem } from '../types/utils'
+import type { GetItemKeys } from '../types/utils'
 
 export function pick<Data extends object, Keys extends keyof Data>(data: Data, keys: Keys[]): Pick<Data, Keys> {
   const result = {} as Pick<Data, Keys>
@@ -120,12 +120,12 @@ export function isEmpty(value: unknown): boolean {
   return false
 }
 
-export function getDisplayValue<T, V>(
-  items: T[],
+export function getDisplayValue<T extends Array<any>, V>(
+  items: T,
   value: V | undefined | null,
   options: {
     valueKey?: GetItemKeys<T>
-    labelKey?: keyof NestedItem<T>
+    labelKey?: GetItemKeys<T>
   } = {}
 ): string | undefined {
   const { valueKey, labelKey } = options


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #3505

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Was actually able to create a small recusive parser which does not need to be re-executed on each input.

<img width="282" height="182" alt="image" src="https://github.com/user-attachments/assets/72570f66-5cf1-4c5a-a707-2763f79ebb62" />

Also fixed support for `modelValue` and `defaultValue` for CheckboxGroup and RadioGroup

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
