### PR TITLE
docs: fix broken i18n link in Nuxt UI docs

### DIFF
--- a/docs/content/docs/2.components/locale-select.md
+++ b/docs/content/docs/2.components/locale-select.md
@@ -17,12 +17,12 @@ The LocaleSelect component extends the [SelectMenu](/docs/components/select-menu
 
 ::framework-only
 #nuxt
-::note{to="/docs/getting-started/i18n/nuxt"}
+::note{to="/docs/getting-started/integrations/i18n/nuxt"}
 This component is meant to be used with the **i18n** system. Learn more about it in the guide.
 ::
 
 #vue
-::note{to="/docs/getting-started/i18n/vue"}
+::note{to="/docs/getting-started/integrations/i18n/vue"}
 This component is meant to be used with the **i18n** system. Learn more about it in the guide.
 ::
 


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The link to the Nuxt i18n guide was outdated and pointed to
`/docs/getting-started/i18n/nuxt`. It has been updated to the correct
path `/docs/getting-started/integrations/i18n/nuxt`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
