### PR TITLE
docs(nuxt.config): remove `noreferrer` for external links

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -178,6 +178,14 @@ export default defineNuxtConfig({
     }
   },
 
+  experimental: {
+    defaults: {
+      nuxtLink: {
+        externalRelAttribute: 'noopener'
+      }
+    }
+  },
+
   componentMeta: {
     exclude: [
       '@nuxt/content',

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -155,6 +155,14 @@ export default defineNuxtConfig({
     '/releases': { redirect: 'https://github.com/nuxt/ui/releases', prerender: false }
   },
 
+  experimental: {
+    defaults: {
+      nuxtLink: {
+        externalRelAttribute: 'noopener'
+      }
+    }
+  },
+
   compatibilityDate: '2024-07-09',
 
   nitro: {
@@ -175,14 +183,6 @@ export default defineNuxtConfig({
     optimizeDeps: {
       // prevents reloading page when navigating between components
       include: ['@internationalized/date', '@vueuse/shared', '@vueuse/integrations/useFuse', '@tanstack/vue-table', 'reka-ui', 'reka-ui/namespaced', 'embla-carousel-vue', 'embla-carousel-autoplay', 'embla-carousel-auto-scroll', 'embla-carousel-auto-height', 'embla-carousel-class-names', 'embla-carousel-fade', 'embla-carousel-wheel-gestures', 'colortranslator', 'tailwindcss/colors', 'tailwind-variants', 'ufo', 'zod', 'vaul-vue', 'scule', 'motion-v', 'json5', 'ohash', 'shiki-transformer-color-highlight']
-    }
-  },
-
-  experimental: {
-    defaults: {
-      nuxtLink: {
-        externalRelAttribute: 'noopener'
-      }
     }
   },
 


### PR DESCRIPTION
I believe this is better to remove it in our docs as we control the external links and it is good for our partners to be able to get the information that Nuxt UI send traffic to them.

About the config: https://nuxt.com/docs/4.x/api/components/nuxt-link#in-nuxt-config