### PR TITLE
feat(Popover): add `close` method in slots

### DIFF
--- a/docs/content/docs/2.components/popover.md
+++ b/docs/content/docs/2.components/popover.md
@@ -238,9 +238,7 @@ name: 'popover-anchor-slot-example'
 :component-slots
 
 ::note
-`close` is only available when using the `click` mode due to Reka UI having it only for the [
-`Popover`](https://reka-ui.com/docs/components/popover#close-using-slot-props) but not the [
-`HoverCard`](https://reka-ui.com/docs/components/hover-card).
+The `close` function is only available when `mode` is set to `click` because Reka UI exposes this for [`Popover`](https://reka-ui.com/docs/components/popover#close-using-slot-props) but not for [`HoverCard`](https://reka-ui.com/docs/components/hover-card).
 ::
 
 ### Emits

--- a/docs/content/docs/2.components/popover.md
+++ b/docs/content/docs/2.components/popover.md
@@ -237,6 +237,12 @@ name: 'popover-anchor-slot-example'
 
 :component-slots
 
+::note
+`close` is only available when using the `click` mode due to Reka UI having it only for the [
+`Popover`](https://reka-ui.com/docs/components/popover#close-using-slot-props) but not the [
+`HoverCard`](https://reka-ui.com/docs/components/hover-card).
+::
+
 ### Emits
 
 :component-emits

--- a/playgrounds/nuxt/app/pages/components/popover.vue
+++ b/playgrounds/nuxt/app/pages/components/popover.vue
@@ -21,8 +21,10 @@ function send() {
       <UPopover arrow :content="{ side: 'top' }">
         <UButton label="Click me top" color="neutral" variant="outline" />
 
-        <template #content>
-          <div class="w-48 h-16" />
+        <template #content="{ close }">
+          <div class="flex justify-center gap-2 p-4 w-48">
+            <UButton label="Close" color="neutral" @click="close" />
+          </div>
         </template>
       </UPopover>
 

--- a/src/runtime/components/Popover.vue
+++ b/src/runtime/components/Popover.vue
@@ -113,25 +113,21 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.popover || {
 }))
 
 const Component = computed(() => props.mode === 'hover' ? HoverCard : Popover)
-type ComponentRootContext = {
-  open: boolean
-  close: M extends 'click' ? (() => void) : never
-}
 </script>
 
 <template>
   <Component.Root v-slot="{ open, close }: {open: boolean, close?: () => void}" v-bind="rootProps">
     <Component.Trigger v-if="!!slots.default || !!reference" as-child :reference="reference" :class="props.class">
-      <slot v-bind="{ open, close } as ComponentRootContext" />
+      <slot v-bind="{ open, close } as Parameters<typeof slots.default>[0]" />
     </Component.Trigger>
 
     <Component.Anchor v-if="'Anchor' in Component && !!slots.anchor" as-child>
-      <slot name="anchor" v-bind="{ open, close } as ComponentRootContext" />
+      <slot name="anchor" v-bind="{ close } as Parameters<typeof slots.anchor>[0]" />
     </Component.Anchor>
 
     <Component.Portal v-bind="portalProps">
       <Component.Content v-bind="contentProps" :class="ui.content({ class: [!slots.default && props.class, props.ui?.content] })" v-on="contentEvents">
-        <slot name="content" v-bind="{ open, close } as ComponentRootContext" />
+        <slot name="content" v-bind="{ close } as Parameters<typeof slots.content>[0]" />
 
         <Component.Arrow v-if="!!arrow" v-bind="arrowProps" :class="ui.arrow({ class: props.ui?.arrow })" />
       </Component.Content>

--- a/src/runtime/components/Popover.vue
+++ b/src/runtime/components/Popover.vue
@@ -115,12 +115,12 @@ const Component = computed(() => props.mode === 'hover' ? HoverCard : Popover)
     </Component.Trigger>
 
     <Component.Anchor v-if="'Anchor' in Component && !!slots.anchor" as-child>
-      <slot name="anchor" v-bind="(close ? { close } : {}) as SlotProps<M>" />
+      <slot name="anchor" v-bind="((close ? { close } : {}) as SlotProps<M>)" />
     </Component.Anchor>
 
     <Component.Portal v-bind="portalProps">
       <Component.Content v-bind="contentProps" :class="ui.content({ class: [!slots.default && props.class, props.ui?.content] })" v-on="contentEvents">
-        <slot name="content" v-bind="(close ? { close } : {}) as SlotProps<M>" />
+        <slot name="content" v-bind="((close ? { close } : {}) as SlotProps<M>)" />
 
         <Component.Arrow v-if="!!arrow" v-bind="arrowProps" :class="ui.arrow({ class: props.ui?.arrow })" />
       </Component.Content>

--- a/src/runtime/components/Popover.vue
+++ b/src/runtime/components/Popover.vue
@@ -6,13 +6,14 @@ import type { EmitsToProps } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Popover = ComponentConfig<typeof theme, AppConfig, 'popover'>
+type PopoverMode = 'click' | 'hover'
 
-export interface PopoverProps extends PopoverRootProps, Pick<HoverCardRootProps, 'openDelay' | 'closeDelay'> {
+export interface PopoverProps<M extends PopoverMode = PopoverMode> extends PopoverRootProps, Pick<HoverCardRootProps, 'openDelay' | 'closeDelay'> {
   /**
    * The display mode of the popover.
    * @defaultValue 'click'
    */
-  mode?: 'click' | 'hover'
+  mode?: M
   /**
    * The content of the popover.
    * @defaultValue { side: 'bottom', sideOffset: 8, collisionPadding: 8 }
@@ -47,32 +48,23 @@ export interface PopoverEmits extends PopoverRootEmits {
   'close:prevent': []
 }
 
-export interface PopoverSlots {
+export interface PopoverSlots<M extends PopoverMode = PopoverMode> {
   default(props: {
     open: boolean
-    /**
-     * Available only with mode 'click'
-     */
-    close?: () => void
+    close: M extends 'click' ? (() => void) : never
   }): any
 
   content(props: {
-    /**
-     * Available only with mode 'click'
-     */
-    close?: () => void
+    close: M extends 'click' ? (() => void) : never
   }): any
 
   anchor(props: {
-    /**
-     * Available only with mode 'click'
-     */
-    close?: () => void
+    close: M extends 'click' ? (() => void) : never
   }): any
 }
 </script>
 
-<script setup lang="ts">
+<script setup lang="ts" generic="M extends PopoverMode = PopoverMode">
 import { computed, toRef } from 'vue'
 import { defu } from 'defu'
 import { useForwardPropsEmits } from 'reka-ui'
@@ -82,15 +74,15 @@ import { useAppConfig } from '#imports'
 import { usePortal } from '../composables/usePortal'
 import { tv } from '../utils/tv'
 
-const props = withDefaults(defineProps<PopoverProps>(), {
+const props = withDefaults(defineProps<PopoverProps<M>>(), {
   portal: true,
-  mode: 'click',
+  mode: 'click' as never,
   openDelay: 0,
   closeDelay: 0,
   dismissible: true
 })
 const emits = defineEmits<PopoverEmits>()
-const slots = defineSlots<PopoverSlots>()
+const slots = defineSlots<PopoverSlots<M>>()
 
 const appConfig = useAppConfig() as Popover['AppConfig']
 
@@ -121,21 +113,25 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.popover || {
 }))
 
 const Component = computed(() => props.mode === 'hover' ? HoverCard : Popover)
+type ComponentRootContext = {
+  open: boolean
+  close: M extends 'click' ? (() => void) : never
+}
 </script>
 
 <template>
-  <Component.Root v-slot="{ open, close }: { open: boolean, close?: () => void }" v-bind="rootProps">
+  <Component.Root v-slot="{ open, close }: {open: boolean, close?: () => void}" v-bind="rootProps">
     <Component.Trigger v-if="!!slots.default || !!reference" as-child :reference="reference" :class="props.class">
-      <slot :open="open" :close="close" />
+      <slot v-bind="{ open, close } as ComponentRootContext" />
     </Component.Trigger>
 
     <Component.Anchor v-if="'Anchor' in Component && !!slots.anchor" as-child>
-      <slot name="anchor" :close="close" />
+      <slot name="anchor" v-bind="{ open, close } as ComponentRootContext" />
     </Component.Anchor>
 
     <Component.Portal v-bind="portalProps">
       <Component.Content v-bind="contentProps" :class="ui.content({ class: [!slots.default && props.class, props.ui?.content] })" v-on="contentEvents">
-        <slot name="content" :close="close" />
+        <slot name="content" v-bind="{ open, close } as ComponentRootContext" />
 
         <Component.Arrow v-if="!!arrow" v-bind="arrowProps" :class="ui.arrow({ class: props.ui?.arrow })" />
       </Component.Content>

--- a/src/runtime/components/Popover.vue
+++ b/src/runtime/components/Popover.vue
@@ -48,19 +48,12 @@ export interface PopoverEmits extends PopoverRootEmits {
   'close:prevent': []
 }
 
+type SlotProps<M extends PopoverMode = PopoverMode> = [M] extends ['hover'] ? {} : { close: () => void }
+
 export interface PopoverSlots<M extends PopoverMode = PopoverMode> {
-  default(props: {
-    open: boolean
-    close: M extends 'click' ? (() => void) : never
-  }): any
-
-  content(props: {
-    close: M extends 'click' ? (() => void) : never
-  }): any
-
-  anchor(props: {
-    close: M extends 'click' ? (() => void) : never
-  }): any
+  default(props: { open: boolean }): any
+  content(props: SlotProps<M>): any
+  anchor(props: SlotProps<M>): any
 }
 </script>
 
@@ -116,18 +109,18 @@ const Component = computed(() => props.mode === 'hover' ? HoverCard : Popover)
 </script>
 
 <template>
-  <Component.Root v-slot="{ open, close }: {open: boolean, close?: () => void}" v-bind="rootProps">
+  <Component.Root v-slot="{ open, close }: { open: boolean, close?: () => void }" v-bind="rootProps">
     <Component.Trigger v-if="!!slots.default || !!reference" as-child :reference="reference" :class="props.class">
-      <slot v-bind="{ open, close } as Parameters<typeof slots.default>[0]" />
+      <slot :open="open" />
     </Component.Trigger>
 
     <Component.Anchor v-if="'Anchor' in Component && !!slots.anchor" as-child>
-      <slot name="anchor" v-bind="{ close } as Parameters<typeof slots.anchor>[0]" />
+      <slot name="anchor" v-bind="(close ? { close } : {}) as SlotProps<M>" />
     </Component.Anchor>
 
     <Component.Portal v-bind="portalProps">
       <Component.Content v-bind="contentProps" :class="ui.content({ class: [!slots.default && props.class, props.ui?.content] })" v-on="contentEvents">
-        <slot name="content" v-bind="{ close } as Parameters<typeof slots.content>[0]" />
+        <slot name="content" v-bind="(close ? { close } : {}) as SlotProps<M>" />
 
         <Component.Arrow v-if="!!arrow" v-bind="arrowProps" :class="ui.arrow({ class: props.ui?.arrow })" />
       </Component.Content>

--- a/src/runtime/components/Popover.vue
+++ b/src/runtime/components/Popover.vue
@@ -64,7 +64,7 @@ export interface PopoverSlots<M extends PopoverMode = PopoverMode> {
 }
 </script>
 
-<script setup lang="ts" generic="M extends PopoverMode = PopoverMode">
+<script setup lang="ts" generic="M extends PopoverMode">
 import { computed, toRef } from 'vue'
 import { defu } from 'defu'
 import { useForwardPropsEmits } from 'reka-ui'

--- a/src/runtime/components/Popover.vue
+++ b/src/runtime/components/Popover.vue
@@ -48,9 +48,27 @@ export interface PopoverEmits extends PopoverRootEmits {
 }
 
 export interface PopoverSlots {
-  default(props: { open: boolean }): any
-  content(props?: {}): any
-  anchor(props?: {}): any
+  default(props: {
+    open: boolean
+    /**
+     * Available only with mode 'click'
+     */
+    close?: () => void
+  }): any
+
+  content(props: {
+    /**
+     * Available only with mode 'click'
+     */
+    close?: () => void
+  }): any
+
+  anchor(props: {
+    /**
+     * Available only with mode 'click'
+     */
+    close?: () => void
+  }): any
 }
 </script>
 
@@ -106,18 +124,18 @@ const Component = computed(() => props.mode === 'hover' ? HoverCard : Popover)
 </script>
 
 <template>
-  <Component.Root v-slot="{ open }" v-bind="rootProps">
+  <Component.Root v-slot="{ open, close }: { open: boolean, close?: () => void }" v-bind="rootProps">
     <Component.Trigger v-if="!!slots.default || !!reference" as-child :reference="reference" :class="props.class">
-      <slot :open="open" />
+      <slot :open="open" :close="close" />
     </Component.Trigger>
 
     <Component.Anchor v-if="'Anchor' in Component && !!slots.anchor" as-child>
-      <slot name="anchor" />
+      <slot name="anchor" :close="close" />
     </Component.Anchor>
 
     <Component.Portal v-bind="portalProps">
       <Component.Content v-bind="contentProps" :class="ui.content({ class: [!slots.default && props.class, props.ui?.content] })" v-on="contentEvents">
-        <slot name="content" />
+        <slot name="content" :close="close" />
 
         <Component.Arrow v-if="!!arrow" v-bind="arrowProps" :class="ui.arrow({ class: props.ui?.arrow })" />
       </Component.Content>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #5161

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds missing `close` prop to all Popover slots.

Popover uses either Reka Popover or Reka HoverCard depending on `mode`, and since HoverCard doesn't provide `close`, it will be undefined in `mode="hover"`. I reflected it in documentation. Please tell if you want me to properly reflect in in the types too (probably should be done via a generic parameter inferring `mode extends 'click'` or something).

I did not touch tests as similar stuff in Modal is not tested, but I did check it locally in my project before commiting.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
