### PR TITLE
docs(mcp): fix configuration example for VS Code

### DIFF
--- a/docs/content/docs/1.getting-started/7.ai/1.mcp.md
+++ b/docs/content/docs/1.getting-started/7.ai/1.mcp.md
@@ -163,8 +163,8 @@ Or manually create/update `.cursor/mcp.json` in your project root:
 {
   "servers": {
     "nuxt-ui": {
-      "type": "http",
-      "url": "https://ui.nuxt.com/mcp"
+      "command": "cmd",
+      "args": ["/c","npx","-y","mcp-remote","https://ui.nuxt.com/mcp"]
     }
   }
 }


### PR DESCRIPTION
Update the mcp server configuration for VS code

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The documentation for hooking up the Nuxt UI MCP server within VS code was incorrect as the fields` type` and `url `are not available. The settings fields of `command` and `args` were needed.
This configuration is the same for Zed Editor windows's version
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
