### PR TITLE
fix(InputTags): add blur and focus event handlers on input

### DIFF
--- a/src/runtime/components/InputTags.vue
+++ b/src/runtime/components/InputTags.vue
@@ -157,8 +157,6 @@ defineExpose({
     :name="name"
     :disabled="disabled"
     @update:model-value="onUpdate"
-    @blur="onBlur"
-    @focus="onFocus"
   >
     <TagsInputItem
       v-for="(item, index) in tags"
@@ -186,6 +184,8 @@ defineExpose({
       :placeholder="placeholder"
       :max-length="maxLength"
       :class="ui.input({ class: props.ui?.input })"
+      @blur="onBlur"
+      @focus="onFocus"
     />
 
     <slot />


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #4889 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

According to `TagsInputRoot` from reka, it doesn't support `@focus` or `@blur`, ([ref](https://reka-ui.com/docs/components/tags-input#root)) I believe we need to add these events to the input instead. (`TagsInputInput`)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
