### PR TITLE
fix(ProseImg): add `w-full` by default

### DIFF
--- a/src/theme/prose/img.ts
+++ b/src/theme/prose/img.ts
@@ -1,6 +1,6 @@
 export default {
   slots: {
-    base: 'rounded-md',
+    base: 'rounded-md w-full',
     overlay: 'fixed inset-0 bg-default/75 backdrop-blur-sm will-change-opacity',
     content: 'fixed inset-0 flex items-center justify-center cursor-zoom-out focus:outline-none p-4 sm:p-8'
   },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Will fix svg based `img` like
<img width="1412" height="794" alt="image" src="https://github.com/user-attachments/assets/d22897cc-5cdc-4153-9b2f-88406e7576df" />
