### PR TITLE
docs(content): fix source paths and warn in migration guide

### DIFF
--- a/docs/content/docs/1.getting-started/3.migration/1.v4.md
+++ b/docs/content/docs/1.getting-started/3.migration/1.v4.md
@@ -165,6 +165,15 @@ export default defineConfig({
 - @import "@nuxt/ui-pro";
 + @import "@nuxt/ui";
 ```
+
+::::info
+If you are upgrading to Nuxt 4 at the same time as Nuxt UI v4, make sure to update the `source` attribute to match the new directory structure.
+
+```diff [app/assets/css/main.css]
+- @source "../../content";
++ @source "../../../content";
+```
+::::
 :::
 
 #vue

--- a/docs/content/docs/1.getting-started/3.migration/1.v4.md
+++ b/docs/content/docs/1.getting-started/3.migration/1.v4.md
@@ -171,7 +171,7 @@ If you are upgrading to Nuxt 4 at the same time as Nuxt UI v4, make sure to upda
 
 ```diff [app/assets/css/main.css]
 - @source "../../content";
-+ @source "../../../content";
++ @source "../../../content/**/*";
 ```
 ::::
 :::

--- a/docs/content/docs/1.getting-started/3.migration/1.v4.md
+++ b/docs/content/docs/1.getting-started/3.migration/1.v4.md
@@ -166,14 +166,18 @@ export default defineConfig({
 + @import "@nuxt/ui";
 ```
 
-::::info
-If you are upgrading to Nuxt 4 at the same time as Nuxt UI v4, make sure to update the `source` attribute to match the new directory structure.
+::::warning
+If you are upgrading to Nuxt 4 at the same time as Nuxt UI v4, make sure to update the `@source` directive to match the new directory structure.
 
 ```diff [app/assets/css/main.css]
+@import "tailwindcss";
+@import "@nuxt/ui";
+
 - @source "../../content/**/*";
 + @source "../../../content/**/*";
 ```
 ::::
+
 :::
 
 #vue
@@ -313,7 +317,7 @@ The `Form` component has been improved in v4 with better state management and ne
 
 ### Removed deprecated utilities
 
-Some **Nuxt Content utilities** that were previously available in Nuxt UI Pro have been **removed** in v4:  
+Some **Nuxt Content utilities** that were previously available in Nuxt UI Pro have been **removed** in v4:
 
 - `findPageBreadcrumb`
 - `findPageHeadline`

--- a/docs/content/docs/1.getting-started/3.migration/1.v4.md
+++ b/docs/content/docs/1.getting-started/3.migration/1.v4.md
@@ -170,7 +170,7 @@ export default defineConfig({
 If you are upgrading to Nuxt 4 at the same time as Nuxt UI v4, make sure to update the `source` attribute to match the new directory structure.
 
 ```diff [app/assets/css/main.css]
-- @source "../../content";
+- @source "../../content/**/*";
 + @source "../../../content/**/*";
 ```
 ::::

--- a/docs/content/docs/1.getting-started/6.integrations/5.content.md
+++ b/docs/content/docs/1.getting-started/6.integrations/5.content.md
@@ -55,7 +55,7 @@ To fix this, use the [`@source` directive](https://tailwindcss.com/docs/function
 @import "tailwindcss";
 @import "@nuxt/ui";
 
-@source "../content/**/*";
+@source "../../../content/**/*";
 ```
 
 This ensures that:
@@ -65,8 +65,8 @@ This ensures that:
 
 ::tip
 You can also use glob patterns to be more specific about which files to scan:
-- `@source "../content/docs/**/*.md"` - Only scan markdown in the docs folder
-- `@source "../content/**/*.{md,yml}"` - Include both markdown and YAML files
+- `@source "../../../content/docs/**/*.md"` - Only scan markdown in the docs folder
+- `@source "../../../content/**/*.{md,yml}"` - Include both markdown and YAML files
 ::
 
 ::note{to="https://tailwindcss.com/docs/detecting-classes-in-source-files" target="_blank"}


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

I think there might be an issue with the `source` suggested in the documentation. It doesn’t match what I have on my side, nor what’s shown in the docs (https://github.com/nuxt/ui/blob/v4/docs/app/assets/css/main.css#L4). I believe there might be an error.


### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
