### PR TITLE
docs(ai): add Cherry Studio MCP `streamableHttp` configuration

### DIFF
--- a/docs/content/docs/1.getting-started/7.ai/1.mcp.md
+++ b/docs/content/docs/1.getting-started/7.ai/1.mcp.md
@@ -163,6 +163,26 @@ Or manually create/update `.cursor/mcp.json` in your project root:
 }
 ```
 
+### Cherry Studio
+
+#### Setup Instructions
+
+1. Open the settings page by clicking on the cog in the top right corner
+2. Navigate to "MCP"
+3. Click "Add" in the top bar and choose "Import from JSON"
+4. Instead of the usual `"type": "http"`, replace it with `"type: streamableHttp"` (case-sensitive) and click "OK":
+
+```json
+{
+  "mcpServers": {
+    "nuxt-ui": {
+      "type": "streamableHttp",
+      "url": "https://ui4.nuxt.com/mcp"
+    }
+  }
+}
+```
+
 ## Usage Examples
 
 Once configured, you can ask your AI assistant questions like:


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

This pull request adds the necessary documentation (located in `/docs/content/docs/1.getting-started/7.ai/1.mcp.md`) [to the current one](https://ui4.nuxt.com/docs/getting-started/ai/mcp) for configuring the Nuxt UI MCP server with Cherry Studio.

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

It appears Cherry Studio rejects the standard `http` transport type for MCP servers. It requires a proprietary `streamableHttp` (case-sensitive) type instead. This clarification saves users from having to figure out why the documented standard configuration fails without any useful error message.

The new section provides the correct JSON snippet and the walkthrough to get it working.

As requested, here is the visual evidence of this little quirk. The first attempt uses `http`, which fails, while the second attempt changes it to `streamableHttp` and is accepted. It also works right away in AI prompts.

https://github.com/user-attachments/assets/06d9b89c-a44e-445b-b723-318542f8d2fe

This should prevent further user confusion.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
