### PR TITLE
docs(color-mode): remove ClientOnly, simplify icon logic, add tooltip

### DIFF
--- a/docs/content/docs/1.getting-started/6.integrations/3.color-mode/1.nuxt.md
+++ b/docs/content/docs/1.getting-started/6.integrations/3.color-mode/1.nuxt.md
@@ -30,21 +30,23 @@ const isDark = computed({
     colorMode.preference = _isDark ? 'dark' : 'light'
   }
 })
+
+const icon = computed(() =>
+  colorMode.preference === "dark" || colorMode.preference === "system"
+    ? "i-lucide-moon"
+    : "i-lucide-sun",
+)
 </script>
 
 <template>
-  <ClientOnly v-if="!colorMode?.forced">
+  <UTooltip :text="`Switch to ${isDark ? 'light' : 'dark'} mode`">
     <UButton
-      :icon="isDark ? 'i-lucide-moon' : 'i-lucide-sun'"
+      :icon="icon"
       color="neutral"
       variant="ghost"
       @click="isDark = !isDark"
     />
-
-    <template #fallback>
-      <div class="size-8" />
-    </template>
-  </ClientOnly>
+  </UTooltip>
 </template>
 ```
 


### PR DESCRIPTION
- Faster initial render by avoiding ClientOnly in the example
- Single computed for icon selection using colorMode.preference
- Add tooltip and aria-label for better UX/a11y
- Add small description tweak