### PR TITLE
fix(Tree): remove `value-key` in favor of `get-key`

### DIFF
--- a/docs/app/components/content/examples/tree/TreeExpandedExample.vue
+++ b/docs/app/components/content/examples/tree/TreeExpandedExample.vue
@@ -4,11 +4,11 @@ import type { TreeItem } from '@nuxt/ui'
 const items: TreeItem[] = [
   {
     label: 'app/',
-    value: 'app',
+    key: 'app',
     children: [
       {
         label: 'composables/',
-        value: 'composables',
+        key: 'composables',
         children: [
           { label: 'useAuth.ts', icon: 'i-vscode-icons-file-type-typescript' },
           { label: 'useUser.ts', icon: 'i-vscode-icons-file-type-typescript' }
@@ -16,7 +16,7 @@ const items: TreeItem[] = [
       },
       {
         label: 'components/',
-        value: 'components',
+        key: 'components',
         children: [
           { label: 'Card.vue', icon: 'i-vscode-icons-file-type-vue' },
           { label: 'Button.vue', icon: 'i-vscode-icons-file-type-vue' }

--- a/docs/app/components/content/examples/tree/TreeExpandedExample.vue
+++ b/docs/app/components/content/examples/tree/TreeExpandedExample.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { TreeItem } from '@nuxt/ui'
 
-const items: TreeItem[] = [
+const items = [
   {
     label: 'app/',
     id: 'app',
@@ -26,7 +26,7 @@ const items: TreeItem[] = [
   },
   { label: 'app.vue', id: 'app.vue', icon: 'i-vscode-icons-file-type-vue' },
   { label: 'nuxt.config.ts', id: 'nuxt.config.ts', icon: 'i-vscode-icons-file-type-nuxt' }
-]
+] satisfies TreeItem[]
 
 const expanded = ref(['app', 'app/composables'])
 </script>

--- a/docs/app/components/content/examples/tree/TreeExpandedExample.vue
+++ b/docs/app/components/content/examples/tree/TreeExpandedExample.vue
@@ -28,7 +28,7 @@ const items: TreeItem[] = [
   { label: 'nuxt.config.ts', id: 'nuxt.config.ts', icon: 'i-vscode-icons-file-type-nuxt' }
 ]
 
-const expanded = ref(['app', 'composables'])
+const expanded = ref(['app', 'app/composables'])
 </script>
 
 <template>

--- a/docs/app/components/content/examples/tree/TreeExpandedExample.vue
+++ b/docs/app/components/content/examples/tree/TreeExpandedExample.vue
@@ -4,11 +4,11 @@ import type { TreeItem } from '@nuxt/ui'
 const items: TreeItem[] = [
   {
     label: 'app/',
-    key: 'app',
+    id: 'app',
     children: [
       {
         label: 'composables/',
-        key: 'composables',
+        id: 'app/composables',
         children: [
           { label: 'useAuth.ts', icon: 'i-vscode-icons-file-type-typescript' },
           { label: 'useUser.ts', icon: 'i-vscode-icons-file-type-typescript' }
@@ -16,7 +16,7 @@ const items: TreeItem[] = [
       },
       {
         label: 'components/',
-        key: 'components',
+        id: 'app/components',
         children: [
           { label: 'Card.vue', icon: 'i-vscode-icons-file-type-vue' },
           { label: 'Button.vue', icon: 'i-vscode-icons-file-type-vue' }
@@ -24,13 +24,13 @@ const items: TreeItem[] = [
       }
     ]
   },
-  { label: 'app.vue', icon: 'i-vscode-icons-file-type-vue' },
-  { label: 'nuxt.config.ts', icon: 'i-vscode-icons-file-type-nuxt' }
+  { label: 'app.vue', id: 'app.vue', icon: 'i-vscode-icons-file-type-vue' },
+  { label: 'nuxt.config.ts', id: 'nuxt.config.ts', icon: 'i-vscode-icons-file-type-nuxt' }
 ]
 
 const expanded = ref(['app', 'composables'])
 </script>
 
 <template>
-  <UTree v-model:expanded="expanded" :items="items" />
+  <UTree v-model:expanded="expanded" :items="items" :get-key="i => i.id" />
 </template>

--- a/docs/app/components/content/examples/tree/TreeModelValueExample.vue
+++ b/docs/app/components/content/examples/tree/TreeModelValueExample.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { TreeItem } from '@nuxt/ui'
 
-const items = [
+const items: TreeItem[] = [
   {
     label: 'app/',
     defaultExpanded: true,
@@ -25,9 +25,9 @@ const items = [
   },
   { label: 'app.vue', icon: 'i-vscode-icons-file-type-vue' },
   { label: 'nuxt.config.ts', icon: 'i-vscode-icons-file-type-nuxt' }
-] satisfies TreeItem[]
+]
 
-const value = ref<(typeof items)[number]>()
+const value = ref()
 </script>
 
 <template>

--- a/docs/app/components/content/examples/tree/TreeModelValueExample.vue
+++ b/docs/app/components/content/examples/tree/TreeModelValueExample.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import type { TreeItem } from '@nuxt/ui'
 
-const items: TreeItem[] = [
+const items = [
   {
     label: 'app/',
     defaultExpanded: true,
@@ -25,9 +25,9 @@ const items: TreeItem[] = [
   },
   { label: 'app.vue', icon: 'i-vscode-icons-file-type-vue' },
   { label: 'nuxt.config.ts', icon: 'i-vscode-icons-file-type-nuxt' }
-]
+] satisfies TreeItem[]
 
-const value = ref()
+const value = ref<(typeof items)[number]>()
 </script>
 
 <template>

--- a/docs/content/docs/2.components/tree.md
+++ b/docs/content/docs/2.components/tree.md
@@ -58,7 +58,7 @@ Use the `items` prop as an array of objects with the following properties:
 - `trailingIcon?: string`{lang="ts-type"}
 - `defaultExpanded?: boolean`{lang="ts-type"}
 - `disabled?: boolean`{lang="ts-type"}
-- `value?: string`{lang="ts-type"}
+- `key?: string`{lang="ts-type"}
 - `slot?: string`{lang="ts-type"}
 - `children?: TreeItem[]`{lang="ts-type"}
 - `onToggle?(e: Event): void`{lang="ts-type"}
@@ -67,7 +67,7 @@ Use the `items` prop as an array of objects with the following properties:
 - `ui?: { item?: ClassNameValue, itemWithChildren?: ClassNameValue, link?: ClassNameValue, linkLeadingIcon?: ClassNameValue, linkLabel?: ClassNameValue, linkTrailing?: ClassNameValue, linkTrailingIcon?: ClassNameValue, listWithChildren?: ClassNameValue }`{lang="ts-type"}
 
 ::note
-A unique identifier is required for each item. The component will use the `value` prop as identifier, falling back to `label` if `value` is not provided. One of these must be provided for the component to work properly.
+A unique identifier is required for each item. The component will use the `key` prop as identifier, falling back to `label` if `key` is not provided. In alternative, you could also use the `index-key` prop to specify a different property to be used as identifier, like `id` when dealing with data from a database.
 ::
 
 ::component-code

--- a/docs/content/docs/2.components/tree.md
+++ b/docs/content/docs/2.components/tree.md
@@ -58,7 +58,6 @@ Use the `items` prop as an array of objects with the following properties:
 - `trailingIcon?: string`{lang="ts-type"}
 - `defaultExpanded?: boolean`{lang="ts-type"}
 - `disabled?: boolean`{lang="ts-type"}
-- `key?: string`{lang="ts-type"}
 - `slot?: string`{lang="ts-type"}
 - `children?: TreeItem[]`{lang="ts-type"}
 - `onToggle?(e: Event): void`{lang="ts-type"}
@@ -67,7 +66,7 @@ Use the `items` prop as an array of objects with the following properties:
 - `ui?: { item?: ClassNameValue, itemWithChildren?: ClassNameValue, link?: ClassNameValue, linkLeadingIcon?: ClassNameValue, linkLabel?: ClassNameValue, linkTrailing?: ClassNameValue, linkTrailingIcon?: ClassNameValue, listWithChildren?: ClassNameValue }`{lang="ts-type"}
 
 ::note
-A unique identifier is required for each item. The component will use the `key` prop as identifier, falling back to `label` if `key` is not provided. In alternative, you could also use the `index-key` prop to specify a different property to be used as identifier, like `id` when dealing with data from a database.
+A unique identifier is required for each item. The component will use the `label` prop as identifier if no `get-key` is provided. Ideally you should provide a `get-key` function prop to return a unique identifier. Alternatively, you can use the `labelKey` prop to specify which property to use as the unique identifier.
 ::
 
 ::component-code

--- a/playgrounds/nuxt/app/pages/components/tree.vue
+++ b/playgrounds/nuxt/app/pages/components/tree.vue
@@ -72,7 +72,7 @@ const modelValueWithMappedId = ref<(typeof itemsWithMappedId)[number]>()
       <UTree :default-value="modelValue" :items="items" />
       <UTree :items="items" @update:model-value="(payload) => payload" />
 
-      <UTree v-model="modelValueWithMappedId" :items="itemsWithMappedId" index-key="id" />
+      <UTree v-model="modelValueWithMappedId" :items="itemsWithMappedId" :get-key="(i) => i.id" />
       <UTree v-model="modelValueWithMappedId" :items="itemsWithMappedId" label-key="title" />
     </template>
   </div>

--- a/playgrounds/nuxt/app/pages/components/tree.vue
+++ b/playgrounds/nuxt/app/pages/components/tree.vue
@@ -41,8 +41,9 @@ const itemsWithMappedId = [
   { id: 'id3', title: 'obiwan kenobi' }
 ]
 
-const modelValue = ref<string>()
-const modelValues = ref<string[]>([])
+const modelValue = ref<(typeof items)[number]>()
+const modelValues = ref<(typeof items)>([])
+const modelValueWithMappedId = ref<(typeof itemsWithMappedId)[number]>()
 </script>
 
 <template>
@@ -71,8 +72,8 @@ const modelValues = ref<string[]>([])
       <UTree :default-value="modelValue" :items="items" />
       <UTree :items="items" @update:model-value="(payload) => payload" />
 
-      <UTree v-model="modelValue" :items="itemsWithMappedId" value-key="id" />
-      <UTree v-model="modelValue" :items="itemsWithMappedId" label-key="title" />
+      <UTree v-model="modelValueWithMappedId" :items="itemsWithMappedId" index-key="id" />
+      <UTree v-model="modelValueWithMappedId" :items="itemsWithMappedId" label-key="title" />
     </template>
   </div>
 </template>

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -241,7 +241,9 @@ const defaultExpanded = computed(() =>
   </DefineTreeTemplate>
 
   <TreeRoot
-    v-bind="{ ...(rootProps as unknown as TreeRootProps<T[number]>), ...$attrs }"
+    v-bind="{ ...rootProps, ...$attrs }"
+    :model-value="modelValue"
+    :default-value="defaultValue"
     :class="ui.root({ class: [props.ui?.root, props.class] })"
     :get-key="getItemKey"
     :default-expanded="defaultExpanded"

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -115,7 +115,7 @@ const slots = defineSlots<TreeSlots<T>>()
 
 const appConfig = useAppConfig() as Tree['AppConfig']
 
-const rootProps = useForwardPropsEmits(reactivePick(props, 'as', 'modelValue', 'defaultValue', 'items', 'multiple', 'expanded', 'disabled', 'propagateSelect', 'bubbleSelect'), emits)
+const rootProps = useForwardPropsEmits(reactivePick(props, 'as', 'items', 'multiple', 'expanded', 'disabled', 'propagateSelect', 'bubbleSelect'), emits)
 
 const [DefineTreeTemplate, ReuseTreeTemplate] = createReusableTemplate<{ items?: TreeItem[], level: number }, TreeSlots<T>>()
 

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -130,7 +130,7 @@ function getItemLabel<Item extends T[number]>(item: Item): string {
 
 function getItemKey<Item extends T[number]>(item: Item): string {
   return props.getKey
-    ? props.getKey(item)
+    ? props.getKey(item) ?? getItemLabel(item)
     : getItemLabel(item)
 }
 

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -4,7 +4,7 @@ import type { TreeRootProps, TreeRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/tree'
 import type { IconProps } from '../types'
-import type { DynamicSlots, GetItemKeys, GetModelValue, GetModelValueEmits, NestedItem } from '../types/utils'
+import type { DynamicSlots, GetItemKeys, NestedItem } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Tree = ComponentConfig<typeof theme, AppConfig, 'tree'>
@@ -16,12 +16,15 @@ export type TreeItem = {
   icon?: IconProps['name']
   label?: string
   /**
+   * The unique key of the item. If not provided, the label will be used as the key.
+   */
+  key?: string
+  /**
    * @IconifyIcon
    */
   trailingIcon?: IconProps['name']
   defaultExpanded?: boolean
   disabled?: boolean
-  value?: string
   slot?: string
   children?: TreeItem[]
   onToggle?(e: Event): void
@@ -31,7 +34,7 @@ export type TreeItem = {
   [key: string]: any
 }
 
-export interface TreeProps<T extends TreeItem[] = TreeItem[], VK extends GetItemKeys<T> = 'value', M extends boolean = false> extends Pick<TreeRootProps<T>, 'expanded' | 'defaultExpanded' | 'selectionBehavior' | 'propagateSelect' | 'disabled' | 'bubbleSelect'> {
+export interface TreeProps<T extends TreeItem[] = TreeItem[], M extends boolean = false> extends Pick<TreeRootProps<T>, 'expanded' | 'defaultExpanded' | 'selectionBehavior' | 'propagateSelect' | 'disabled' | 'bubbleSelect'> {
   /**
    * The element or component this component should render as.
    * @defaultValue 'ul'
@@ -46,15 +49,15 @@ export interface TreeProps<T extends TreeItem[] = TreeItem[], VK extends GetItem
    */
   size?: Tree['variants']['size']
   /**
-   * The key used to get the value from the item.
-   * @defaultValue 'value'
-   */
-  valueKey?: VK
-  /**
    * The key used to get the label from the item.
    * @defaultValue 'label'
    */
   labelKey?: GetItemKeys<T>
+  /**
+   * The key used to get the unique key from the item.
+   * @defaultValue 'key'
+   */
+  indexKey?: GetItemKeys<T>
   /**
    * The icon displayed on the right side of a parent node.
    * @defaultValue appConfig.ui.icons.chevronDown
@@ -75,16 +78,16 @@ export interface TreeProps<T extends TreeItem[] = TreeItem[], VK extends GetItem
   collapsedIcon?: IconProps['name']
   items?: T
   /** The controlled value of the Tree. Can be bind as `v-model`. */
-  modelValue?: GetModelValue<T, VK, M>
+  modelValue?: M extends true ? NestedItem<T>[] : NestedItem<T>
   /** The value of the Tree when initially rendered. Use when you do not need to control the state of the Tree. */
-  defaultValue?: GetModelValue<T, VK, M>
+  defaultValue?: M extends true ? NestedItem<T>[] : NestedItem<T>
   /** Whether multiple options can be selected or not. */
   multiple?: M & boolean
   class?: any
   ui?: Tree['slots']
 }
 
-export type TreeEmits<A extends TreeItem[], VK extends GetItemKeys<A> | undefined, M extends boolean> = Omit<TreeRootEmits, 'update:modelValue'> & GetModelValueEmits<A, VK, M>
+export type TreeEmits<T extends TreeItem = TreeItem, M extends boolean = false> = TreeRootEmits<T, M>
 
 type SlotProps<T extends TreeItem> = (props: { item: T, index: number, level: number, expanded: boolean, selected: boolean }) => any
 
@@ -101,7 +104,7 @@ export type TreeSlots<
 
 </script>
 
-<script setup lang="ts" generic="T extends TreeItem[], VK extends GetItemKeys<T> = 'value', M extends boolean = false">
+<script setup lang="ts" generic="T extends TreeItem[], M extends boolean = false">
 import { computed } from 'vue'
 import { TreeRoot, TreeItem, useForwardPropsEmits } from 'reka-ui'
 import { reactivePick, createReusableTemplate } from '@vueuse/core'
@@ -112,11 +115,11 @@ import UIcon from './Icon.vue'
 
 defineOptions({ inheritAttrs: false })
 
-const props = withDefaults(defineProps<TreeProps<T, VK, M>>(), {
+const props = withDefaults(defineProps<TreeProps<T, M>>(), {
   labelKey: 'label',
-  valueKey: 'value' as never
+  indexKey: 'key'
 })
-const emits = defineEmits<TreeEmits<T, VK, M>>()
+const emits = defineEmits<TreeEmits<T[number], M>>()
 const slots = defineSlots<TreeSlots<T>>()
 
 const appConfig = useAppConfig() as Tree['AppConfig']
@@ -134,12 +137,12 @@ function getItemLabel<Item extends TreeItem = NestedItem<T>>(item: Item): string
   return get(item, props.labelKey as string)
 }
 
-function getItemValue(item: NestedItem<T>): string {
-  return get(item, props.valueKey as string) ?? get(item, props.labelKey as string)
+function getItemKey<Item extends TreeItem = NestedItem<T>>(item: Item): string {
+  return get(item, props.indexKey as string) ?? getItemLabel(item)
 }
 
 function getDefaultOpenedItems(item: NestedItem<T>): string[] {
-  const currentItem = item.defaultExpanded ? getItemValue(item) : null
+  const currentItem = item.defaultExpanded ? getItemKey(item) : null
   const childItems = item.children?.flatMap((child: TreeItem) => getDefaultOpenedItems(child as NestedItem<T>)) ?? []
 
   return [currentItem, ...childItems].filter(Boolean) as string[]
@@ -236,7 +239,7 @@ const defaultExpanded = computed(() =>
   <TreeRoot
     v-bind="{ ...(rootProps as unknown as TreeRootProps<NestedItem<T>>), ...$attrs }"
     :class="ui.root({ class: [props.ui?.root, props.class] })"
-    :get-key="getItemValue"
+    :get-key="getItemKey"
     :default-expanded="defaultExpanded"
     :selection-behavior="selectionBehavior"
   >

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -130,7 +130,7 @@ function getItemLabel<Item extends T[number]>(item: Item): string {
 
 function getItemKey<Item extends T[number]>(item: Item): string {
   return props.getKey
-    ? props.getKey(item) ?? getItemLabel(item)
+    ? props.getKey(item) || getItemLabel(item)
     : getItemLabel(item)
 }
 

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -80,7 +80,7 @@ export interface TreeProps<T extends TreeItem[] = TreeItem[], M extends boolean 
   ui?: Tree['slots']
 }
 
-export type TreeEmits<T extends TreeItem = TreeItem, M extends boolean = false> = TreeRootEmits<T, M>
+export type TreeEmits<T extends TreeItem[] = TreeItem[], M extends boolean = false> = TreeRootEmits<T[number], M>
 
 type SlotProps<T extends TreeItem> = (props: { item: T, index: number, level: number, expanded: boolean, selected: boolean }) => any
 
@@ -111,7 +111,7 @@ defineOptions({ inheritAttrs: false })
 const props = withDefaults(defineProps<TreeProps<T, M>>(), {
   labelKey: 'label'
 })
-const emits = defineEmits<TreeEmits<T[number], M>>()
+const emits = defineEmits<TreeEmits<T, M>>()
 const slots = defineSlots<TreeSlots<T>>()
 
 const appConfig = useAppConfig() as Tree['AppConfig']

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -4,7 +4,7 @@ import type { TreeRootProps, TreeRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/tree'
 import type { IconProps } from '../types'
-import type { DynamicSlots, GetItemKeys, NestedItem } from '../types/utils'
+import type { DynamicSlots, GetItemKeys } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Tree = ComponentConfig<typeof theme, AppConfig, 'tree'>
@@ -45,7 +45,7 @@ export interface TreeProps<T extends TreeItem[] = TreeItem[], M extends boolean 
    */
   size?: Tree['variants']['size']
   /** This function is passed the index of each item and should return a unique key for that item */
-  getKey?: (val: NestedItem<T>) => string
+  getKey?: (val: T[number]) => string
   /**
    * The key used to get the label from the item.
    * @defaultValue 'label'
@@ -71,9 +71,9 @@ export interface TreeProps<T extends TreeItem[] = TreeItem[], M extends boolean 
   collapsedIcon?: IconProps['name']
   items?: T
   /** The controlled value of the Tree. Can be bind as `v-model`. */
-  modelValue?: M extends true ? NestedItem<T>[] : NestedItem<T>
+  modelValue?: M extends true ? T[number][] : T[number]
   /** The value of the Tree when initially rendered. Use when you do not need to control the state of the Tree. */
-  defaultValue?: M extends true ? NestedItem<T>[] : NestedItem<T>
+  defaultValue?: M extends true ? T[number][] : T[number]
   /** Whether multiple options can be selected or not. */
   multiple?: M & boolean
   class?: any
@@ -85,15 +85,14 @@ export type TreeEmits<T extends TreeItem[] = TreeItem[], M extends boolean = fal
 type SlotProps<T extends TreeItem> = (props: { item: T, index: number, level: number, expanded: boolean, selected: boolean }) => any
 
 export type TreeSlots<
-  A extends TreeItem[] = TreeItem[],
-  T extends NestedItem<A> = NestedItem<A>
+  T extends TreeItem[] = TreeItem[]
 > = {
-  'item-wrapper': SlotProps<T>
-  'item': SlotProps<T>
-  'item-leading': SlotProps<T>
-  'item-label': SlotProps<T>
-  'item-trailing': SlotProps<T>
-} & DynamicSlots<T, undefined, { index: number, level: number, expanded: boolean, selected: boolean }>
+  'item-wrapper': SlotProps<T[number]>
+  'item': SlotProps<T[number]>
+  'item-leading': SlotProps<T[number]>
+  'item-label': SlotProps<T[number]>
+  'item-trailing': SlotProps<T[number]>
+} & DynamicSlots<T[number], undefined, { index: number, level: number, expanded: boolean, selected: boolean }>
 
 </script>
 
@@ -125,25 +124,25 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.tree || {}) 
   size: props.size
 }))
 
-function getItemLabel<Item extends NestedItem<T>>(item: Item): string {
+function getItemLabel<Item extends T[number]>(item: Item): string {
   return get(item, props.labelKey as string)
 }
 
-function getItemKey<Item extends NestedItem<T>>(item: Item): string {
+function getItemKey<Item extends T[number]>(item: Item): string {
   return props.getKey
     ? props.getKey(item)
     : getItemLabel(item)
 }
 
-function getDefaultOpenedItems(item: NestedItem<T>): string[] {
+function getDefaultOpenedItems(item: T[number]): string[] {
   const currentItem = item.defaultExpanded ? getItemKey(item) : null
-  const childItems = item.children?.flatMap((child: NestedItem<T>) => getDefaultOpenedItems(child)) ?? []
+  const childItems = item.children?.flatMap((child: T[number]) => getDefaultOpenedItems(child)) ?? []
 
   return [currentItem, ...childItems].filter(Boolean) as string[]
 }
 
 const defaultExpanded = computed(() =>
-  props.defaultExpanded ?? props.items?.flatMap(item => getDefaultOpenedItems(item as NestedItem<T>))
+  props.defaultExpanded ?? props.items?.flatMap(item => getDefaultOpenedItems(item))
 )
 </script>
 
@@ -162,7 +161,8 @@ const defaultExpanded = computed(() =>
     >
       <slot
         :name="((item.slot ? `${item.slot}-wrapper` : 'item-wrapper') as keyof TreeSlots<T>)"
-        v-bind="{ item, index, level, expanded: isExpanded, selected: isSelected }"
+        v-bind="{ index, level, expanded: isExpanded, selected: isSelected }"
+        :item="(item as Extract<T[number], { slot: string; }>)"
       >
         <button
           type="button"
@@ -170,8 +170,16 @@ const defaultExpanded = computed(() =>
           :data-expanded="isExpanded"
           :class="ui.link({ class: [props.ui?.link, item.ui?.link, item.class], selected: isSelected, disabled: item.disabled || disabled })"
         >
-          <slot :name="((item.slot || 'item') as keyof TreeSlots<T>)" v-bind="{ index, level, expanded: isExpanded, selected: isSelected }" :item="(item as Extract<NestedItem<T>, { slot: string; }>)">
-            <slot :name="((item.slot ? `${item.slot}-leading`: 'item-leading') as keyof TreeSlots<T>)" v-bind="{ index, level, expanded: isExpanded, selected: isSelected }" :item="(item as Extract<NestedItem<T>, { slot: string; }>)">
+          <slot
+            :name="((item.slot || 'item') as keyof TreeSlots<T>)"
+            v-bind="{ index, level, expanded: isExpanded, selected: isSelected }"
+            :item="(item as Extract<T[number], { slot: string; }>)"
+          >
+            <slot
+              :name="((item.slot ? `${item.slot}-leading`: 'item-leading') as keyof TreeSlots<T>)"
+              v-bind="{ index, level, expanded: isExpanded, selected: isSelected }"
+              :item="(item as Extract<T[number], { slot: string; }>)"
+            >
               <UIcon
                 v-if="item.icon"
                 :name="item.icon"
@@ -185,14 +193,15 @@ const defaultExpanded = computed(() =>
             </slot>
 
             <span
-              v-if="getItemLabel(item as NestedItem<T>) || !!slots[(item.slot ? `${item.slot}-label`: 'item-label') as keyof TreeSlots<T>]"
+              v-if="getItemLabel(item) || !!slots[(item.slot ? `${item.slot}-label`: 'item-label') as keyof TreeSlots<T>]"
               :class="ui.linkLabel({ class: [props.ui?.linkLabel, item.ui?.linkLabel] })"
             >
               <slot
                 :name="((item.slot ? `${item.slot}-label`: 'item-label') as keyof TreeSlots<T>)"
-                v-bind="{ item, index, level, expanded: isExpanded, selected: isSelected }"
+                v-bind="{ index, level, expanded: isExpanded, selected: isSelected }"
+                :item="(item as Extract<T[number], { slot: string; }>)"
               >
-                {{ getItemLabel(item as NestedItem<T>) }}
+                {{ getItemLabel(item) }}
               </slot>
             </span>
 
@@ -202,7 +211,8 @@ const defaultExpanded = computed(() =>
             >
               <slot
                 :name="((item.slot ? `${item.slot}-trailing`: 'item-trailing') as keyof TreeSlots<T>)"
-                v-bind="{ item, index, level, expanded: isExpanded, selected: isSelected }"
+                v-bind="{ index, level, expanded: isExpanded, selected: isSelected }"
+                :item="(item as Extract<T[number], { slot: string; }>)"
               >
                 <UIcon
                   v-if="item.trailingIcon"
@@ -231,7 +241,7 @@ const defaultExpanded = computed(() =>
   </DefineTreeTemplate>
 
   <TreeRoot
-    v-bind="{ ...(rootProps as unknown as TreeRootProps<NestedItem<T>>), ...$attrs }"
+    v-bind="{ ...(rootProps as unknown as TreeRootProps<T[number]>), ...$attrs }"
     :class="ui.root({ class: [props.ui?.root, props.class] })"
     :get-key="getItemKey"
     :default-expanded="defaultExpanded"

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -16,10 +16,6 @@ export type TreeItem = {
   icon?: IconProps['name']
   label?: string
   /**
-   * The unique key of the item. If not provided, the label will be used as the key.
-   */
-  key?: string
-  /**
    * @IconifyIcon
    */
   trailingIcon?: IconProps['name']
@@ -48,16 +44,13 @@ export interface TreeProps<T extends TreeItem[] = TreeItem[], M extends boolean 
    * @defaultValue 'md'
    */
   size?: Tree['variants']['size']
+  /** This function is passed the index of each item and should return a unique key for that item */
+  getKey?: (val: NestedItem<T>) => string
   /**
    * The key used to get the label from the item.
    * @defaultValue 'label'
    */
   labelKey?: GetItemKeys<T>
-  /**
-   * The key used to get the unique key from the item.
-   * @defaultValue 'key'
-   */
-  indexKey?: GetItemKeys<T>
   /**
    * The icon displayed on the right side of a parent node.
    * @defaultValue appConfig.ui.icons.chevronDown
@@ -116,8 +109,7 @@ import UIcon from './Icon.vue'
 defineOptions({ inheritAttrs: false })
 
 const props = withDefaults(defineProps<TreeProps<T, M>>(), {
-  labelKey: 'label',
-  indexKey: 'key'
+  labelKey: 'label'
 })
 const emits = defineEmits<TreeEmits<T[number], M>>()
 const slots = defineSlots<TreeSlots<T>>()
@@ -133,17 +125,19 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.tree || {}) 
   size: props.size
 }))
 
-function getItemLabel<Item extends TreeItem = NestedItem<T>>(item: Item): string {
+function getItemLabel<Item extends NestedItem<T>>(item: Item): string {
   return get(item, props.labelKey as string)
 }
 
-function getItemKey<Item extends TreeItem = NestedItem<T>>(item: Item): string {
-  return get(item, props.indexKey as string) ?? getItemLabel(item)
+function getItemKey<Item extends NestedItem<T>>(item: Item): string {
+  return props.getKey
+    ? props.getKey(item)
+    : getItemLabel(item)
 }
 
 function getDefaultOpenedItems(item: NestedItem<T>): string[] {
   const currentItem = item.defaultExpanded ? getItemKey(item) : null
-  const childItems = item.children?.flatMap((child: TreeItem) => getDefaultOpenedItems(child as NestedItem<T>)) ?? []
+  const childItems = item.children?.flatMap((child: NestedItem<T>) => getDefaultOpenedItems(child)) ?? []
 
   return [currentItem, ...childItems].filter(Boolean) as string[]
 }
@@ -191,14 +185,14 @@ const defaultExpanded = computed(() =>
             </slot>
 
             <span
-              v-if="getItemLabel(item) || !!slots[(item.slot ? `${item.slot}-label`: 'item-label') as keyof TreeSlots<T>]"
+              v-if="getItemLabel(item as NestedItem<T>) || !!slots[(item.slot ? `${item.slot}-label`: 'item-label') as keyof TreeSlots<T>]"
               :class="ui.linkLabel({ class: [props.ui?.linkLabel, item.ui?.linkLabel] })"
             >
               <slot
                 :name="((item.slot ? `${item.slot}-label`: 'item-label') as keyof TreeSlots<T>)"
                 v-bind="{ item, index, level, expanded: isExpanded, selected: isSelected }"
               >
-                {{ getItemLabel(item) }}
+                {{ getItemLabel(item as NestedItem<T>) }}
               </slot>
             </span>
 

--- a/test/components/Tree.spec.ts
+++ b/test/components/Tree.spec.ts
@@ -10,7 +10,7 @@ describe('Tree', () => {
 
   const items: TreeItem[] = [
     {
-      value: 'root',
+      key: 'root',
       label: 'app',
       slot: 'app',
       children: [{
@@ -22,8 +22,8 @@ describe('Tree', () => {
         ]
       }]
     },
-    { value: 'app-vue', label: 'app.vue', icon: 'i-vscode-icons-file-type-vue' },
-    { value: 'nuxt-config-ts', label: 'nuxt.config.ts', icon: 'i-vscode-icons-file-type-nuxt' }
+    { key: 'app-vue', label: 'app.vue', icon: 'i-vscode-icons-file-type-vue' },
+    { key: 'nuxt-config-ts', label: 'nuxt.config.ts', icon: 'i-vscode-icons-file-type-nuxt' }
   ]
 
   const props = { items }
@@ -37,8 +37,8 @@ describe('Tree', () => {
     ['with expanded', { props: { ...props, expanded: [items[0]] } }],
     ['with defaultExpanded', { props: { ...props, defaultExpanded: [items[0]] } }],
     // Key mapping
-    ['with valueKey', { props: { ...props, valueKey: 'label' } }],
-    ['with labelKey', { props: { ...props, labelKey: 'value' } }],
+    ['with indexKey', { props: { ...props, indexKey: 'label' } }],
+    ['with labelKey', { props: { ...props, labelKey: 'key' } }],
     // Multiple
     ['with multiple', { props: { ...props, multiple: true } }],
     ['with multiple and modelValue', { props: { ...props, multiple: true, modelValue: [items[0], items[1]] } }],
@@ -71,15 +71,13 @@ describe('Tree', () => {
   })
 
   test('should have the correct types', () => {
-    // with default `value` key
     expectEmitPayloadType('update:modelValue', () => Tree({
-      items: [{ label: 'foo', value: 'bar' }, { label: 'baz', value: 'qux' }]
-    })).toEqualTypeOf<[string]>()
+      items: [{ label: 'foo' }, { label: 'baz' }]
+    })).toEqualTypeOf<[{ label: string }]>()
 
-    // with custom value key
     expectEmitPayloadType('update:modelValue', () => Tree({
-      items: [{ label: 'foo', value: 'bar', id: 1 }, { label: 'baz', value: 'qux', id: 2 }],
-      valueKey: 'id'
-    })).toEqualTypeOf<[number]>()
+      items: [{ label: 'foo', id: 1 }, { label: 'baz', id: 2 }],
+      indexKey: 'id'
+    })).toEqualTypeOf<[{ label: string, id: number }]>()
   })
 })

--- a/test/components/Tree.spec.ts
+++ b/test/components/Tree.spec.ts
@@ -10,7 +10,7 @@ describe('Tree', () => {
 
   const items: TreeItem[] = [
     {
-      key: 'root',
+      id: 'root',
       label: 'app',
       slot: 'app',
       children: [{
@@ -22,8 +22,8 @@ describe('Tree', () => {
         ]
       }]
     },
-    { key: 'app-vue', label: 'app.vue', icon: 'i-vscode-icons-file-type-vue' },
-    { key: 'nuxt-config-ts', label: 'nuxt.config.ts', icon: 'i-vscode-icons-file-type-nuxt' }
+    { id: 'app-vue', label: 'app.vue', icon: 'i-vscode-icons-file-type-vue' },
+    { id: 'nuxt-config-ts', label: 'nuxt.config.ts', icon: 'i-vscode-icons-file-type-nuxt' }
   ]
 
   const props = { items }
@@ -37,8 +37,8 @@ describe('Tree', () => {
     ['with expanded', { props: { ...props, expanded: [items[0]] } }],
     ['with defaultExpanded', { props: { ...props, defaultExpanded: [items[0]] } }],
     // Key mapping
-    ['with indexKey', { props: { ...props, indexKey: 'label' } }],
-    ['with labelKey', { props: { ...props, labelKey: 'key' } }],
+    ['with labelKey', { props: { ...props, labelKey: 'id' } }],
+    ['with getKey', { props: { ...props, getKey: (item: TreeItem) => item.id } }],
     // Multiple
     ['with multiple', { props: { ...props, multiple: true } }],
     ['with multiple and modelValue', { props: { ...props, multiple: true, modelValue: [items[0], items[1]] } }],
@@ -76,8 +76,8 @@ describe('Tree', () => {
     })).toEqualTypeOf<[{ label: string }]>()
 
     expectEmitPayloadType('update:modelValue', () => Tree({
-      items: [{ label: 'foo', id: 1 }, { label: 'baz', id: 2 }],
-      indexKey: 'id'
-    })).toEqualTypeOf<[{ label: string, id: number }]>()
+      items: [{ label: 'foo', id: 'one' }, { label: 'baz', id: 'two' }],
+      getKey: i => i.id
+    })).toEqualTypeOf<[{ label: string, id: string }]>()
   })
 })

--- a/test/components/__snapshots__/Tree-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Tree-vue.spec.ts.snap
@@ -204,6 +204,24 @@ exports[`Tree > renders with expandedIcon correctly 1`] = `
 </ul>"
 `;
 
+exports[`Tree > renders with indexKey correctly 1`] = `
+"<ul class="relative isolate" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="tree">
+  <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-expanded="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="shrink-0 size-5"></svg><span class="truncate">app</span><span class="ms-auto inline-flex gap-1.5 items-center"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="shrink-0 transform transition-transform duration-200 group-data-[expanded=true]:rotate-180 size-5"></svg></span></button>
+    <!--v-if-->
+  </li>
+  <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="shrink-0 size-5"></svg><span class="truncate">app.vue</span>
+      <!--v-if-->
+    </button>
+    <!--v-if-->
+  </li>
+  <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="shrink-0 size-5"></svg><span class="truncate">nuxt.config.ts</span>
+      <!--v-if-->
+    </button>
+    <!--v-if-->
+  </li>
+</ul>"
+`;
+
 exports[`Tree > renders with item slot correctly 1`] = `
 "<ul class="relative isolate" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="tree">
   <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-expanded="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="shrink-0 size-5"></svg><span class="truncate">app</span><span class="ms-auto inline-flex gap-1.5 items-center"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="shrink-0 transform transition-transform duration-200 group-data-[expanded=true]:rotate-180 size-5"></svg></span></button>
@@ -509,24 +527,6 @@ exports[`Tree > renders with ui correctly 1`] = `
     <!--v-if-->
   </li>
   <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors font-bold"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="shrink-0 size-5"></svg><span class="truncate">nuxt.config.ts</span>
-      <!--v-if-->
-    </button>
-    <!--v-if-->
-  </li>
-</ul>"
-`;
-
-exports[`Tree > renders with valueKey correctly 1`] = `
-"<ul class="relative isolate" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="tree">
-  <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-expanded="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="shrink-0 size-5"></svg><span class="truncate">app</span><span class="ms-auto inline-flex gap-1.5 items-center"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="shrink-0 transform transition-transform duration-200 group-data-[expanded=true]:rotate-180 size-5"></svg></span></button>
-    <!--v-if-->
-  </li>
-  <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="shrink-0 size-5"></svg><span class="truncate">app.vue</span>
-      <!--v-if-->
-    </button>
-    <!--v-if-->
-  </li>
-  <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="shrink-0 size-5"></svg><span class="truncate">nuxt.config.ts</span>
       <!--v-if-->
     </button>
     <!--v-if-->

--- a/test/components/__snapshots__/Tree-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Tree-vue.spec.ts.snap
@@ -204,7 +204,7 @@ exports[`Tree > renders with expandedIcon correctly 1`] = `
 </ul>"
 `;
 
-exports[`Tree > renders with indexKey correctly 1`] = `
+exports[`Tree > renders with getKey correctly 1`] = `
 "<ul class="relative isolate" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="tree">
   <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-expanded="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="shrink-0 size-5"></svg><span class="truncate">app</span><span class="ms-auto inline-flex gap-1.5 items-center"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" class="shrink-0 transform transition-transform duration-200 group-data-[expanded=true]:rotate-180 size-5"></svg></span></button>
     <!--v-if-->

--- a/test/components/__snapshots__/Tree.spec.ts.snap
+++ b/test/components/__snapshots__/Tree.spec.ts.snap
@@ -204,6 +204,24 @@ exports[`Tree > renders with expandedIcon correctly 1`] = `
 </ul>"
 `;
 
+exports[`Tree > renders with indexKey correctly 1`] = `
+"<ul class="relative isolate" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="tree">
+  <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-expanded="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><span class="iconify i-lucide:folder shrink-0 size-5" aria-hidden="true"></span><span class="truncate">app</span><span class="ms-auto inline-flex gap-1.5 items-center"><span class="iconify i-lucide:chevron-down shrink-0 transform transition-transform duration-200 group-data-[expanded=true]:rotate-180 size-5" aria-hidden="true"></span></span></button>
+    <!--v-if-->
+  </li>
+  <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><span class="iconify i-vscode-icons:file-type-vue shrink-0 size-5" aria-hidden="true"></span><span class="truncate">app.vue</span>
+      <!--v-if-->
+    </button>
+    <!--v-if-->
+  </li>
+  <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><span class="iconify i-vscode-icons:file-type-nuxt shrink-0 size-5" aria-hidden="true"></span><span class="truncate">nuxt.config.ts</span>
+      <!--v-if-->
+    </button>
+    <!--v-if-->
+  </li>
+</ul>"
+`;
+
 exports[`Tree > renders with item slot correctly 1`] = `
 "<ul class="relative isolate" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="tree">
   <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-expanded="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><span class="iconify i-lucide:folder shrink-0 size-5" aria-hidden="true"></span><span class="truncate">app</span><span class="ms-auto inline-flex gap-1.5 items-center"><span class="iconify i-lucide:chevron-down shrink-0 transform transition-transform duration-200 group-data-[expanded=true]:rotate-180 size-5" aria-hidden="true"></span></span></button>
@@ -509,24 +527,6 @@ exports[`Tree > renders with ui correctly 1`] = `
     <!--v-if-->
   </li>
   <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors font-bold"><span class="iconify i-vscode-icons:file-type-nuxt shrink-0 size-5" aria-hidden="true"></span><span class="truncate">nuxt.config.ts</span>
-      <!--v-if-->
-    </button>
-    <!--v-if-->
-  </li>
-</ul>"
-`;
-
-exports[`Tree > renders with valueKey correctly 1`] = `
-"<ul class="relative isolate" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="tree">
-  <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-expanded="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><span class="iconify i-lucide:folder shrink-0 size-5" aria-hidden="true"></span><span class="truncate">app</span><span class="ms-auto inline-flex gap-1.5 items-center"><span class="iconify i-lucide:chevron-down shrink-0 transform transition-transform duration-200 group-data-[expanded=true]:rotate-180 size-5" aria-hidden="true"></span></span></button>
-    <!--v-if-->
-  </li>
-  <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><span class="iconify i-vscode-icons:file-type-vue shrink-0 size-5" aria-hidden="true"></span><span class="truncate">app.vue</span>
-      <!--v-if-->
-    </button>
-    <!--v-if-->
-  </li>
-  <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><span class="iconify i-vscode-icons:file-type-nuxt shrink-0 size-5" aria-hidden="true"></span><span class="truncate">nuxt.config.ts</span>
       <!--v-if-->
     </button>
     <!--v-if-->

--- a/test/components/__snapshots__/Tree.spec.ts.snap
+++ b/test/components/__snapshots__/Tree.spec.ts.snap
@@ -204,7 +204,7 @@ exports[`Tree > renders with expandedIcon correctly 1`] = `
 </ul>"
 `;
 
-exports[`Tree > renders with indexKey correctly 1`] = `
+exports[`Tree > renders with getKey correctly 1`] = `
 "<ul class="relative isolate" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="tree">
   <li data-reka-collection-item="" tabindex="-1" data-orientation="vertical" class="" role="treeitem" aria-selected="false" aria-expanded="false" aria-level="1" data-indent="1"><button type="button" data-expanded="false" class="relative group w-full flex items-center before:absolute before:inset-y-px before:inset-x-0 before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:ring-inset focus-visible:before:ring-2 focus-visible:before:ring-primary px-2.5 py-1.5 text-sm gap-1.5 hover:not-disabled:text-highlighted hover:not-disabled:before:bg-elevated/50 transition-colors before:transition-colors"><span class="iconify i-lucide:folder shrink-0 size-5" aria-hidden="true"></span><span class="truncate">app</span><span class="ms-auto inline-flex gap-1.5 items-center"><span class="iconify i-lucide:chevron-down shrink-0 transform transition-transform duration-200 group-data-[expanded=true]:rotate-180 size-5" aria-hidden="true"></span></span></button>
     <!--v-if-->


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #3762

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The type support for Tree commponent was almost completely broken, but more importantly it had the same `value` key which other components do use to extract a specific value from the object input, but `UTree` doesn't actually extract the value, it returns the whole object. What it does require is a unique index for each item in the array, which is customizable via `get-key` prop, that when undefined it falls back to `label`, this should cover for most generic uses of the component, even small improper ones.

Intentionally not mentioning this in the v4 migration, as it was broken to begin with in v3.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
