### PR TITLE
docs: correct code example for nuxt-i18n when translations are lazy-loaded

### DIFF
--- a/docs/content/docs/2.components/locale-select.md
+++ b/docs/content/docs/2.components/locale-select.md
@@ -68,11 +68,15 @@ You can use it with Nuxt i18n:
 import * as locales from '@nuxt/ui/locale'
 
 const { locale, setLocale } = useI18n()
+const selectedLang = ref(locale.value) // This ref is needed for lazy loaded translations
+watch(locale, newLocale => {
+    selectedLang.value = newLocale
+})
 </script>
 
 <template>
   <ULocaleSelect
-    v-model="locale"
+    v-model="selectedLang"
     :locales="Object.values(locales)"
     @update:model-value="setLocale($event)"
   />


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The nuxt-i18n docs state that you are not supposed to directly change the value of locale. However, this was the case in the code example, because locale was passed to v-model which caused undesirable behavior. Specifically, this changed the locale before it was loaded from the server. This would result in a console error and the translation key rendering instead of the translation for a brief moment. The watch isn't strictly necessary, I suppose, but nice to ensure the state of locale and selectedLang always match.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
