### PR TITLE
fix(components): standardize naming for type interfaces

### DIFF
--- a/docs/app/components/content/ComponentCode.vue
+++ b/docs/app/components/content/ComponentCode.vue
@@ -300,7 +300,7 @@ ${props.slots?.default}
   return code
 })
 
-const { data: ast } = await useAsyncData(`component-code-${name}-${hash({ props: componentProps, slots: props.slots, external: props.external, externalTypes: props.externalTypes })}`, async () => {
+const { data: ast } = await useAsyncData(`component-code-${name}-${hash({ props: componentProps, slots: props.slots, external: props.external, externalTypes: props.externalTypes, collapse: props.collapse })}`, async () => {
   if (!props.prettier) {
     return parseMarkdown(code.value)
   }

--- a/docs/app/components/content/ComponentExample.vue
+++ b/docs/app/components/content/ComponentExample.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import type { ChipProps } from '@nuxt/ui'
 import { camelCase } from 'scule'
+import { hash } from 'ohash'
 import { useElementSize } from '@vueuse/core'
 import { get, set } from '#ui/utils'
 
@@ -99,7 +100,7 @@ ${data?.code ?? ''}
   return code
 })
 
-const { data: ast } = await useAsyncData(`component-example-${camelName}`, async () => {
+const { data: ast } = await useAsyncData(`component-example-${camelName}${hash({ props: componentProps, collapse: props.collapse })}`, async () => {
   if (!props.prettier) {
     return parseMarkdown(code.value)
   }

--- a/docs/content/docs/2.components/accordion.md
+++ b/docs/content/docs/2.components/accordion.md
@@ -22,8 +22,6 @@ ignore:
   - ui.content
 external:
   - items
-externalTypes:
-  - AccordionItem[]
 hide:
   - class
   - ui

--- a/docs/content/docs/2.components/checkbox-group.md
+++ b/docs/content/docs/2.components/checkbox-group.md
@@ -18,7 +18,6 @@ Use the `v-model` directive to control the value of the CheckboxGroup or the `de
 
 ::component-code
 ---
-collapse: true
 prettier: true
 ignore:
   - modelValue
@@ -49,9 +48,6 @@ ignore:
 external:
   - items
   - modelValue
-externalTypes:
-  - CheckboxGroupItem[]
-  - CheckboxGroupValue[]
 props:
   modelValue:
     - 'System'
@@ -81,7 +77,6 @@ external:
   - modelValue
 externalTypes:
   - CheckboxGroupItem[]
-  - CheckboxGroupValue[]
 props:
   modelValue:
     - 'system'
@@ -117,7 +112,6 @@ external:
   - modelValue
 externalTypes:
   - CheckboxGroupItem[]
-  - CheckboxGroupValue[]
 props:
   modelValue:
     - 'light'
@@ -147,8 +141,6 @@ ignore:
   - items
 external:
   - items
-externalTypes:
-  - CheckboxGroupItem[]
 props:
   legend: 'Theme'
   defaultValue:
@@ -172,8 +164,6 @@ ignore:
   - items
 external:
   - items
-externalTypes:
-  - CheckboxGroupItem[]
 items:
   color:
     - primary
@@ -206,8 +196,6 @@ ignore:
   - items
 external:
   - items
-externalTypes:
-  - CheckboxGroupItem[]
 items:
   color:
     - primary
@@ -245,8 +233,6 @@ ignore:
   - items
 external:
   - items
-externalTypes:
-  - CheckboxGroupItem[]
 items:
   variant:
     - list
@@ -276,8 +262,6 @@ ignore:
   - items
 external:
   - items
-externalTypes:
-  - CheckboxGroupItem[]
 items:
   variant:
     - list
@@ -307,8 +291,6 @@ ignore:
   - items
 external:
   - items
-externalTypes:
-  - CheckboxGroupItem[]
 items:
   indicator:
     - start
@@ -342,8 +324,6 @@ ignore:
   - items
 external:
   - items
-externalTypes:
-  - CheckboxGroupItem[]
 props:
   disabled: true
   defaultValue:

--- a/docs/content/docs/2.components/input-menu.md
+++ b/docs/content/docs/2.components/input-menu.md
@@ -85,6 +85,8 @@ ignore:
 external:
   - items
   - modelValue
+externalTypes:
+  - InputMenuItem[]
 props:
   modelValue:
     label: 'Todo'
@@ -137,6 +139,8 @@ ignore:
 external:
   - items
   - modelValue
+externalTypes:
+  - InputMenuItem[]
 props:
   modelValue: 'todo'
   valueKey: 'id'
@@ -610,6 +614,8 @@ ignore:
 external:
   - items
   - modelValue
+externalTypes:
+  - InputMenuItem[]
 props:
   modelValue: 'Apple'
   items:

--- a/docs/content/docs/2.components/radio-group.md
+++ b/docs/content/docs/2.components/radio-group.md
@@ -46,9 +46,6 @@ ignore:
 external:
   - items
   - modelValue
-externalTypes:
-  - RadioGroupItem[]
-  - RadioGroupValue
 props:
   modelValue: 'System'
   items:
@@ -77,7 +74,6 @@ external:
   - modelValue
 externalTypes:
   - RadioGroupItem[]
-  - RadioGroupValue
 props:
   modelValue: 'system'
   items:
@@ -112,7 +108,6 @@ external:
   - modelValue
 externalTypes:
   - RadioGroupItem[]
-  - RadioGroupValue
 props:
   modelValue: 'light'
   valueKey: 'id'
@@ -141,8 +136,6 @@ ignore:
   - items
 external:
   - items
-externalTypes:
-  - RadioGroupItem[]
 props:
   legend: 'Theme'
   defaultValue: 'System'
@@ -165,8 +158,6 @@ ignore:
   - items
 external:
   - items
-externalTypes:
-  - RadioGroupItem[]
 props:
   color: neutral
   defaultValue: 'System'
@@ -220,8 +211,6 @@ ignore:
   - items
 external:
   - items
-externalTypes:
-  - RadioGroupItem[]
 props:
   size: 'xl'
   variant: 'list'
@@ -245,8 +234,6 @@ ignore:
   - items
 external:
   - items
-externalTypes:
-  - RadioGroupItem[]
 props:
   orientation: 'horizontal'
   variant: 'list'
@@ -270,8 +257,6 @@ ignore:
   - items
 external:
   - items
-externalTypes:
-  - RadioGroupItem[]
 props:
   indicator: 'end'
   variant: 'card'
@@ -295,8 +280,6 @@ ignore:
   - items
 external:
   - items
-externalTypes:
-  - RadioGroupItem[]
 props:
   disabled: true
   defaultValue: 'System'

--- a/docs/content/docs/2.components/select-menu.md
+++ b/docs/content/docs/2.components/select-menu.md
@@ -92,6 +92,8 @@ ignore:
 external:
   - items
   - modelValue
+externalTypes:
+  - SelectMenuItem[]
 props:
   modelValue:
     label: 'Todo'
@@ -152,6 +154,8 @@ ignore:
 external:
   - items
   - modelValue
+externalTypes:
+  - SelectMenuItem[]
 props:
   modelValue: 'todo'
   valueKey: 'id'
@@ -241,6 +245,8 @@ ignore:
 external:
   - items
   - modelValue
+externalTypes:
+  - SelectMenuItem[]
 props:
   modelValue:
     label: 'Backlog'
@@ -656,6 +662,8 @@ ignore:
 external:
   - items
   - modelValue
+externalTypes:
+  - SelectMenuItem[]
 props:
   modelValue: 'Apple'
   items:

--- a/docs/content/docs/2.components/select.md
+++ b/docs/content/docs/2.components/select.md
@@ -612,6 +612,8 @@ ignore:
 external:
   - items
   - modelValue
+externalTypes:
+  - SelectItem[]
 props:
   modelValue: 'Apple'
   items:

--- a/docs/content/docs/2.components/select.md
+++ b/docs/content/docs/2.components/select.md
@@ -83,6 +83,8 @@ ignore:
 external:
   - items
   - modelValue
+externalTypes:
+  - SelectItem[]
 props:
   modelValue: 'backlog'
   items:
@@ -145,6 +147,8 @@ ignore:
 external:
   - items
   - modelValue
+externalTypes:
+  - SelectItem[]
 props:
   modelValue: 'backlog'
   valueKey: 'id'

--- a/docs/content/docs/2.components/stepper.md
+++ b/docs/content/docs/2.components/stepper.md
@@ -125,14 +125,14 @@ externalTypes:
 props:
   size: xl
   items:
-  - title: 'Address'
-    description: 'Add your address here'
-    icon: 'i-lucide-house'
-  - title: 'Shipping'
-    description: 'Set your preferred shipping method'
-    icon: 'i-lucide-truck'
-  - title: 'Checkout'
-    description: 'Confirm your order'
+    - title: 'Address'
+      description: 'Add your address here'
+      icon: 'i-lucide-house'
+    - title: 'Shipping'
+      description: 'Set your preferred shipping method'
+      icon: 'i-lucide-truck'
+    - title: 'Checkout'
+      description: 'Confirm your order'
   class: 'w-full'
 ---
 ::
@@ -154,14 +154,14 @@ externalTypes:
 props:
   orientation: vertical
   items:
-  - title: 'Address'
-    description: 'Add your address here'
-    icon: 'i-lucide-house'
-  - title: 'Shipping'
-    description: 'Set your preferred shipping method'
-    icon: 'i-lucide-truck'
-  - title: 'Checkout'
-    description: 'Confirm your order'
+    - title: 'Address'
+      description: 'Add your address here'
+      icon: 'i-lucide-house'
+    - title: 'Shipping'
+      description: 'Set your preferred shipping method'
+      icon: 'i-lucide-truck'
+    - title: 'Checkout'
+      description: 'Confirm your order'
   class: 'w-full'
 ---
 ::
@@ -183,14 +183,14 @@ externalTypes:
 props:
   disabled: true
   items:
-  - title: 'Address'
-    description: 'Add your address here'
-    icon: 'i-lucide-house'
-  - title: 'Shipping'
-    description: 'Set your preferred shipping method'
-    icon: 'i-lucide-truck'
-  - title: 'Checkout'
-    description: 'Confirm your order'
+    - title: 'Address'
+      description: 'Add your address here'
+      icon: 'i-lucide-house'
+    - title: 'Shipping'
+      description: 'Set your preferred shipping method'
+      icon: 'i-lucide-truck'
+    - title: 'Checkout'
+      description: 'Confirm your order'
 ---
 ::
 

--- a/docs/content/docs/2.components/tree.md
+++ b/docs/content/docs/2.components/tree.md
@@ -79,6 +79,8 @@ ignore:
   - items
 external:
   - items
+externalTypes:
+  - TreeItem[]
 props:
   items:
     - label: 'app/'
@@ -118,6 +120,8 @@ ignore:
   - items
 external:
   - items
+externalTypes:
+  - TreeItem[]
 props:
   multiple: true
   items:
@@ -158,6 +162,8 @@ ignore:
   - items
 external:
   - items
+externalTypes:
+  - TreeItem[]
 props:
   color: neutral
   items:
@@ -198,6 +204,8 @@ ignore:
   - items
 external:
   - items
+externalTypes:
+  - TreeItem[]
 props:
   size: xl
   items:
@@ -242,6 +250,8 @@ ignore:
   - items
 external:
   - items
+externalTypes:
+  - TreeItem[]
 props:
   trailingIcon: 'i-lucide-arrow-down'
   items:
@@ -295,6 +305,8 @@ ignore:
   - items
 external:
   - items
+externalTypes:
+  - TreeItem[]
 props:
   expandedIcon: 'i-lucide-book-open'
   collapsedIcon: 'i-lucide-book'
@@ -352,6 +364,8 @@ ignore:
   - items
 external:
   - items
+externalTypes:
+  - TreeItem[]
 props:
   disabled: true
   items:

--- a/src/runtime/components/Carousel.vue
+++ b/src/runtime/components/Carousel.vue
@@ -1,7 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
 import type { AppConfig } from '@nuxt/schema'
-import type { AcceptableValue } from 'reka-ui'
 import type { EmblaCarouselType, EmblaOptionsType, EmblaPluginType } from 'embla-carousel'
 import type { AutoplayOptionsType } from 'embla-carousel-autoplay'
 import type { AutoScrollOptionsType } from 'embla-carousel-auto-scroll'
@@ -11,17 +10,17 @@ import type { FadeOptionsType } from 'embla-carousel-fade'
 import type { WheelGesturesPluginOptions } from 'embla-carousel-wheel-gestures'
 import theme from '#build/ui/carousel'
 import type { ButtonProps, IconProps } from '../types'
+import type { AcceptableValue } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Carousel = ComponentConfig<typeof theme, AppConfig, 'carousel'>
 
-interface _CarouselItem {
+export type CarouselValue = AcceptableValue
+export type CarouselItem = CarouselValue | {
   class?: any
   ui?: Pick<Carousel['slots'], 'item'>
   [key: string]: any
 }
-
-export type CarouselItem = _CarouselItem | AcceptableValue
 
 export interface CarouselProps<T extends CarouselItem = CarouselItem> extends Omit<EmblaOptionsType, 'axis' | 'container' | 'slides' | 'direction'> {
   /**
@@ -265,7 +264,7 @@ function onSelect(api: EmblaCarouselType) {
   emits('select', selectedIndex.value)
 }
 
-function isCarouselItem(item: CarouselItem): item is _CarouselItem {
+function isCarouselItem(item: CarouselItem): item is Exclude<CarouselItem, CarouselValue> {
   return typeof item === 'object' && item !== null
 }
 

--- a/src/runtime/components/CheckboxGroup.vue
+++ b/src/runtime/components/CheckboxGroup.vue
@@ -9,8 +9,7 @@ import type { ComponentConfig } from '../types/tv'
 type CheckboxGroup = ComponentConfig<typeof theme, AppConfig, 'checkboxGroup'>
 
 export type CheckboxGroupValue = AcceptableValue
-
-export type CheckboxGroupItem = {
+export type CheckboxGroupItem = CheckboxGroupValue | {
   label?: string
   description?: string
   disabled?: boolean
@@ -18,7 +17,7 @@ export type CheckboxGroupItem = {
   class?: any
   ui?: Pick<CheckboxGroup['slots'], 'item'> & Omit<Required<CheckboxProps>['ui'], 'root'>
   [key: string]: any
-} | CheckboxGroupValue
+}
 
 export interface CheckboxGroupProps<T extends CheckboxGroupItem[] = CheckboxGroupItem[], VK extends GetItemKeys<T> = 'value'> extends Pick<CheckboxGroupRootProps, 'disabled' | 'loop' | 'name' | 'required'>, Pick<CheckboxProps, 'color' | 'indicator' | 'icon'> {
   /**

--- a/src/runtime/components/Input.vue
+++ b/src/runtime/components/Input.vue
@@ -10,7 +10,8 @@ import type { ComponentConfig } from '../types/tv'
 
 type Input = ComponentConfig<typeof theme, AppConfig, 'input'>
 
-export interface InputProps<T extends AcceptableValue = AcceptableValue> extends UseComponentIconsProps {
+export type InputValue = AcceptableValue
+export interface InputProps<T extends InputValue = InputValue> extends UseComponentIconsProps {
   /**
    * The element or component this component should render as.
    * @defaultValue 'div'
@@ -47,7 +48,7 @@ export interface InputProps<T extends AcceptableValue = AcceptableValue> extends
   ui?: Input['slots']
 }
 
-export interface InputEmits<T extends AcceptableValue = AcceptableValue> {
+export interface InputEmits<T extends InputValue = InputValue> {
   'update:modelValue': [value: T]
   'blur': [event: FocusEvent]
   'change': [event: Event]
@@ -60,7 +61,7 @@ export interface InputSlots {
 }
 </script>
 
-<script setup lang="ts" generic="T extends AcceptableValue">
+<script setup lang="ts" generic="T extends InputValue">
 import { ref, computed, onMounted } from 'vue'
 import { Primitive } from 'reka-ui'
 import { useVModel } from '@vueuse/core'

--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -10,7 +10,8 @@ import type { ComponentConfig } from '../types/tv'
 
 type InputMenu = ComponentConfig<typeof theme, AppConfig, 'inputMenu'>
 
-interface _InputMenuItem {
+export type InputMenuValue = AcceptableValue | boolean
+export type InputMenuItem = InputMenuValue | {
   label?: string
   /**
    * @IconifyIcon
@@ -29,7 +30,6 @@ interface _InputMenuItem {
   ui?: Pick<InputMenu['slots'], 'tagsItem' | 'tagsItemText' | 'tagsItemDelete' | 'tagsItemDeleteIcon' | 'label' | 'separator' | 'item' | 'itemLeadingIcon' | 'itemLeadingAvatarSize' | 'itemLeadingAvatar' | 'itemLeadingChip' | 'itemLeadingChipSize' | 'itemLabel' | 'itemTrailing' | 'itemTrailingIcon'>
   [key: string]: any
 }
-export type InputMenuItem = _InputMenuItem | AcceptableValue | boolean
 
 export interface InputMenuProps<T extends ArrayOrNested<InputMenuItem> = ArrayOrNested<InputMenuItem>, VK extends GetItemKeys<T> | undefined = undefined, M extends boolean = false> extends Pick<ComboboxRootProps<T>, 'open' | 'defaultOpen' | 'disabled' | 'name' | 'resetSearchTermOnBlur' | 'resetSearchTermOnSelect' | 'highlightOnHover' | 'openOnClick' | 'openOnFocus'>, UseComponentIconsProps {
   /**
@@ -389,7 +389,7 @@ function onSelect(e: Event, item: InputMenuItem) {
   item.onSelect?.(e)
 }
 
-function isInputItem(item: InputMenuItem): item is _InputMenuItem {
+function isInputItem(item: InputMenuItem): item is Exclude<InputMenuItem, InputMenuValue> {
   return typeof item === 'object' && item !== null
 }
 

--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -10,7 +10,7 @@ import type { ComponentConfig } from '../types/tv'
 
 type InputMenu = ComponentConfig<typeof theme, AppConfig, 'inputMenu'>
 
-export type InputMenuValue = AcceptableValue | boolean
+export type InputMenuValue = AcceptableValue
 export type InputMenuItem = InputMenuValue | {
   label?: string
   /**

--- a/src/runtime/components/RadioGroup.vue
+++ b/src/runtime/components/RadioGroup.vue
@@ -88,7 +88,7 @@ export interface RadioGroupSlots<T extends RadioGroupItem[] = RadioGroupItem[]> 
 
 <script setup lang="ts" generic="T extends RadioGroupItem[], VK extends GetItemKeys<T> = 'value'">
 import { computed, useId } from 'vue'
-import { RadioGroupRoot, RadioGroupItem, RadioGroupIndicator, Label, useForwardPropsEmits } from 'reka-ui'
+import { RadioGroupRoot, RadioGroupItem as RRadioGroupItem, RadioGroupIndicator, Label, useForwardPropsEmits } from 'reka-ui'
 import { reactivePick } from '@vueuse/core'
 import { useAppConfig } from '#imports'
 import { useFormField } from '../composables/useFormField'
@@ -172,8 +172,8 @@ function onUpdate(value: any) {
   <RadioGroupRoot
     :id="id"
     v-bind="rootProps"
-    :model-value="modelValue"
-    :default-value="defaultValue"
+    :model-value="(modelValue as Exclude<RadioGroupItem, boolean> | Exclude<RadioGroupItem, boolean>[])"
+    :default-value="(defaultValue as Exclude<RadioGroupItem, boolean> | Exclude<RadioGroupItem, boolean>[])"
     :orientation="orientation"
     :name="name"
     :disabled="disabled"
@@ -189,14 +189,14 @@ function onUpdate(value: any) {
 
       <component :is="(!variant || variant === 'list') ? 'div' : Label" v-for="item in normalizedItems" :key="item.value" :class="ui.item({ class: [props.ui?.item, item.ui?.item, item.class] })">
         <div :class="ui.container({ class: [props.ui?.container, item.ui?.container] })">
-          <RadioGroupItem
+          <RRadioGroupItem
             :id="item.id"
             :value="item.value"
             :disabled="item.disabled"
             :class="ui.base({ class: [props.ui?.base, item.ui?.base], disabled: item.disabled })"
           >
             <RadioGroupIndicator :class="ui.indicator({ class: [props.ui?.indicator, item.ui?.indicator] })" />
-          </RadioGroupItem>
+          </RRadioGroupItem>
         </div>
 
         <div v-if="(item.label || !!slots.label) || (item.description || !!slots.description)" :class="ui.wrapper({ class: [props.ui?.wrapper, item.ui?.wrapper] })">

--- a/src/runtime/components/RadioGroup.vue
+++ b/src/runtime/components/RadioGroup.vue
@@ -8,7 +8,7 @@ import type { ComponentConfig } from '../types/tv'
 type RadioGroup = ComponentConfig<typeof theme, AppConfig, 'radioGroup'>
 
 export type RadioGroupValue = AcceptableValue
-export type RadioGroupItem = {
+export type RadioGroupItem = RadioGroupValue | {
   label?: string
   description?: string
   disabled?: boolean
@@ -16,7 +16,7 @@ export type RadioGroupItem = {
   class?: any
   ui?: Pick<RadioGroup['slots'], 'item' | 'container' | 'base' | 'indicator' | 'wrapper' | 'label' | 'description'>
   [key: string]: any
-} | RadioGroupValue
+}
 
 export interface RadioGroupProps<T extends RadioGroupItem[] = RadioGroupItem[], VK extends GetItemKeys<T> = 'value'> extends Pick<RadioGroupRootProps, 'disabled' | 'loop' | 'name' | 'required'> {
   /**

--- a/src/runtime/components/Select.vue
+++ b/src/runtime/components/Select.vue
@@ -9,7 +9,8 @@ import type { ComponentConfig } from '../types/tv'
 
 type Select = ComponentConfig<typeof theme, AppConfig, 'select'>
 
-interface SelectItemBase {
+export type SelectValue = AcceptableValue | boolean
+export type SelectItem = SelectValue | {
   label?: string
   /**
    * @IconifyIcon
@@ -22,14 +23,13 @@ interface SelectItemBase {
    * @defaultValue 'item'
    */
   type?: 'label' | 'separator' | 'item'
-  value?: AcceptableValue | boolean
+  value?: SelectValue
   disabled?: boolean
   onSelect?(e?: Event): void
   class?: any
   ui?: Pick<Select['slots'], 'label' | 'separator' | 'item' | 'itemLeadingIcon' | 'itemLeadingAvatarSize' | 'itemLeadingAvatar' | 'itemLeadingChipSize' | 'itemLeadingChip' | 'itemLabel' | 'itemTrailing' | 'itemTrailingIcon'>
   [key: string]: any
 }
-export type SelectItem = SelectItemBase | AcceptableValue | boolean
 
 export interface SelectProps<T extends ArrayOrNested<SelectItem> = ArrayOrNested<SelectItem>, VK extends GetItemKeys<T> = 'value', M extends boolean = false> extends Omit<SelectRootProps<T>, 'dir' | 'multiple' | 'modelValue' | 'defaultValue' | 'by'>, UseComponentIconsProps {
   id?: string
@@ -138,7 +138,7 @@ export interface SelectSlots<
 
 <script setup lang="ts" generic="T extends ArrayOrNested<SelectItem>, VK extends GetItemKeys<T> = 'value', M extends boolean = false">
 import { ref, computed, onMounted, toRef } from 'vue'
-import { SelectRoot, SelectArrow, SelectTrigger, SelectPortal, SelectContent, SelectLabel, SelectGroup, SelectItem, SelectItemIndicator, SelectItemText, SelectSeparator, useForwardPropsEmits } from 'reka-ui'
+import { SelectRoot, SelectArrow, SelectTrigger, SelectPortal, SelectContent, SelectLabel, SelectGroup, SelectItem as RSelectItem, SelectItemIndicator, SelectItemText, SelectSeparator, useForwardPropsEmits } from 'reka-ui'
 import { defu } from 'defu'
 import { reactivePick } from '@vueuse/core'
 import { useAppConfig } from '#imports'
@@ -251,7 +251,7 @@ function onUpdateOpen(value: boolean) {
   }
 }
 
-function isSelectItem(item: SelectItem): item is SelectItemBase {
+function isSelectItem(item: SelectItem): item is Exclude<SelectItem, SelectValue> {
   return typeof item === 'object' && item !== null
 }
 
@@ -268,8 +268,8 @@ defineExpose({
     v-bind="rootProps"
     :autocomplete="autocomplete"
     :disabled="disabled"
-    :default-value="(defaultValue as (AcceptableValue | AcceptableValue[]))"
-    :model-value="(modelValue as (AcceptableValue | AcceptableValue[]))"
+    :default-value="(defaultValue as (Exclude<SelectItem, boolean> | Exclude<SelectItem, boolean>[]))"
+    :model-value="(modelValue as (Exclude<SelectItem, boolean> | Exclude<SelectItem, boolean>[]))"
     @update:model-value="onUpdate"
     @update:open="onUpdateOpen"
   >
@@ -317,7 +317,7 @@ defineExpose({
 
               <SelectSeparator v-else-if="isSelectItem(item) && item.type === 'separator'" :class="ui.separator({ class: [props.ui?.separator, item.ui?.separator, item.class] })" />
 
-              <SelectItem
+              <RSelectItem
                 v-else
                 :class="ui.item({ class: [props.ui?.item, isSelectItem(item) && item.ui?.item, isSelectItem(item) && item.class] })"
                 :disabled="isSelectItem(item) && item.disabled"
@@ -352,7 +352,7 @@ defineExpose({
                     </SelectItemIndicator>
                   </span>
                 </slot>
-              </SelectItem>
+              </RSelectItem>
             </template>
           </SelectGroup>
         </div>

--- a/src/runtime/components/Select.vue
+++ b/src/runtime/components/Select.vue
@@ -268,8 +268,8 @@ defineExpose({
     v-bind="rootProps"
     :autocomplete="autocomplete"
     :disabled="disabled"
-    :default-value="defaultValue"
-    :model-value="modelValue"
+    :default-value="(defaultValue as Exclude<SelectItem, boolean> | Exclude<SelectItem, boolean>[])"
+    :model-value="(modelValue as Exclude<SelectItem, boolean> | Exclude<SelectItem, boolean>[])"
     @update:model-value="onUpdate"
     @update:open="onUpdateOpen"
   >

--- a/src/runtime/components/Select.vue
+++ b/src/runtime/components/Select.vue
@@ -9,7 +9,7 @@ import type { ComponentConfig } from '../types/tv'
 
 type Select = ComponentConfig<typeof theme, AppConfig, 'select'>
 
-export type SelectValue = AcceptableValue | boolean
+export type SelectValue = AcceptableValue
 export type SelectItem = SelectValue | {
   label?: string
   /**
@@ -268,8 +268,8 @@ defineExpose({
     v-bind="rootProps"
     :autocomplete="autocomplete"
     :disabled="disabled"
-    :default-value="(defaultValue as (Exclude<SelectItem, boolean> | Exclude<SelectItem, boolean>[]))"
-    :model-value="(modelValue as (Exclude<SelectItem, boolean> | Exclude<SelectItem, boolean>[]))"
+    :default-value="defaultValue"
+    :model-value="modelValue"
     @update:model-value="onUpdate"
     @update:open="onUpdateOpen"
   >

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -9,7 +9,7 @@ import type { ComponentConfig } from '../types/tv'
 
 type SelectMenu = ComponentConfig<typeof theme, AppConfig, 'selectMenu'>
 
-export type SelectMenuValue = AcceptableValue | boolean
+export type SelectMenuValue = AcceptableValue
 export type SelectMenuItem = SelectMenuValue | {
   label?: string
   /**

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -9,7 +9,8 @@ import type { ComponentConfig } from '../types/tv'
 
 type SelectMenu = ComponentConfig<typeof theme, AppConfig, 'selectMenu'>
 
-interface _SelectMenuItem {
+export type SelectMenuValue = AcceptableValue | boolean
+export type SelectMenuItem = SelectMenuValue | {
   label?: string
   /**
    * @IconifyIcon
@@ -28,7 +29,6 @@ interface _SelectMenuItem {
   ui?: Pick<SelectMenu['slots'], 'label' | 'separator' | 'item' | 'itemLeadingIcon' | 'itemLeadingAvatarSize' | 'itemLeadingAvatar' | 'itemLeadingChipSize' | 'itemLeadingChip' | 'itemLabel' | 'itemTrailing' | 'itemTrailingIcon'>
   [key: string]: any
 }
-export type SelectMenuItem = _SelectMenuItem | AcceptableValue | boolean
 
 export interface SelectMenuProps<T extends ArrayOrNested<SelectMenuItem> = ArrayOrNested<SelectMenuItem>, VK extends GetItemKeys<T> | undefined = undefined, M extends boolean = false> extends Pick<ComboboxRootProps<T>, 'open' | 'defaultOpen' | 'disabled' | 'name' | 'resetSearchTermOnBlur' | 'resetSearchTermOnSelect' | 'highlightOnHover'>, UseComponentIconsProps {
   id?: string
@@ -372,7 +372,7 @@ function onSelect(e: Event, item: SelectMenuItem) {
   item.onSelect?.(e)
 }
 
-function isSelectItem(item: SelectMenuItem): item is _SelectMenuItem {
+function isSelectItem(item: SelectMenuItem): item is Exclude<SelectMenuItem, SelectMenuValue> {
   return typeof item === 'object' && item !== null
 }
 

--- a/src/runtime/types/utils.ts
+++ b/src/runtime/types/utils.ts
@@ -26,7 +26,9 @@ export type GetObjectField<MaybeObject, Key extends string> = MaybeObject extend
   ? MaybeObject[Key]
   : never
 
-export type AcceptableValue = Exclude<_AcceptableValue, Record<string, any>>
+// NOTE: `Boolean` could potentially cause casting issues, but have been safe so far.
+// https://vuejs.org/guide/components/props.html#boolean-casting
+export type AcceptableValue = Exclude<_AcceptableValue, Record<string, any>> | boolean
 export type ArrayOrNested<T> = T[] | T[][]
 export type NestedItem<T> = T extends Array<infer I> ? NestedItem<I> : T
 type AllKeys<T> = T extends any ? keyof T : never


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

For those components that both accept an object and normal values (string, number, null) we only referred as `<component-name>Item` interfaces, with this change we also introduce `<component-name>Value` to refer only to normal values.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
