### PR TITLE
feat(Tree): provide additional slot props

### DIFF
--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -105,7 +105,7 @@ export interface TreeProps<T extends TreeItem[] = TreeItem[], M extends boolean 
 
 export type TreeEmits<T extends TreeItem[] = TreeItem[], M extends boolean = false> = TreeRootEmits<T[number], M>
 
-type SlotProps<T extends TreeItem> = (props: { item: T, index: number, level: number, expanded: boolean, selected: boolean }) => any
+type SlotProps<T extends TreeItem> = (props: { item: T, index: number, level: number, expanded: boolean, selected: boolean, indeterminate: boolean }) => any
 
 export type TreeSlots<
   T extends TreeItem[] = TreeItem[]
@@ -115,7 +115,7 @@ export type TreeSlots<
   'item-leading': SlotProps<T[number]>
   'item-label': SlotProps<T[number]>
   'item-trailing': SlotProps<T[number]>
-} & DynamicSlots<T[number], undefined, { index: number, level: number, expanded: boolean, selected: boolean }>
+} & DynamicSlots<T[number], undefined, { index: number, level: number, expanded: boolean, selected: boolean, indeterminate: boolean }>
 
 </script>
 
@@ -217,7 +217,7 @@ const defaultExpanded = computed(() =>
 <template>
   <DefineItemTemplate v-slot="{ item, index, level }">
     <TreeItem
-      v-slot="{ isExpanded, isSelected }"
+      v-slot="{ isExpanded, isSelected, isIndeterminate }"
       :level="level"
       :value="item"
       :class="!!nested && level > 1 ? ui.itemWithChildren({ class: [props.ui?.itemWithChildren, item.ui?.itemWithChildren] }) : ui.item({ class: [props.ui?.item, item.ui?.item] })"
@@ -226,7 +226,7 @@ const defaultExpanded = computed(() =>
     >
       <slot
         :name="((item.slot ? `${item.slot}-wrapper` : 'item-wrapper') as keyof TreeSlots<T>)"
-        v-bind="{ index, level, expanded: isExpanded, selected: isSelected }"
+        v-bind="{ index, level, expanded: isExpanded, selected: isSelected, indeterminate: isIndeterminate }"
         :item="(item as Extract<T[number], { slot: string; }>)"
       >
         <button
@@ -238,12 +238,12 @@ const defaultExpanded = computed(() =>
         >
           <slot
             :name="((item.slot || 'item') as keyof TreeSlots<T>)"
-            v-bind="{ index, level, expanded: isExpanded, selected: isSelected }"
+            v-bind="{ index, level, expanded: isExpanded, selected: isSelected, indeterminate: isIndeterminate }"
             :item="(item as Extract<T[number], { slot: string; }>)"
           >
             <slot
               :name="((item.slot ? `${item.slot}-leading`: 'item-leading') as keyof TreeSlots<T>)"
-              v-bind="{ index, level, expanded: isExpanded, selected: isSelected }"
+              v-bind="{ index, level, expanded: isExpanded, selected: isSelected, indeterminate: isIndeterminate }"
               :item="(item as Extract<T[number], { slot: string; }>)"
             >
               <UIcon
@@ -264,7 +264,7 @@ const defaultExpanded = computed(() =>
             >
               <slot
                 :name="((item.slot ? `${item.slot}-label`: 'item-label') as keyof TreeSlots<T>)"
-                v-bind="{ index, level, expanded: isExpanded, selected: isSelected }"
+                v-bind="{ index, level, expanded: isExpanded, selected: isSelected, indeterminate: isIndeterminate }"
                 :item="(item as Extract<T[number], { slot: string; }>)"
               >
                 {{ getItemLabel(item) }}
@@ -277,7 +277,7 @@ const defaultExpanded = computed(() =>
             >
               <slot
                 :name="((item.slot ? `${item.slot}-trailing`: 'item-trailing') as keyof TreeSlots<T>)"
-                v-bind="{ index, level, expanded: isExpanded, selected: isSelected }"
+                v-bind="{ index, level, expanded: isExpanded, selected: isSelected, indeterminate: isIndeterminate }"
                 :item="(item as Extract<T[number], { slot: string; }>)"
               >
                 <UIcon

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -105,7 +105,16 @@ export interface TreeProps<T extends TreeItem[] = TreeItem[], M extends boolean 
 
 export type TreeEmits<T extends TreeItem[] = TreeItem[], M extends boolean = false> = TreeRootEmits<T[number], M>
 
-type SlotProps<T extends TreeItem> = (props: { item: T, index: number, level: number, expanded: boolean, selected: boolean, indeterminate: boolean }) => any
+type SlotProps<T extends TreeItem> = (props: {
+  item: T
+  index: number
+  level: number
+  expanded: boolean
+  selected: boolean
+  indeterminate: boolean | undefined
+  handleSelect: () => void
+  handleToggle: () => void
+}) => any
 
 export type TreeSlots<
   T extends TreeItem[] = TreeItem[]
@@ -115,7 +124,15 @@ export type TreeSlots<
   'item-leading': SlotProps<T[number]>
   'item-label': SlotProps<T[number]>
   'item-trailing': SlotProps<T[number]>
-} & DynamicSlots<T[number], undefined, { index: number, level: number, expanded: boolean, selected: boolean, indeterminate: boolean }>
+} & DynamicSlots<T[number], undefined, {
+  index: number
+  level: number
+  expanded: boolean
+  selected: boolean
+  indeterminate: boolean | undefined
+  handleSelect: () => void
+  handleToggle: () => void
+}>
 
 </script>
 
@@ -217,7 +234,7 @@ const defaultExpanded = computed(() =>
 <template>
   <DefineItemTemplate v-slot="{ item, index, level }">
     <TreeItem
-      v-slot="{ isExpanded, isSelected, isIndeterminate }"
+      v-slot="{ isExpanded, isSelected, isIndeterminate, handleSelect, handleToggle }"
       :level="level"
       :value="item"
       :class="!!nested && level > 1 ? ui.itemWithChildren({ class: [props.ui?.itemWithChildren, item.ui?.itemWithChildren] }) : ui.item({ class: [props.ui?.item, item.ui?.item] })"
@@ -226,7 +243,7 @@ const defaultExpanded = computed(() =>
     >
       <slot
         :name="((item.slot ? `${item.slot}-wrapper` : 'item-wrapper') as keyof TreeSlots<T>)"
-        v-bind="{ index, level, expanded: isExpanded, selected: isSelected, indeterminate: isIndeterminate }"
+        v-bind="{ index, level, expanded: isExpanded, selected: isSelected, indeterminate: isIndeterminate, handleSelect, handleToggle }"
         :item="(item as Extract<T[number], { slot: string; }>)"
       >
         <button
@@ -238,12 +255,12 @@ const defaultExpanded = computed(() =>
         >
           <slot
             :name="((item.slot || 'item') as keyof TreeSlots<T>)"
-            v-bind="{ index, level, expanded: isExpanded, selected: isSelected, indeterminate: isIndeterminate }"
+            v-bind="{ index, level, expanded: isExpanded, selected: isSelected, indeterminate: isIndeterminate, handleSelect, handleToggle }"
             :item="(item as Extract<T[number], { slot: string; }>)"
           >
             <slot
               :name="((item.slot ? `${item.slot}-leading`: 'item-leading') as keyof TreeSlots<T>)"
-              v-bind="{ index, level, expanded: isExpanded, selected: isSelected, indeterminate: isIndeterminate }"
+              v-bind="{ index, level, expanded: isExpanded, selected: isSelected, indeterminate: isIndeterminate, handleSelect, handleToggle }"
               :item="(item as Extract<T[number], { slot: string; }>)"
             >
               <UIcon
@@ -264,7 +281,7 @@ const defaultExpanded = computed(() =>
             >
               <slot
                 :name="((item.slot ? `${item.slot}-label`: 'item-label') as keyof TreeSlots<T>)"
-                v-bind="{ index, level, expanded: isExpanded, selected: isSelected, indeterminate: isIndeterminate }"
+                v-bind="{ index, level, expanded: isExpanded, selected: isSelected, indeterminate: isIndeterminate, handleSelect, handleToggle }"
                 :item="(item as Extract<T[number], { slot: string; }>)"
               >
                 {{ getItemLabel(item) }}
@@ -277,7 +294,7 @@ const defaultExpanded = computed(() =>
             >
               <slot
                 :name="((item.slot ? `${item.slot}-trailing`: 'item-trailing') as keyof TreeSlots<T>)"
-                v-bind="{ index, level, expanded: isExpanded, selected: isSelected, indeterminate: isIndeterminate }"
+                v-bind="{ index, level, expanded: isExpanded, selected: isSelected, indeterminate: isIndeterminate, handleSelect, handleToggle }"
                 :item="(item as Extract<T[number], { slot: string; }>)"
               >
                 <UIcon


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Needed to display an indeterminate state, if, for example, we are creating a checkbox.

Add: `isIndeterminate`, `handleSelect`, `handleToggle`

https://reka-ui.com/docs/components/tree

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
