### PR TITLE
docs(llms): add proper spacing to text

### DIFF
--- a/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
+++ b/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
@@ -20,9 +20,7 @@ We provide LLMs.txt routes to help AI tools access our documentation:
 ## Choosing the Right File
 
 ::note{icon="i-lucide-info"}
-**Most users should start with `/llms.txt`** - it contains all essential information and works with standard LLM context windows. 
-
-Use `/llms-full.txt` only if you need comprehensive implementation examples and your AI tool supports large contexts (200K+ tokens).
+**Most users should start with `/llms.txt`** - it contains all essential information and works with standard LLM context windows. Use `/llms-full.txt` only if you need comprehensive implementation examples and your AI tool supports large contexts (200K+ tokens).
 ::
 
 ## Important usage notes

--- a/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
+++ b/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
@@ -20,7 +20,7 @@ We provide LLMs.txt routes to help AI tools access our documentation:
 ## Choosing the Right File
 
 ::note{icon="i-lucide-info"}
-**Most users should start with `/llms.txt`** - it contains all essential information and works with standard LLM context windows.
+**Most users should start with `/llms.txt`** - it contains all essential information and works with standard LLM context windows. 
 
 Use `/llms-full.txt` only if you need comprehensive implementation examples and your AI tool supports large contexts (200K+ tokens).
 ::


### PR DESCRIPTION
There was a space missing so the content read like: '... windows.Use '/llms-full.txt'. Note the missing space after the period, and before the word 'use'.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
There was a space missing so the content read like: '... windows.Use '/llms-full.txt'. Note the missing space after the period, and before the word 'use'.
<img width="921" height="208" alt="Screenshot 2025-10-01 at 4 43 02 PM" src="https://github.com/user-attachments/assets/3e5b62c3-6c2c-48e0-8b6d-ba4de9b4fa8f" />
(Note the lack of space after the words 'context windows').
<!-- Why is this change required? What problem does it solve? -->
It looks bad on the official nuxt ui website.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
