### PR TITLE
docs(mcp): fix configuration example for Zed

### DIFF
--- a/docs/content/docs/1.getting-started/7.ai/1.mcp.md
+++ b/docs/content/docs/1.getting-started/7.ai/1.mcp.md
@@ -202,8 +202,9 @@ Or manually create/update `.cursor/mcp.json` in your project root:
   "context_servers": {
     "nuxt-ui": {
       "source": "custom",
-      "type": "http",
-      "url": "https://ui.nuxt.com/mcp"
+      "command": "npx",
+      "args": ["mcp-remote", "https://ui.nuxt.com/mcp"],
+      "env": {}
     }
   }
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
Resolves #5051 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The documentation for hooking up the Nuxt UI MCP server within Zed was incorrect as the fields `type` and `url` are not available. The settings fields of `command` and `args` were needed. 

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
