### PR TITLE
fix(Form): remove `joi` and `yup` in favor of @standard-schema/spec

### DIFF
--- a/docs/content/docs/2.components/form.md
+++ b/docs/content/docs/2.components/form.md
@@ -9,7 +9,7 @@ links:
 
 ## Usage
 
-Use the Form component to validate form data using any validation library supporting [Standard Schema](https://standardschema.dev/) such as [Valibot](https://github.com/fabian-hiller/valibot), [Zod](https://github.com/colinhacks/zod), [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi) or [Superstruct](https://github.com/ianstormtaylor/superstruct) or your own validation logic.
+Use the Form component to validate form data using any validation library supporting [Standard Schema](https://github.com/standard-schema/standard-schema) such as [Valibot](https://github.com/fabian-hiller/valibot), [Zod](https://github.com/colinhacks/zod), [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi) or [Superstruct](https://github.com/ianstormtaylor/superstruct) or your own validation logic.
 
 It works with the [FormField](/docs/components/form-field) component to display error messages around form elements automatically.
 
@@ -18,7 +18,7 @@ It works with the [FormField](/docs/components/form-field) component to display 
 It requires two props:
 
 - `state` - a reactive object holding the form's state.
-- `schema` - any [Standard Schema](https://standardschema.dev/) or [Superstruct](https://github.com/ianstormtaylor/superstruct).
+- `schema` - any [Standard Schema](https://github.com/standard-schema/standard-schema) or [Superstruct](https://github.com/ianstormtaylor/superstruct).
 
 ::warning
 **No validation library is included** by default, ensure you **install the one you need**.

--- a/docs/content/docs/2.components/form.md
+++ b/docs/content/docs/2.components/form.md
@@ -9,7 +9,7 @@ links:
 
 ## Usage
 
-Use the Form component to validate form data using validation libraries such as [Valibot](https://github.com/fabian-hiller/valibot), [Zod](https://github.com/colinhacks/zod), [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi), [Superstruct](https://github.com/ianstormtaylor/superstruct) or your own validation logic.
+Use the Form component to validate form data using any validation library supporting [Standard Schema](https://standardschema.dev/) such as [Valibot](https://github.com/fabian-hiller/valibot), [Zod](https://github.com/colinhacks/zod), [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi) or [Superstruct](https://github.com/ianstormtaylor/superstruct) or your own validation logic.
 
 It works with the [FormField](/docs/components/form-field) component to display error messages around form elements automatically.
 
@@ -18,7 +18,7 @@ It works with the [FormField](/docs/components/form-field) component to display 
 It requires two props:
 
 - `state` - a reactive object holding the form's state.
-- `schema` - any [Standard Schema](https://standardschema.dev/) or a schema from [Yup](https://github.com/jquense/yup), [Joi](https://github.com/hapijs/joi) or [Superstruct](https://github.com/ianstormtaylor/superstruct).
+- `schema` - any [Standard Schema](https://standardschema.dev/) or [Superstruct](https://github.com/ianstormtaylor/superstruct).
 
 ::warning
 **No validation library is included** by default, ensure you **install the one you need**.

--- a/package.json
+++ b/package.json
@@ -175,18 +175,34 @@
   },
   "peerDependencies": {
     "@inertiajs/vue3": "^2.0.7",
+    "joi": "^18.0.0",
     "superstruct": "^2.0.0",
     "typescript": "^5.6.3",
-    "vue-router": "^4.5.0"
+    "valibot": "^1.0.0",
+    "vue-router": "^4.5.0",
+    "yup": "^1.7.0",
+    "zod": "^3.24.0 || ^4.0.0"
   },
   "peerDependenciesMeta": {
     "@inertiajs/vue3": {
+      "optional": true
+    },
+    "joi": {
+      "optional": true
+    },
+    "valibot": {
       "optional": true
     },
     "superstruct": {
       "optional": true
     },
     "vue-router": {
+      "optional": true
+    },
+    "yup": {
+      "optional": true
+    },
+    "zod": {
       "optional": true
     }
   },

--- a/package.json
+++ b/package.json
@@ -175,34 +175,18 @@
   },
   "peerDependencies": {
     "@inertiajs/vue3": "^2.0.7",
-    "joi": "^17.13.0",
     "superstruct": "^2.0.0",
     "typescript": "^5.6.3",
-    "valibot": "^1.0.0",
-    "vue-router": "^4.5.0",
-    "yup": "^1.6.0",
-    "zod": "^3.24.0 || ^4.0.0"
+    "vue-router": "^4.5.0"
   },
   "peerDependenciesMeta": {
     "@inertiajs/vue3": {
-      "optional": true
-    },
-    "joi": {
-      "optional": true
-    },
-    "valibot": {
       "optional": true
     },
     "superstruct": {
       "optional": true
     },
     "vue-router": {
-      "optional": true
-    },
-    "yup": {
-      "optional": true
-    },
-    "zod": {
       "optional": true
     }
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,9 +104,6 @@ importers:
       hookable:
         specifier: ^5.5.3
         version: 5.5.3
-      joi:
-        specifier: ^17.13.0
-        version: 17.13.3
       knitwork:
         specifier: ^1.2.0
         version: 1.2.0
@@ -158,9 +155,6 @@ importers:
       unplugin-vue-components:
         specifier: ^29.1.0
         version: 29.1.0(@babel/parser@7.28.3)(@nuxt/kit@4.0.3(magicast@0.3.5))(vue@3.5.21(typescript@5.8.3))
-      valibot:
-        specifier: ^1.0.0
-        version: 1.1.0(typescript@5.8.3)
       vaul-vue:
         specifier: 0.4.1
         version: 0.4.1(reka-ui@2.5.0(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))
@@ -170,12 +164,6 @@ importers:
       vue-router:
         specifier: ^4.5.0
         version: 4.5.1(vue@3.5.21(typescript@5.8.3))
-      yup:
-        specifier: ^1.6.0
-        version: 1.7.1
-      zod:
-        specifier: ^3.24.0 || ^4.0.0
-        version: 4.1.11
     devDependencies:
       '@nuxt/content':
         specifier: ^3.7.1
@@ -1018,18 +1006,12 @@ packages:
   '@hapi/hoek@11.0.7':
     resolution: {integrity: sha512-HV5undWkKzcB4RZUusqOpcgxOaq6VOAH7zhhIr2g3G8NF/MlFO75SjOr2NfuSx0Mh40+1FqCkagKLJRykUWoFQ==}
 
-  '@hapi/hoek@9.3.0':
-    resolution: {integrity: sha512-/c6rf4UJlmHlC9b5BaNvzAcFv7HZ2QHaV0D4/HNlBdvFnvQq8RI4kYdhyPCl7Xj+oWvTWQ8ujhqS53LIgAe6KQ==}
-
   '@hapi/pinpoint@2.0.1':
     resolution: {integrity: sha512-EKQmr16tM8s16vTT3cA5L0kZZcTMU5DUOZTuvpnY738m+jyP3JIUj+Mm1xc1rsLkGBQ/gVnfKYPwOmPg1tUR4Q==}
 
   '@hapi/tlds@1.1.2':
     resolution: {integrity: sha512-1jkwm1WY9VIb6WhdANRmWDkXQUcIRpxqZpSdS+HD9vhoVL3zwoFvP8doQNEgT6k3VST0Ewu50wZnXIceRYp5tw==}
     engines: {node: '>=14.0.0'}
-
-  '@hapi/topo@5.1.0':
-    resolution: {integrity: sha512-foQZKJig7Ob0BMAYBfcJk8d77QtOe7Wo4ox7ff1lQYoNNAb6jwcY1ncdoy2e9wQZzvNy7ODZCYJkK8kzmcAnAg==}
 
   '@hapi/topo@6.0.2':
     resolution: {integrity: sha512-KR3rD5inZbGMrHmgPxsJ9dbi6zEK+C3ZwUwTa+eMwWLz7oijWUTWD2pMSNNYJAU6Qq+65NkxXjqHr/7LM2Xkqg==}
@@ -2244,15 +2226,6 @@ packages:
     resolution: {integrity: sha512-3NgmNyH3l/Hv6EvsWJbsvpcpUba6R8IREQ83nH83cyakCw7uM1arZKNfHwv1Wz6jgqrF/j4x5ELvR6PnK9nTcA==}
     engines: {node: '>= 8.0.0'}
     hasBin: true
-
-  '@sideway/address@4.1.5':
-    resolution: {integrity: sha512-IqO/DUQHUkPeixNQ8n0JA6102hT9CmaljNTPmQ1u8MEhBo/R4Q8eKLN/vGZxuebwOroDB4cbpjheD4+/sKFK4Q==}
-
-  '@sideway/formula@3.0.1':
-    resolution: {integrity: sha512-/poHZJJVjx3L+zVD6g9KgHfYnb443oi7wLu/XKojDviHy6HOEOA6z1Trk5aR1dGcmPenJEgb2sK2I80LeS3MIg==}
-
-  '@sideway/pinpoint@2.0.0':
-    resolution: {integrity: sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==}
 
   '@sindresorhus/is@4.6.0':
     resolution: {integrity: sha512-t09vSN3MdfsyCHoFcTRCH/iUtG7OJ0CsjzB8cjAmKc/va/kIgeDI/TxsigdncE/4be734m0cvIYwNaV4i2XqAw==}
@@ -4957,9 +4930,6 @@ packages:
   jiti@2.5.1:
     resolution: {integrity: sha512-twQoecYPiVA5K/h6SxtORw/Bs3ar+mLUtoPSc7iMXzQzK8d7eJ/R09wmTwAjiamETn1cXYPGfNnu7DMoHgu12w==}
     hasBin: true
-
-  joi@17.13.3:
-    resolution: {integrity: sha512-otDA4ldcIx+ZXsKHWmp0YizCweVRZG96J10b0FevjfuncLO1oX59THoAmHkNubYJ+9gWsYsp5k8v4ib6oDv1fA==}
 
   joi@18.0.1:
     resolution: {integrity: sha512-IiQpRyypSnLisQf3PwuN2eIHAsAIGZIrLZkd4zdvIar2bDyhM91ubRjy8a3eYablXsh9BeI/c7dmPYHca5qtoA==}
@@ -8290,15 +8260,9 @@ snapshots:
 
   '@hapi/hoek@11.0.7': {}
 
-  '@hapi/hoek@9.3.0': {}
-
   '@hapi/pinpoint@2.0.1': {}
 
   '@hapi/tlds@1.1.2': {}
-
-  '@hapi/topo@5.1.0':
-    dependencies:
-      '@hapi/hoek': 9.3.0
 
   '@hapi/topo@6.0.2':
     dependencies:
@@ -9806,14 +9770,6 @@ snapshots:
     dependencies:
       fflate: 0.7.4
       string.prototype.codepointat: 0.2.1
-
-  '@sideway/address@4.1.5':
-    dependencies:
-      '@hapi/hoek': 9.3.0
-
-  '@sideway/formula@3.0.1': {}
-
-  '@sideway/pinpoint@2.0.0': {}
 
   '@sindresorhus/is@4.6.0': {}
 
@@ -12749,14 +12705,6 @@ snapshots:
   jiti@1.21.7: {}
 
   jiti@2.5.1: {}
-
-  joi@17.13.3:
-    dependencies:
-      '@hapi/hoek': 9.3.0
-      '@hapi/topo': 5.1.0
-      '@sideway/address': 4.1.5
-      '@sideway/formula': 3.0.1
-      '@sideway/pinpoint': 2.0.0
 
   joi@18.0.1:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -104,6 +104,9 @@ importers:
       hookable:
         specifier: ^5.5.3
         version: 5.5.3
+      joi:
+        specifier: ^18.0.0
+        version: 18.0.1
       knitwork:
         specifier: ^1.2.0
         version: 1.2.0
@@ -155,6 +158,9 @@ importers:
       unplugin-vue-components:
         specifier: ^29.1.0
         version: 29.1.0(@babel/parser@7.28.3)(@nuxt/kit@4.0.3(magicast@0.3.5))(vue@3.5.21(typescript@5.8.3))
+      valibot:
+        specifier: ^1.0.0
+        version: 1.1.0(typescript@5.8.3)
       vaul-vue:
         specifier: 0.4.1
         version: 0.4.1(reka-ui@2.5.0(typescript@5.8.3)(vue@3.5.21(typescript@5.8.3)))(vue@3.5.21(typescript@5.8.3))
@@ -164,6 +170,12 @@ importers:
       vue-router:
         specifier: ^4.5.0
         version: 4.5.1(vue@3.5.21(typescript@5.8.3))
+      yup:
+        specifier: ^1.7.0
+        version: 1.7.1
+      zod:
+        specifier: ^3.24.0 || ^4.0.0
+        version: 4.1.11
     devDependencies:
       '@nuxt/content':
         specifier: ^3.7.1

--- a/src/runtime/types/form.ts
+++ b/src/runtime/types/form.ts
@@ -1,7 +1,5 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { ComputedRef, DeepReadonly, Ref } from 'vue'
-import type { Schema as JoiSchema } from 'joi'
-import type { ObjectSchema as YupObjectSchema } from 'yup'
 import type { GetObjectField } from './utils'
 import type { Struct as SuperstructSchema } from 'superstruct'
 
@@ -22,25 +20,19 @@ export interface Form<S extends FormSchema> {
 }
 
 export type FormSchema<I extends object = object, O extends object = I>
-  = | YupObjectSchema<I>
-    | JoiSchema<I>
-    | SuperstructSchema<any, any>
+  = | SuperstructSchema<any, any>
     | StandardSchemaV1<I, O>
 
 // Define a utility type to infer the input type based on the schema type
 export type InferInput<Schema> = Schema extends StandardSchemaV1 ? StandardSchemaV1.InferInput<Schema>
-  : Schema extends YupObjectSchema<infer I> ? I
-    : Schema extends JoiSchema<infer I> ? I
-      : Schema extends SuperstructSchema<infer I, any> ? I
-        : Schema extends StandardSchemaV1 ? StandardSchemaV1.InferInput<Schema>
-          : never
+  : Schema extends SuperstructSchema<infer I, any> ? I
+    : Schema extends StandardSchemaV1 ? StandardSchemaV1.InferInput<Schema>
+      : never
 
 // Define a utility type to infer the output type based on the schema type
 export type InferOutput<Schema> = Schema extends StandardSchemaV1 ? StandardSchemaV1.InferOutput<Schema>
-  : Schema extends YupObjectSchema<infer O> ? O
-    : Schema extends JoiSchema<infer O> ? O
-      : Schema extends SuperstructSchema<infer O, any> ? O
-        : never
+  : Schema extends SuperstructSchema<infer O, any> ? O
+    : never
 
 export type FormData<S extends FormSchema, T extends boolean = true> = T extends true ? InferOutput<S> : InferInput<S>
 

--- a/src/runtime/utils/form.ts
+++ b/src/runtime/utils/form.ts
@@ -1,16 +1,6 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
-import type { ValidationError as JoiError, Schema as JoiSchema } from 'joi'
-import type { ObjectSchema as YupObjectSchema, ValidationError as YupError } from 'yup'
 import type { Struct } from 'superstruct'
 import type { FormSchema, ValidateReturnSchema } from '../types/form'
-
-export function isYupSchema(schema: any): schema is YupObjectSchema<any> {
-  return schema.validate && schema.__isYupSchema__
-}
-
-export function isYupError(error: any): error is YupError {
-  return error.inner !== undefined
-}
 
 export function isSuperStructSchema(schema: any): schema is Struct<any, any> {
   return (
@@ -19,14 +9,6 @@ export function isSuperStructSchema(schema: any): schema is Struct<any, any> {
     && typeof schema.validator === 'function'
     && typeof schema.refiner === 'function'
   )
-}
-
-export function isJoiSchema(schema: any): schema is JoiSchema {
-  return schema.validateAsync !== undefined && schema.id !== undefined
-}
-
-export function isJoiError(error: any): error is JoiError {
-  return error.isJoi === true
 }
 
 export function isStandardSchema(schema: any): schema is StandardSchemaV1 {
@@ -55,33 +37,6 @@ export async function validateStandardSchema(
   }
 }
 
-async function validateYupSchema(
-  state: any,
-  schema: YupObjectSchema<any>
-): Promise<ValidateReturnSchema<typeof state>> {
-  try {
-    const result = await schema.validate(state, { abortEarly: false })
-    return {
-      errors: null,
-      result
-    }
-  } catch (error) {
-    if (isYupError(error)) {
-      const errors = error.inner.map(issue => ({
-        name: issue.path ?? '',
-        message: issue.message
-      }))
-
-      return {
-        errors,
-        result: null
-      }
-    } else {
-      throw error
-    }
-  }
-}
-
 async function validateSuperstructSchema(state: any, schema: Struct<any, any>): Promise<ValidateReturnSchema<typeof state>> {
   const [err, result] = schema.validate(state)
   if (err) {
@@ -102,40 +57,9 @@ async function validateSuperstructSchema(state: any, schema: Struct<any, any>): 
   }
 }
 
-async function validateJoiSchema(
-  state: any,
-  schema: JoiSchema
-): Promise<ValidateReturnSchema<typeof state>> {
-  try {
-    const result = await schema.validateAsync(state, { abortEarly: false })
-    return {
-      errors: null,
-      result
-    }
-  } catch (error) {
-    if (isJoiError(error)) {
-      const errors = error.details.map(issue => ({
-        name: issue.path.join('.'),
-        message: issue.message
-      }))
-
-      return {
-        errors,
-        result: null
-      }
-    } else {
-      throw error
-    }
-  }
-}
-
 export function validateSchema<T extends object>(state: T, schema: FormSchema<T>): Promise<ValidateReturnSchema<typeof state>> {
   if (isStandardSchema(schema)) {
     return validateStandardSchema(state, schema)
-  } else if (isJoiSchema(schema)) {
-    return validateJoiSchema(state, schema)
-  } else if (isYupSchema(schema)) {
-    return validateYupSchema(state, schema)
   } else if (isSuperStructSchema(schema)) {
     return validateSuperstructSchema(state, schema)
   } else {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Considering that Joi and Yup are now [part of the `@standard-schema/spec`](https://github.com/standard-schema/standard-schema?tab=readme-ov-file#what-schema-libraries-implement-the-spec) we nolonger need specify them. I've also removed them from peer deps (as well as valibot and zod), as we should either add all the standard-schema supported libs or none of them. The only exeption is [`superstruct` which doesn't yet support it](https://github.com/ianstormtaylor/superstruct/issues/1291).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
