### PR TITLE
docs(typography): add missing github links

### DIFF
--- a/docs/content/docs/4.typography/accordion.md
+++ b/docs/content/docs/4.typography/accordion.md
@@ -3,6 +3,10 @@ title: Accordion
 description: 'Create expandable content sections for better information organization.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/Accordion.vue
 ---
 
 ## Usage

--- a/docs/content/docs/4.typography/badge.md
+++ b/docs/content/docs/4.typography/badge.md
@@ -3,6 +3,10 @@ title: Badge
 description: 'Display version numbers, status labels, and tags within your content.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/Badge.vue
 ---
 
 ## Usage

--- a/docs/content/docs/4.typography/callout.md
+++ b/docs/content/docs/4.typography/callout.md
@@ -3,6 +3,10 @@ title: Callout
 description: 'Highlight important information with eye-catching colored boxes and icons.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/Callout.vue
 ---
 
 ## Usage

--- a/docs/content/docs/4.typography/card-group.md
+++ b/docs/content/docs/4.typography/card-group.md
@@ -3,6 +3,10 @@ title: CardGroup
 description: 'Organize multiple cards in responsive grid layouts for better content presentation.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/CardGroup.vue
 ---
 
 ## Usage

--- a/docs/content/docs/4.typography/card.md
+++ b/docs/content/docs/4.typography/card.md
@@ -3,6 +3,10 @@ title: Card
 description: 'Create highlighted content blocks with optional links and navigation.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/Card.vue
 ---
 
 ## Usage

--- a/docs/content/docs/4.typography/code-collapse.md
+++ b/docs/content/docs/4.typography/code-collapse.md
@@ -3,6 +3,10 @@ title: CodeCollapse
 description: 'Make long code blocks collapsible to save space and improve readability.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/CodeCollapse.vue
 ---
 
 ## Usage

--- a/docs/content/docs/4.typography/code-group.md
+++ b/docs/content/docs/4.typography/code-group.md
@@ -3,6 +3,10 @@ title: CodeGroup
 description: 'Group multiple code examples in tabbed interfaces for easy comparison.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/CodeGroup.vue
 ---
 
 ## Usage

--- a/docs/content/docs/4.typography/code-preview.md
+++ b/docs/content/docs/4.typography/code-preview.md
@@ -3,6 +3,10 @@ title: CodePreview
 description: 'Display code examples with a preview and their source for clearer documentation.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/CodePreview.vue
 ---
 
 ## Usage

--- a/docs/content/docs/4.typography/code-tree.md
+++ b/docs/content/docs/4.typography/code-tree.md
@@ -3,6 +3,10 @@ title: CodeTree
 description: 'Visualize file and folder structures with syntax-highlighted code.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/CodeTree.vue
 ---
 
 ## Usage

--- a/docs/content/docs/4.typography/collapsible.md
+++ b/docs/content/docs/4.typography/collapsible.md
@@ -3,6 +3,10 @@ title: Collapsible
 description: 'Toggle content visibility with smooth expand and collapse animations.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/Collapsible.vue
 ---
 
 ## Usage

--- a/docs/content/docs/4.typography/field-group.md
+++ b/docs/content/docs/4.typography/field-group.md
@@ -3,6 +3,10 @@ title: FieldGroup
 description: 'Group related fields together for comprehensive API documentation.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/FieldGroup.vue
 ---
 
 ## Usage

--- a/docs/content/docs/4.typography/field.md
+++ b/docs/content/docs/4.typography/field.md
@@ -3,6 +3,10 @@ title: Field
 description: 'Document API parameters, props, and configuration options clearly.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/Field.vue
 ---
 
 ## Usage

--- a/docs/content/docs/4.typography/icon.md
+++ b/docs/content/docs/4.typography/icon.md
@@ -3,6 +3,10 @@ title: Icon
 description: 'Display icons from popular icon libraries to enhance your content.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/Icon.vue
 ---
 
 ## Usage

--- a/docs/content/docs/4.typography/kbd.md
+++ b/docs/content/docs/4.typography/kbd.md
@@ -3,6 +3,10 @@ title: Kbd
 description: 'Display keyboard shortcuts and key combinations with proper styling.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/Kbd.vue
 ---
 
 ## Usage

--- a/docs/content/docs/4.typography/steps.md
+++ b/docs/content/docs/4.typography/steps.md
@@ -3,6 +3,10 @@ title: Steps
 description: 'Transform headings into numbered step-by-step guides and tutorials.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/Steps.vue
 ---
 
 ## Usage

--- a/docs/content/docs/4.typography/tabs.md
+++ b/docs/content/docs/4.typography/tabs.md
@@ -3,6 +3,10 @@ title: Tabs
 description: 'Organize related content in interactive tabbed interfaces.'
 framework: nuxt
 category: components
+links:
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/prose/Tabs.vue
 ---
 
 ## Usage


### PR DESCRIPTION
I believe this was missing