### PR TITLE
fix(types): resolve ambient declaration error in `icons` type

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -206,7 +206,7 @@ import type { TVConfig } from '@nuxt/ui'
 import type { defaultConfig } from 'tailwind-variants'
 import colors from 'tailwindcss/colors'
 
-const icons = ${JSON.stringify(uiConfig.icons)};
+type IconsConfig = ${JSON.stringify(uiConfig.icons)};
 
 type NeutralColor = 'slate' | 'gray' | 'zinc' | 'neutral' | 'stone'
 type Color = Exclude<keyof typeof colors, 'inherit' | 'current' | 'transparent' | 'black' | 'white' | NeutralColor> | (string & {})
@@ -216,7 +216,7 @@ type AppConfigUI = {
     ${options.theme?.colors?.map(color => `'${color}'?: Color`).join('\n\t\t')}
     neutral?: NeutralColor | (string & {})
   }
-  icons?: Partial<typeof icons>
+  icons?: Partial<IconsConfig>
   tv?: typeof defaultConfig
 } & TVConfig<typeof ui>
 

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -201,12 +201,16 @@ export function getTemplates(options: ModuleOptions, uiConfig: Record<string, an
   // FIXME: `typeof colors[number]` should include all colors from the theme
   templates.push({
     filename: 'types/ui.d.ts',
-    getContents: () => `import * as ui from '#build/ui'
+    getContents: () => {
+      const iconKeys = Object.keys(uiConfig?.icons || {})
+      const iconUnion = iconKeys.length ? iconKeys.map(i => JSON.stringify(i)).join(' | ') : 'string'
+
+      return `import * as ui from '#build/ui'
 import type { TVConfig } from '@nuxt/ui'
 import type { defaultConfig } from 'tailwind-variants'
 import colors from 'tailwindcss/colors'
 
-type IconsConfig = ${JSON.stringify(uiConfig.icons)};
+type IconsConfig = Record<${iconUnion} | (string & {}), string>
 
 type NeutralColor = 'slate' | 'gray' | 'zinc' | 'neutral' | 'stone'
 type Color = Exclude<keyof typeof colors, 'inherit' | 'current' | 'transparent' | 'black' | 'white' | NeutralColor> | (string & {})
@@ -232,6 +236,7 @@ declare module '@nuxt/schema' {
 
 export {}
 `
+    }
   })
 
   templates.push({


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #4959

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

According to typechecking error message, it is not possible to have object in ambient types. This fix resolves it by replacing `const icons` by defining it as a type.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
