### PR TITLE
fix(useKbd): update escape key from `⎋` to `Esc`

### DIFF
--- a/src/runtime/composables/useKbd.ts
+++ b/src/runtime/composables/useKbd.ts
@@ -19,7 +19,7 @@ export const kbdKeysMap = {
   enter: '↵',
   delete: '⌦',
   backspace: '⌫',
-  escape: '⎋',
+  escape: 'Esc',
   tab: '⇥',
   capslock: '⇪',
   arrowup: '↑',


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #4940 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The symbol for 'Escape' Kdb binding is outdated - 'Esc' is used consistently across other apps, keyboards and languages.

The value is updated in the useKdb compostable.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
