### PR TITLE
fix(Carousel): invert arrow keys in RTL direction

### DIFF
--- a/src/runtime/components/Carousel.vue
+++ b/src/runtime/components/Carousel.vue
@@ -231,8 +231,15 @@ function scrollTo(index: number) {
 }
 
 function onKeyDown(event: KeyboardEvent) {
-  const prevKey = props.orientation === 'vertical' ? 'ArrowUp' : 'ArrowLeft'
-  const nextKey = props.orientation === 'vertical' ? 'ArrowDown' : 'ArrowRight'
+  let prevKey
+  let nextKey
+  if (props.orientation === 'horizontal') {
+    prevKey = dir.value === 'ltr' ? 'ArrowLeft' : 'ArrowRight'
+    nextKey = dir.value === 'ltr' ? 'ArrowRight' : 'ArrowLeft'
+  } else {
+    prevKey = 'ArrowUp'
+    nextKey = 'ArrowDown'
+  }
 
   if (event.key === prevKey) {
     event.preventDefault()


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #5048

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This is an enhancement when using the keyboard to change carousel slides.

When locale is in right-to-left (RTL) direction, left arrow key should move to the left, right arrow key to the right. This change makes the arrow keys matching the carousel arrow buttons behavior.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
