### PR TITLE
fix(unplugin): generate theme templates as real files

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,18 +77,12 @@
       ]
     }
   },
-  "imports": {
-    "#build/ui/*": "./.nuxt/ui/*.ts",
-    "#build/ui.css": "./.nuxt/ui.css"
-  },
   "bin": {
     "nuxt-ui": "./cli/index.mjs"
   },
   "style": "./dist/runtime/index.css",
   "main": "./dist/module.mjs",
   "files": [
-    ".nuxt/ui",
-    ".nuxt/ui.css",
     "dist",
     "cli",
     "vue-plugin.d.ts"

--- a/src/plugins/templates.ts
+++ b/src/plugins/templates.ts
@@ -1,3 +1,6 @@
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { writeFileSync, mkdirSync, realpathSync } from 'node:fs'
 import type { UnpluginOptions } from 'unplugin'
 import type { NuxtUIOptions } from '../unplugin'
 import { getTemplates } from '../templates'
@@ -7,21 +10,58 @@ import { getTemplates } from '../templates'
  * making them available to the Vue build.
  */
 export default function TemplatePlugin(options: NuxtUIOptions, appConfig: Record<string, any>) {
-  const templates = getTemplates(options, appConfig.ui)
-  const templateKeys = new Set(templates.map(t => `#build/${t.filename}`))
+  let detectionComplete = false
+  const aliases: Record<string, string> = {}
+
+  // Write templates to a temporary directory (for Tailwind to read)
+  const tempDir = join(tmpdir(), 'nuxt-ui-templates')
+  mkdirSync(tempDir, { recursive: true })
+  // Resolve to real path (handles symlinks like /var -> /private/var on macOS)
+  const realTempDir = realpathSync(tempDir)
+
+  async function initializeTemplates() {
+    if (detectionComplete) return
+
+    const templates = getTemplates(options, appConfig.ui, undefined)
+
+    for (const template of templates) {
+      if (template.write && template.filename) {
+        const filepath = join(realTempDir, template.filename)
+        const dir = join(filepath, '..')
+        mkdirSync(dir, { recursive: true })
+        const contents = await template.getContents!({} as any)
+        writeFileSync(filepath, contents as string)
+
+        aliases[`#build/${template.filename}`] = filepath
+      }
+    }
+
+    detectionComplete = true
+  }
+
+  const initPromise = initializeTemplates()
 
   return {
     name: 'nuxt:ui:templates',
     enforce: 'pre',
-    resolveId(id) {
-      if (templateKeys.has(id + '.ts')) {
-        return id.replace('#build/', 'virtual:nuxt-ui-templates/') + '.ts'
+    async resolveId(id) {
+      await initPromise
+
+      const aliasPath = aliases[id + '.ts']
+      if (aliasPath) {
+        return { id: aliasPath }
       }
     },
-    loadInclude: id => templateKeys.has(id.replace('virtual:nuxt-ui-templates/', '#build/')),
-    load(id) {
-      id = id.replace('virtual:nuxt-ui-templates/', '#build/')
-      return templates.find(t => `#build/${t.filename}` === id)!.getContents!({} as any)
+    vite: {
+      async config() {
+        await initPromise
+
+        return {
+          resolve: {
+            alias: aliases
+          }
+        }
+      }
     }
   } satisfies UnpluginOptions
 }

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -70,9 +70,9 @@ export const NuxtUIPlugin = createUnplugin<NuxtUIOptions | undefined>((_options 
     NuxtEnvironmentPlugin(options),
     ComponentImportPlugin(options, meta),
     AutoImportPlugin(options, meta),
+    TemplatePlugin(options, appConfig),
     tailwind(),
     PluginsPlugin(options),
-    TemplatePlugin(options, appConfig),
     AppConfigPlugin(options, appConfig),
     <UnpluginOptions>{
       name: 'nuxt:ui:plugins-duplication-detection',


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
Resolves #4951

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
Fixes the Vite plugin where theme files were incorrectly shipped inside `.nuxt/` on NPM (`#build/ui.css` import was not working).

They are now properly generated as real files that Tailwind CSS can read, ensuring custom theme colors and user configuration work correctly.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
