### PR TITLE
fix(components): improve slots return types

### DIFF
--- a/docs/app/components/content/ComponentExample.vue
+++ b/docs/app/components/content/ComponentExample.vue
@@ -1,10 +1,10 @@
 <script setup lang="ts">
-import type { VNode } from 'vue'
 import type { ChipProps } from '@nuxt/ui'
 import { camelCase } from 'scule'
 import { hash } from 'ohash'
 import { useElementSize } from '@vueuse/core'
 import { get, set } from '#ui/utils'
+import type { SlotsReturn } from '#ui/types/utils'
 
 const props = withDefaults(defineProps<{
   name: string
@@ -66,8 +66,8 @@ const props = withDefaults(defineProps<{
 })
 
 const slots = defineSlots<{
-  options?(props?: {}): VNode
-  code?(props?: {}): VNode
+  options?(props?: {}): SlotsReturn
+  code?(props?: {}): SlotsReturn
 }>()
 
 const el = ref<HTMLElement | null>(null)

--- a/docs/app/components/content/ComponentExample.vue
+++ b/docs/app/components/content/ComponentExample.vue
@@ -1,4 +1,5 @@
 <script setup lang="ts">
+import type { VNode } from 'vue'
 import type { ChipProps } from '@nuxt/ui'
 import { camelCase } from 'scule'
 import { hash } from 'ohash'
@@ -65,8 +66,8 @@ const props = withDefaults(defineProps<{
 })
 
 const slots = defineSlots<{
-  options(props?: {}): any
-  code(props?: {}): any
+  options?(props?: {}): VNode
+  code?(props?: {}): VNode
 }>()
 
 const el = ref<HTMLElement | null>(null)

--- a/docs/app/components/theme-picker/ThemePickerButton.vue
+++ b/docs/app/components/theme-picker/ThemePickerButton.vue
@@ -7,7 +7,7 @@ defineProps<{
 }>()
 
 const slots = defineSlots<{
-  leading: () => any
+  leading?(): VNode[]
 }>()
 </script>
 

--- a/docs/app/components/theme-picker/ThemePickerButton.vue
+++ b/docs/app/components/theme-picker/ThemePickerButton.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts">
+import type { SlotsReturn } from '#ui/types/utils'
+
 defineProps<{
   label: string
   icon?: string
@@ -7,7 +9,7 @@ defineProps<{
 }>()
 
 const slots = defineSlots<{
-  leading?(): VNode[]
+  leading?(): SlotsReturn
 }>()
 </script>
 

--- a/playgrounds/nuxt/app/components/Matrix.vue
+++ b/playgrounds/nuxt/app/components/Matrix.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts" generic="T extends Record<string, string[]>">
-import type { VNode } from 'vue'
+import type { SlotsReturn } from '#ui/types/utils'
 
 const props = defineProps<{
   attrs: T
@@ -8,7 +8,7 @@ const props = defineProps<{
 }>()
 
 defineSlots<{
-  default?(props?: { [K in keyof T]: T[K] extends (infer U)[] ? U : never }): VNode
+  default?(props?: { [K in keyof T]: T[K] extends (infer U)[] ? U : never }): SlotsReturn
 }>()
 
 const combinations = computed(() => {

--- a/playgrounds/nuxt/app/components/Matrix.vue
+++ b/playgrounds/nuxt/app/components/Matrix.vue
@@ -1,4 +1,6 @@
 <script setup lang="ts" generic="T extends Record<string, string[]>">
+import type { VNode } from 'vue'
+
 const props = defineProps<{
   attrs: T
   containerClass?: string
@@ -6,7 +8,7 @@ const props = defineProps<{
 }>()
 
 defineSlots<{
-  default: (props?: { [K in keyof T]: T[K] extends (infer U)[] ? U : never }) => any
+  default?(props?: { [K in keyof T]: T[K] extends (infer U)[] ? U : never }): VNode
 }>()
 
 const combinations = computed(() => {

--- a/src/runtime/components/Accordion.vue
+++ b/src/runtime/components/Accordion.vue
@@ -1,11 +1,10 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AccordionRootProps, AccordionRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/accordion'
 import type { IconProps } from '../types'
-import type { DynamicSlots, GetItemKeys } from '../types/utils'
+import type { DynamicSlots, GetItemKeys, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Accordion = ComponentConfig<typeof theme, AppConfig, 'accordion'>
@@ -54,7 +53,7 @@ export interface AccordionProps<T extends AccordionItem = AccordionItem> extends
 
 export interface AccordionEmits extends AccordionRootEmits {}
 
-type SlotProps<T extends AccordionItem> = (props: { item: T, index: number, open: boolean }) => VNode[]
+type SlotProps<T extends AccordionItem> = (props: { item: T, index: number, open: boolean }) => SlotsReturn
 
 export type AccordionSlots<T extends AccordionItem = AccordionItem> = {
   leading?: SlotProps<T>

--- a/src/runtime/components/Accordion.vue
+++ b/src/runtime/components/Accordion.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AccordionRootProps, AccordionRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/accordion'
@@ -53,14 +54,14 @@ export interface AccordionProps<T extends AccordionItem = AccordionItem> extends
 
 export interface AccordionEmits extends AccordionRootEmits {}
 
-type SlotProps<T extends AccordionItem> = (props: { item: T, index: number, open: boolean }) => any
+type SlotProps<T extends AccordionItem> = (props: { item: T, index: number, open: boolean }) => VNode[]
 
 export type AccordionSlots<T extends AccordionItem = AccordionItem> = {
-  leading: SlotProps<T>
-  default: SlotProps<T>
-  trailing: SlotProps<T>
-  content: SlotProps<T>
-  body: SlotProps<T>
+  leading?: SlotProps<T>
+  default?: SlotProps<T>
+  trailing?: SlotProps<T>
+  content?: SlotProps<T>
+  body?: SlotProps<T>
 } & DynamicSlots<T, 'body', { index: number, open: boolean }>
 
 </script>

--- a/src/runtime/components/Alert.vue
+++ b/src/runtime/components/Alert.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/alert'
 import type { AvatarProps, ButtonProps, IconProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Alert = ComponentConfig<typeof theme, AppConfig, 'alert'>
 
@@ -62,11 +62,11 @@ export interface AlertEmits {
 }
 
 export interface AlertSlots {
-  leading?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  actions?(props?: {}): VNode[]
-  close?(props: { ui: { [K in keyof Required<Alert['slots']>]: (props?: Record<string, any>) => string } }): VNode[]
+  leading?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  actions?(props?: {}): SlotsReturn
+  close?(props: { ui: { [K in keyof Required<Alert['slots']>]: (props?: Record<string, any>) => string } }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Alert.vue
+++ b/src/runtime/components/Alert.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/alert'
 import type { AvatarProps, ButtonProps, IconProps } from '../types'
@@ -61,11 +62,11 @@ export interface AlertEmits {
 }
 
 export interface AlertSlots {
-  leading(props?: {}): any
-  title(props?: {}): any
-  description(props?: {}): any
-  actions(props?: {}): any
-  close(props: { ui: { [K in keyof Required<Alert['slots']>]: (props?: Record<string, any>) => string } }): any
+  leading?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  actions?(props?: {}): VNode[]
+  close?(props: { ui: { [K in keyof Required<Alert['slots']>]: (props?: Record<string, any>) => string } }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/App.vue
+++ b/src/runtime/components/App.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { ConfigProviderProps, TooltipProviderProps } from 'reka-ui'
 import type { ToasterProps } from '../types'
 import type { Locale, Messages } from '../types/locale'
@@ -11,7 +12,7 @@ export interface AppProps<T extends Messages = Messages> extends Omit<ConfigProv
 }
 
 export interface AppSlots {
-  default(props?: {}): any
+  default?(props?: {}): VNode[]
 }
 
 export default {

--- a/src/runtime/components/App.vue
+++ b/src/runtime/components/App.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { ConfigProviderProps, TooltipProviderProps } from 'reka-ui'
 import type { ToasterProps } from '../types'
 import type { Locale, Messages } from '../types/locale'
+import type { SlotsReturn } from '../types/utils'
 
 export interface AppProps<T extends Messages = Messages> extends Omit<ConfigProviderProps, 'useId' | 'dir' | 'locale'> {
   tooltip?: TooltipProviderProps
@@ -12,7 +12,7 @@ export interface AppProps<T extends Messages = Messages> extends Omit<ConfigProv
 }
 
 export interface AppSlots {
-  default?(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 
 export default {

--- a/src/runtime/components/AuthForm.vue
+++ b/src/runtime/components/AuthForm.vue
@@ -1,11 +1,11 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/auth-form'
 import type { ButtonProps, FormProps, FormFieldProps, SeparatorProps, InputProps, CheckboxProps, SelectMenuProps, PinInputProps, IconProps } from '../types'
 import type { FormSchema, FormSubmitEvent, InferInput } from '../types/form'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type AuthForm = ComponentConfig<typeof theme, AppConfig, 'authForm'>
 
@@ -91,19 +91,19 @@ export type AuthFormEmits<T extends object> = {
   submit: [payload: FormSubmitEvent<T>]
 }
 
-type DynamicFieldSlots<T, F, SlotProps = { field: F, state: T }> = Record<string, (props: SlotProps) => VNode[]> & Record<`${keyof T extends string ? keyof T : never}-field`, (props: SlotProps) => VNode[]>
+type DynamicFieldSlots<T, F, SlotProps = { field: F, state: T }> = Record<string, (props: SlotProps) => SlotsReturn> & Record<`${keyof T extends string ? keyof T : never}-field`, (props: SlotProps) => SlotsReturn>
 
-type DynamicFormFieldSlots<T> = Record<string, (props?: {}) => VNode[]> & Record<`${keyof T extends string ? keyof T : never}-${'label' | 'description' | 'hint' | 'help' | 'error'}`, (props?: {}) => VNode[]>
+type DynamicFormFieldSlots<T> = Record<string, (props?: {}) => SlotsReturn> & Record<`${keyof T extends string ? keyof T : never}-${'label' | 'description' | 'hint' | 'help' | 'error'}`, (props?: {}) => SlotsReturn>
 
 export type AuthFormSlots<T extends object = object, F extends AuthFormField = AuthFormField> = {
-  header?(props?: {}): VNode[]
-  leading?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  providers?(props?: {}): VNode[]
-  validation?(props?: {}): VNode[]
-  submit?(props: { loading: boolean }): VNode[]
-  footer?(props?: {}): VNode[]
+  header?(props?: {}): SlotsReturn
+  leading?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  providers?(props?: {}): SlotsReturn
+  validation?(props?: {}): SlotsReturn
+  submit?(props: { loading: boolean }): SlotsReturn
+  footer?(props?: {}): SlotsReturn
 } & DynamicFieldSlots<T, F> & DynamicFormFieldSlots<T>
 
 </script>

--- a/src/runtime/components/AuthForm.vue
+++ b/src/runtime/components/AuthForm.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/auth-form'
 import type { ButtonProps, FormProps, FormFieldProps, SeparatorProps, InputProps, CheckboxProps, SelectMenuProps, PinInputProps, IconProps } from '../types'
@@ -90,19 +91,19 @@ export type AuthFormEmits<T extends object> = {
   submit: [payload: FormSubmitEvent<T>]
 }
 
-type DynamicFieldSlots<T, F, SlotProps = { field: F, state: T }> = Record<string, (props: SlotProps) => any> & Record<`${keyof T extends string ? keyof T : never}-field`, (props: SlotProps) => any>
+type DynamicFieldSlots<T, F, SlotProps = { field: F, state: T }> = Record<string, (props: SlotProps) => VNode[]> & Record<`${keyof T extends string ? keyof T : never}-field`, (props: SlotProps) => VNode[]>
 
-type DynamicFormFieldSlots<T> = Record<string, (props?: {}) => any> & Record<`${keyof T extends string ? keyof T : never}-${'label' | 'description' | 'hint' | 'help' | 'error'}`, (props?: {}) => any>
+type DynamicFormFieldSlots<T> = Record<string, (props?: {}) => VNode[]> & Record<`${keyof T extends string ? keyof T : never}-${'label' | 'description' | 'hint' | 'help' | 'error'}`, (props?: {}) => VNode[]>
 
 export type AuthFormSlots<T extends object = object, F extends AuthFormField = AuthFormField> = {
-  header(props?: {}): any
-  leading(props?: {}): any
-  title(props?: {}): any
-  description(props?: {}): any
-  providers(props?: {}): any
-  validation(props?: {}): any
-  submit(props: { loading: boolean }): any
-  footer(props?: {}): any
+  header?(props?: {}): VNode[]
+  leading?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  providers?(props?: {}): VNode[]
+  validation?(props?: {}): VNode[]
+  submit?(props: { loading: boolean }): VNode[]
+  footer?(props?: {}): VNode[]
 } & DynamicFieldSlots<T, F> & DynamicFormFieldSlots<T>
 
 </script>

--- a/src/runtime/components/Avatar.vue
+++ b/src/runtime/components/Avatar.vue
@@ -3,6 +3,7 @@ import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/avatar'
 import type { ChipProps, IconProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Avatar = ComponentConfig<typeof theme, AppConfig, 'avatar'>
 
@@ -30,7 +31,7 @@ export interface AvatarProps {
 }
 
 export interface AvatarSlots {
-  default(props?: {}): any
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Avatar.vue
+++ b/src/runtime/components/Avatar.vue
@@ -31,7 +31,7 @@ export interface AvatarProps {
 }
 
 export interface AvatarSlots {
-  default(props?: {}): SlotsReturn
+  default?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/AvatarGroup.vue
+++ b/src/runtime/components/AvatarGroup.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/avatar-group'
 import type { ComponentConfig } from '../types/tv'
@@ -24,7 +25,7 @@ export interface AvatarGroupProps {
 }
 
 export interface AvatarGroupSlots {
-  default(props?: {}): any
+  default?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/AvatarGroup.vue
+++ b/src/runtime/components/AvatarGroup.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/avatar-group'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type AvatarGroup = ComponentConfig<typeof theme, AppConfig, 'avatarGroup'>
 
@@ -25,7 +25,7 @@ export interface AvatarGroupProps {
 }
 
 export interface AvatarGroupSlots {
-  default?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
 }
 </script>
 
@@ -50,6 +50,9 @@ const max = computed(() => typeof props.max === 'string' ? Number.parseInt(props
 
 const children = computed(() => {
   let children = slots.default?.()
+  if (!Array.isArray(children)) {
+    children = children ? [children] : []
+  }
   if (children?.length) {
     children = children.flatMap((child: any) => {
       if (typeof child.type === 'symbol') {

--- a/src/runtime/components/Badge.vue
+++ b/src/runtime/components/Badge.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/badge'
 import type { UseComponentIconsProps } from '../composables/useComponentIcons'
@@ -33,9 +34,9 @@ export interface BadgeProps extends Omit<UseComponentIconsProps, 'loading' | 'lo
 }
 
 export interface BadgeSlots {
-  leading(props?: {}): any
-  default(props?: {}): any
-  trailing(props?: {}): any
+  leading?(props?: {}): VNode[]
+  default?(props?: {}): VNode[]
+  trailing?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Badge.vue
+++ b/src/runtime/components/Badge.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/badge'
 import type { UseComponentIconsProps } from '../composables/useComponentIcons'
 import type { AvatarProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Badge = ComponentConfig<typeof theme, AppConfig, 'badge'>
 
@@ -34,9 +34,9 @@ export interface BadgeProps extends Omit<UseComponentIconsProps, 'loading' | 'lo
 }
 
 export interface BadgeSlots {
-  leading?(props?: {}): VNode[]
-  default?(props?: {}): VNode[]
-  trailing?(props?: {}): VNode[]
+  leading?(props?: {}): SlotsReturn
+  default?(props?: {}): SlotsReturn
+  trailing?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Banner.vue
+++ b/src/runtime/components/Banner.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/banner'
 import type { ButtonProps, IconProps, LinkProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Banner = ComponentConfig<typeof theme, AppConfig, 'banner'>
 
@@ -54,10 +54,10 @@ export interface BannerProps {
 }
 
 export interface BannerSlots {
-  leading?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
-  actions?(props?: {}): VNode[]
-  close?(props: { ui: any }): VNode[]
+  leading?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  actions?(props?: {}): SlotsReturn
+  close?(props: { ui: any }): SlotsReturn
 }
 
 export interface BannerEmits {

--- a/src/runtime/components/Banner.vue
+++ b/src/runtime/components/Banner.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/banner'
 import type { ButtonProps, IconProps, LinkProps } from '../types'
@@ -53,10 +54,10 @@ export interface BannerProps {
 }
 
 export interface BannerSlots {
-  leading(props?: {}): any
-  title(props?: {}): any
-  actions(props?: {}): any
-  close(props: { ui: any }): any
+  leading?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
+  actions?(props?: {}): VNode[]
+  close?(props: { ui: any }): VNode[]
 }
 
 export interface BannerEmits {

--- a/src/runtime/components/BlogPost.vue
+++ b/src/runtime/components/BlogPost.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/blog-post'
 import type { BadgeProps, LinkProps, UserProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type BlogPost = ComponentConfig<typeof theme, AppConfig, 'blogPost'>
 
@@ -44,14 +44,14 @@ export interface BlogPostProps {
 }
 
 export interface BlogPostSlots {
-  date?(props?: {}): VNode[]
-  badge?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  authors?(props?: {}): VNode[]
-  header?(props?: {}): VNode[]
-  body?(props?: {}): VNode[]
-  footer?(props?: {}): VNode[]
+  date?(props?: {}): SlotsReturn
+  badge?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  authors?(props?: {}): SlotsReturn
+  header?(props?: {}): SlotsReturn
+  body?(props?: {}): SlotsReturn
+  footer?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/BlogPost.vue
+++ b/src/runtime/components/BlogPost.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/blog-post'
 import type { BadgeProps, LinkProps, UserProps } from '../types'
@@ -43,14 +44,14 @@ export interface BlogPostProps {
 }
 
 export interface BlogPostSlots {
-  date(props?: {}): any
-  badge(props?: {}): any
-  title(props?: {}): any
-  description(props?: {}): any
-  authors(props?: {}): any
-  header(props?: {}): any
-  body(props?: {}): any
-  footer(props?: {}): any
+  date?(props?: {}): VNode[]
+  badge?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  authors?(props?: {}): VNode[]
+  header?(props?: {}): VNode[]
+  body?(props?: {}): VNode[]
+  footer?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/BlogPosts.vue
+++ b/src/runtime/components/BlogPosts.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/blog-posts'
 import type { BlogPostProps } from '../types'
@@ -22,7 +23,7 @@ export interface BlogPostsProps {
 }
 
 export interface BlogPostsSlots {
-  default(props?: {}): any
+  default?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/BlogPosts.vue
+++ b/src/runtime/components/BlogPosts.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/blog-posts'
 import type { BlogPostProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type BlogPosts = ComponentConfig<typeof theme, AppConfig, 'blogPosts'>
 
@@ -23,7 +23,7 @@ export interface BlogPostsProps {
 }
 
 export interface BlogPostsSlots {
-  default?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Breadcrumb.vue
+++ b/src/runtime/components/Breadcrumb.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/breadcrumb'
 import type { AvatarProps, IconProps, LinkProps } from '../types'
@@ -43,14 +44,14 @@ export interface BreadcrumbProps<T extends BreadcrumbItem = BreadcrumbItem> {
   ui?: Breadcrumb['slots']
 }
 
-type SlotProps<T extends BreadcrumbItem> = (props: { item: T, index: number, active?: boolean }) => any
+type SlotProps<T extends BreadcrumbItem> = (props: { item: T, index: number, active?: boolean }) => VNode[]
 
 export type BreadcrumbSlots<T extends BreadcrumbItem = BreadcrumbItem> = {
-  'item': SlotProps<T>
-  'item-leading': SlotProps<T>
-  'item-label': SlotProps<T>
-  'item-trailing': SlotProps<T>
-  'separator': any
+  'item'?: SlotProps<T>
+  'item-leading'?: SlotProps<T>
+  'item-label'?: SlotProps<T>
+  'item-trailing'?: SlotProps<T>
+  'separator'?: (props?: {}) => VNode[]
 } & DynamicSlots<T, 'leading' | 'label' | 'trailing', { index: number, active?: boolean }>
 
 </script>
@@ -90,19 +91,19 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.breadcrumb |
         <li :class="ui.item({ class: [props.ui?.item, item.ui?.item] })">
           <ULink v-slot="{ active, ...slotProps }" v-bind="pickLinkProps(item)" custom>
             <ULinkBase v-bind="slotProps" as="span" :aria-current="active && (index === items!.length - 1) ? 'page' : undefined" :class="ui.link({ class: [props.ui?.link, item.ui?.link, item.class], active: index === items!.length - 1, disabled: !!item.disabled, to: !!item.to })">
-              <slot :name="((item.slot || 'item') as keyof BreadcrumbSlots<T>)" :item="item" :index="index">
-                <slot :name="((item.slot ? `${item.slot}-leading`: 'item-leading') as keyof BreadcrumbSlots<T>)" :item="item" :active="index === items!.length - 1" :index="index">
+              <slot :name="((item.slot || 'item') as keyof BreadcrumbSlots<T>)" :item="(item as Extract<T, { slot: string }>)" :index="index">
+                <slot :name="((item.slot ? `${item.slot}-leading`: 'item-leading') as keyof BreadcrumbSlots<T>)" :item="(item as Extract<T, { slot: string }>)" :active="index === items!.length - 1" :index="index">
                   <UIcon v-if="item.icon" :name="item.icon" :class="ui.linkLeadingIcon({ class: [props.ui?.linkLeadingIcon, item.ui?.linkLeadingIcon], active: index === items!.length - 1 })" />
                   <UAvatar v-else-if="item.avatar" :size="((props.ui?.linkLeadingAvatarSize || ui.linkLeadingAvatarSize()) as AvatarProps['size'])" v-bind="item.avatar" :class="ui.linkLeadingAvatar({ class: [props.ui?.linkLeadingAvatar, item.ui?.linkLeadingAvatar], active: index === items!.length - 1 })" />
                 </slot>
 
                 <span v-if="get(item, props.labelKey as string) || !!slots[(item.slot ? `${item.slot}-label`: 'item-label') as keyof BreadcrumbSlots<T>]" :class="ui.linkLabel({ class: [props.ui?.linkLabel, item.ui?.linkLabel] })">
-                  <slot :name="((item.slot ? `${item.slot}-label`: 'item-label') as keyof BreadcrumbSlots<T>)" :item="item" :active="index === items!.length - 1" :index="index">
+                  <slot :name="((item.slot ? `${item.slot}-label`: 'item-label') as keyof BreadcrumbSlots<T>)" :item="(item as Extract<T, { slot: string }>)" :active="index === items!.length - 1" :index="index">
                     {{ get(item, props.labelKey as string) }}
                   </slot>
                 </span>
 
-                <slot :name="((item.slot ? `${item.slot}-trailing`: 'item-trailing') as keyof BreadcrumbSlots<T>)" :item="item" :active="index === items!.length - 1" :index="index" />
+                <slot :name="((item.slot ? `${item.slot}-trailing`: 'item-trailing') as keyof BreadcrumbSlots<T>)" :item="(item as Extract<T, { slot: string }>)" :active="index === items!.length - 1" :index="index" />
               </slot>
             </ULinkBase>
           </ULink>

--- a/src/runtime/components/Breadcrumb.vue
+++ b/src/runtime/components/Breadcrumb.vue
@@ -1,10 +1,9 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/breadcrumb'
 import type { AvatarProps, IconProps, LinkProps } from '../types'
-import type { DynamicSlots, GetItemKeys } from '../types/utils'
+import type { DynamicSlots, GetItemKeys, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Breadcrumb = ComponentConfig<typeof theme, AppConfig, 'breadcrumb'>
@@ -44,14 +43,14 @@ export interface BreadcrumbProps<T extends BreadcrumbItem = BreadcrumbItem> {
   ui?: Breadcrumb['slots']
 }
 
-type SlotProps<T extends BreadcrumbItem> = (props: { item: T, index: number, active?: boolean }) => VNode[]
+type SlotProps<T extends BreadcrumbItem> = (props: { item: T, index: number, active?: boolean }) => SlotsReturn
 
 export type BreadcrumbSlots<T extends BreadcrumbItem = BreadcrumbItem> = {
   'item'?: SlotProps<T>
   'item-leading'?: SlotProps<T>
   'item-label'?: SlotProps<T>
   'item-trailing'?: SlotProps<T>
-  'separator'?: (props?: {}) => VNode[]
+  'separator'?: (props?: {}) => SlotsReturn
 } & DynamicSlots<T, 'leading' | 'label' | 'trailing', { index: number, active?: boolean }>
 
 </script>

--- a/src/runtime/components/Button.vue
+++ b/src/runtime/components/Button.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { Ref, VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/button'
 import type { UseComponentIconsProps } from '../composables/useComponentIcons'
@@ -35,15 +36,14 @@ export interface ButtonProps extends UseComponentIconsProps, Omit<LinkProps, 'ra
 }
 
 export interface ButtonSlots {
-  leading(props?: {}): any
-  default(props?: {}): any
-  trailing(props?: {}): any
+  leading?(props?: {}): VNode[]
+  default?(props?: {}): VNode[]
+  trailing?(props?: {}): VNode[]
 }
 </script>
 
 <script setup lang="ts">
 import { computed, ref, inject } from 'vue'
-import type { Ref } from 'vue'
 import { defu } from 'defu'
 import { useForwardProps } from 'reka-ui'
 import { useAppConfig } from '#imports'

--- a/src/runtime/components/Button.vue
+++ b/src/runtime/components/Button.vue
@@ -1,10 +1,11 @@
 <script lang="ts">
-import type { Ref, VNode } from 'vue'
+import type { Ref } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/button'
 import type { UseComponentIconsProps } from '../composables/useComponentIcons'
 import type { LinkProps, AvatarProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Button = ComponentConfig<typeof theme, AppConfig, 'button'>
 
@@ -36,9 +37,9 @@ export interface ButtonProps extends UseComponentIconsProps, Omit<LinkProps, 'ra
 }
 
 export interface ButtonSlots {
-  leading?(props?: {}): VNode[]
-  default?(props?: {}): VNode[]
-  trailing?(props?: {}): VNode[]
+  leading?(props?: {}): SlotsReturn
+  default?(props?: {}): SlotsReturn
+  trailing?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Calendar.vue
+++ b/src/runtime/components/Calendar.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { CalendarRootProps, CalendarRootEmits, RangeCalendarRootProps, RangeCalendarRootEmits, DateRange, CalendarCellTriggerProps } from 'reka-ui'
 import type { DateValue } from '@internationalized/date'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/calendar'
 import type { ButtonProps, IconProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Calendar = ComponentConfig<typeof theme, AppConfig, 'calendar'>
 
@@ -104,9 +104,9 @@ export interface CalendarEmits<R extends boolean, M extends boolean> extends Omi
 }
 
 export interface CalendarSlots {
-  'heading'?: (props: { value: string }) => VNode[]
-  'day'?: (props: Pick<CalendarCellTriggerProps, 'day'>) => VNode[]
-  'week-day'?: (props: { day: string }) => VNode[]
+  'heading'?: (props: { value: string }) => SlotsReturn
+  'day'?: (props: Pick<CalendarCellTriggerProps, 'day'>) => SlotsReturn
+  'week-day'?: (props: { day: string }) => SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Calendar.vue
+++ b/src/runtime/components/Calendar.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { CalendarRootProps, CalendarRootEmits, RangeCalendarRootProps, RangeCalendarRootEmits, DateRange, CalendarCellTriggerProps } from 'reka-ui'
 import type { DateValue } from '@internationalized/date'
 import type { AppConfig } from '@nuxt/schema'
@@ -103,9 +104,9 @@ export interface CalendarEmits<R extends boolean, M extends boolean> extends Omi
 }
 
 export interface CalendarSlots {
-  'heading': (props: { value: string }) => any
-  'day': (props: Pick<CalendarCellTriggerProps, 'day'>) => any
-  'week-day': (props: { day: string }) => any
+  'heading'?: (props: { value: string }) => VNode[]
+  'day'?: (props: Pick<CalendarCellTriggerProps, 'day'>) => VNode[]
+  'week-day'?: (props: { day: string }) => VNode[]
 }
 </script>
 

--- a/src/runtime/components/Card.vue
+++ b/src/runtime/components/Card.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/card'
 import type { ComponentConfig } from '../types/tv'
@@ -20,9 +21,9 @@ export interface CardProps {
 }
 
 export interface CardSlots {
-  header(props?: {}): any
-  default(props?: {}): any
-  footer(props?: {}): any
+  header?(props?: {}): VNode[]
+  default?(props?: {}): VNode[]
+  footer?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Card.vue
+++ b/src/runtime/components/Card.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/card'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Card = ComponentConfig<typeof theme, AppConfig, 'card'>
 
@@ -21,9 +21,9 @@ export interface CardProps {
 }
 
 export interface CardSlots {
-  header?(props?: {}): VNode[]
-  default?(props?: {}): VNode[]
-  footer?(props?: {}): VNode[]
+  header?(props?: {}): SlotsReturn
+  default?(props?: {}): SlotsReturn
+  footer?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Carousel.vue
+++ b/src/runtime/components/Carousel.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { EmblaCarouselType, EmblaOptionsType, EmblaPluginType } from 'embla-carousel'
 import type { AutoplayOptionsType } from 'embla-carousel-autoplay'
@@ -101,7 +102,7 @@ export interface CarouselProps<T extends CarouselItem = CarouselItem> extends Om
 }
 
 export type CarouselSlots<T extends CarouselItem = CarouselItem> = {
-  default(props: { item: T, index: number }): any
+  default?(props: { item: T, index: number }): VNode[]
 }
 
 export interface CarouselEmits {

--- a/src/runtime/components/Carousel.vue
+++ b/src/runtime/components/Carousel.vue
@@ -1,6 +1,5 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { EmblaCarouselType, EmblaOptionsType, EmblaPluginType } from 'embla-carousel'
 import type { AutoplayOptionsType } from 'embla-carousel-autoplay'
@@ -11,7 +10,7 @@ import type { FadeOptionsType } from 'embla-carousel-fade'
 import type { WheelGesturesPluginOptions } from 'embla-carousel-wheel-gestures'
 import theme from '#build/ui/carousel'
 import type { ButtonProps, IconProps } from '../types'
-import type { AcceptableValue } from '../types/utils'
+import type { AcceptableValue, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Carousel = ComponentConfig<typeof theme, AppConfig, 'carousel'>
@@ -102,7 +101,7 @@ export interface CarouselProps<T extends CarouselItem = CarouselItem> extends Om
 }
 
 export type CarouselSlots<T extends CarouselItem = CarouselItem> = {
-  default?(props: { item: T, index: number }): VNode[]
+  default?(props: { item: T, index: number }): SlotsReturn
 }
 
 export interface CarouselEmits {

--- a/src/runtime/components/ChangelogVersion.vue
+++ b/src/runtime/components/ChangelogVersion.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/changelog-version'
 import type { BadgeProps, LinkProps, UserProps } from '../types'
@@ -39,17 +40,17 @@ export interface ChangelogVersionProps {
 }
 
 export interface ChangelogVersionSlots {
-  header(props?: {}): any
-  badge(props?: {}): any
-  date(props?: {}): any
-  title(props?: {}): any
-  description(props?: {}): any
-  image(props?: {}): any
-  body(props?: {}): any
-  footer(props?: {}): any
-  authors(props?: {}): any
-  actions(props?: {}): any
-  indicator(props?: {}): any
+  header?(props?: {}): VNode[]
+  badge?(props?: {}): VNode[]
+  date?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  image?(props?: {}): VNode[]
+  body?(props?: {}): VNode[]
+  footer?(props?: {}): VNode[]
+  authors?(props?: {}): VNode[]
+  actions?(props?: {}): VNode[]
+  indicator?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/ChangelogVersion.vue
+++ b/src/runtime/components/ChangelogVersion.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/changelog-version'
 import type { BadgeProps, LinkProps, UserProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type ChangelogVersion = ComponentConfig<typeof theme, AppConfig, 'changelogVersion'>
 
@@ -40,17 +40,17 @@ export interface ChangelogVersionProps {
 }
 
 export interface ChangelogVersionSlots {
-  header?(props?: {}): VNode[]
-  badge?(props?: {}): VNode[]
-  date?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  image?(props?: {}): VNode[]
-  body?(props?: {}): VNode[]
-  footer?(props?: {}): VNode[]
-  authors?(props?: {}): VNode[]
-  actions?(props?: {}): VNode[]
-  indicator?(props?: {}): VNode[]
+  header?(props?: {}): SlotsReturn
+  badge?(props?: {}): SlotsReturn
+  date?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  image?(props?: {}): SlotsReturn
+  body?(props?: {}): SlotsReturn
+  footer?(props?: {}): SlotsReturn
+  authors?(props?: {}): SlotsReturn
+  actions?(props?: {}): SlotsReturn
+  indicator?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/ChangelogVersions.vue
+++ b/src/runtime/components/ChangelogVersions.vue
@@ -44,7 +44,6 @@ export interface ChangelogVersionsSlots<T extends ChangelogVersionProps = Change
   footer?(props: { version: T }): SlotsReturn
   authors?(props: { version: T }): SlotsReturn
   actions?(props: { version: T }): SlotsReturn
-  indicator?(props: { version: T }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/ChangelogVersions.vue
+++ b/src/runtime/components/ChangelogVersions.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { SpringOptions } from 'motion-v'
 import theme from '#build/ui/changelog-versions'
@@ -31,19 +32,19 @@ export interface ChangelogVersionsProps<T extends ChangelogVersionProps = Change
 }
 
 export interface ChangelogVersionsSlots<T extends ChangelogVersionProps = ChangelogVersionProps> {
-  default(props?: {}): any
-  indicator(props?: {}): any
-  header(props: { version: T }): any
-  badge(props: { version: T }): any
-  date(props: { version: T }): any
-  title(props: { version: T }): any
-  description(props: { version: T }): any
-  image(props: { version: T }): any
-  body(props: { version: T }): any
-  footer(props: { version: T }): any
-  authors(props: { version: T }): any
-  actions(props: { version: T }): any
-  indicator(props: { version: T }): any
+  default?(props?: {}): VNode[]
+  indicator?(props?: {}): VNode[]
+  header?(props: { version: T }): VNode[]
+  badge?(props: { version: T }): VNode[]
+  date?(props: { version: T }): VNode[]
+  title?(props: { version: T }): VNode[]
+  description?(props: { version: T }): VNode[]
+  image?(props: { version: T }): VNode[]
+  body?(props: { version: T }): VNode[]
+  footer?(props: { version: T }): VNode[]
+  authors?(props: { version: T }): VNode[]
+  actions?(props: { version: T }): VNode[]
+  indicator?(props: { version: T }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/ChangelogVersions.vue
+++ b/src/runtime/components/ChangelogVersions.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { SpringOptions } from 'motion-v'
 import theme from '#build/ui/changelog-versions'
 import type { ChangelogVersionProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type ChangelogVersions = ComponentConfig<typeof theme, AppConfig, 'changelogVersions'>
 
@@ -32,19 +32,19 @@ export interface ChangelogVersionsProps<T extends ChangelogVersionProps = Change
 }
 
 export interface ChangelogVersionsSlots<T extends ChangelogVersionProps = ChangelogVersionProps> {
-  default?(props?: {}): VNode[]
-  indicator?(props?: {}): VNode[]
-  header?(props: { version: T }): VNode[]
-  badge?(props: { version: T }): VNode[]
-  date?(props: { version: T }): VNode[]
-  title?(props: { version: T }): VNode[]
-  description?(props: { version: T }): VNode[]
-  image?(props: { version: T }): VNode[]
-  body?(props: { version: T }): VNode[]
-  footer?(props: { version: T }): VNode[]
-  authors?(props: { version: T }): VNode[]
-  actions?(props: { version: T }): VNode[]
-  indicator?(props: { version: T }): VNode[]
+  default?(props?: {}): SlotsReturn
+  indicator?(props?: {}): SlotsReturn
+  header?(props: { version: T }): SlotsReturn
+  badge?(props: { version: T }): SlotsReturn
+  date?(props: { version: T }): SlotsReturn
+  title?(props: { version: T }): SlotsReturn
+  description?(props: { version: T }): SlotsReturn
+  image?(props: { version: T }): SlotsReturn
+  body?(props: { version: T }): SlotsReturn
+  footer?(props: { version: T }): SlotsReturn
+  authors?(props: { version: T }): SlotsReturn
+  actions?(props: { version: T }): SlotsReturn
+  indicator?(props: { version: T }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/ChatMessage.vue
+++ b/src/runtime/components/ChatMessage.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { UIMessage } from 'ai'
 import theme from '#build/ui/chat-message'
 import type { AvatarProps, ButtonProps, IconProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type ChatMessage = ComponentConfig<typeof theme, AppConfig, 'chatMessage'>
 
@@ -49,9 +49,9 @@ export interface ChatMessageProps extends UIMessage {
 }
 
 export interface ChatMessageSlots {
-  leading?(props: { avatar: ChatMessageProps['avatar'] }): VNode[]
-  content?(props: ChatMessageProps): VNode[]
-  actions?(props: { actions: ChatMessageProps['actions'] }): VNode[]
+  leading?(props: { avatar: ChatMessageProps['avatar'] }): SlotsReturn
+  content?(props: ChatMessageProps): SlotsReturn
+  actions?(props: { actions: ChatMessageProps['actions'] }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/ChatMessage.vue
+++ b/src/runtime/components/ChatMessage.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { UIMessage } from 'ai'
 import theme from '#build/ui/chat-message'
@@ -48,9 +49,9 @@ export interface ChatMessageProps extends UIMessage {
 }
 
 export interface ChatMessageSlots {
-  leading(props: { avatar: ChatMessageProps['avatar'] }): any
-  content(props: ChatMessageProps): any
-  actions(props: { actions: ChatMessageProps['actions'] }): any
+  leading?(props: { avatar: ChatMessageProps['avatar'] }): VNode[]
+  content?(props: ChatMessageProps): VNode[]
+  actions?(props: { actions: ChatMessageProps['actions'] }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/ChatMessages.vue
+++ b/src/runtime/components/ChatMessages.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { ComponentPublicInstance, VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { UIMessage, ChatStatus } from 'ai'
 import theme from '#build/ui/chat-messages'
@@ -58,17 +59,16 @@ export interface ChatMessagesProps {
 }
 
 export interface ChatMessagesSlots {
-  default(props?: {}): any
-  indicator(props?: {}): any
-  viewport(props: { onClick: () => void }): any
-  content(props: { message: UIMessage }): any
-  leading(props: { message: UIMessage }): any
-  actions(props: { message: UIMessage }): any
+  default?(props?: {}): VNode[]
+  indicator?(props?: {}): VNode[]
+  viewport?(props: { onClick: () => void }): VNode[]
+  content?(props: { message: UIMessage }): VNode[]
+  leading?(props: { message: UIMessage }): VNode[]
+  actions?(props: { message: UIMessage }): VNode[]
 }
 </script>
 
 <script setup lang="ts">
-import type { ComponentPublicInstance } from 'vue'
 import { ref, computed, watch, nextTick, toRef, onMounted } from 'vue'
 import { Presence } from 'reka-ui'
 import { defu } from 'defu'

--- a/src/runtime/components/ChatMessages.vue
+++ b/src/runtime/components/ChatMessages.vue
@@ -1,10 +1,11 @@
 <script lang="ts">
-import type { ComponentPublicInstance, VNode } from 'vue'
+import type { ComponentPublicInstance } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { UIMessage, ChatStatus } from 'ai'
 import theme from '#build/ui/chat-messages'
 import type { ButtonProps, ChatMessageProps, IconProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type ChatMessages = ComponentConfig<typeof theme, AppConfig, 'chatMessages'>
 
@@ -59,12 +60,12 @@ export interface ChatMessagesProps {
 }
 
 export interface ChatMessagesSlots {
-  default?(props?: {}): VNode[]
-  indicator?(props?: {}): VNode[]
-  viewport?(props: { onClick: () => void }): VNode[]
-  content?(props: { message: UIMessage }): VNode[]
-  leading?(props: { message: UIMessage }): VNode[]
-  actions?(props: { message: UIMessage }): VNode[]
+  default?(props?: {}): SlotsReturn
+  indicator?(props?: {}): SlotsReturn
+  viewport?(props: { onClick: () => void }): SlotsReturn
+  content?(props: { message: UIMessage }): SlotsReturn
+  leading?(props: { message: UIMessage }): SlotsReturn
+  actions?(props: { message: UIMessage }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/ChatPalette.vue
+++ b/src/runtime/components/ChatPalette.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/chat-palette'
 import type { ComponentConfig } from '../types/tv'
@@ -16,8 +17,8 @@ export interface ChatPaletteProps {
 }
 
 export interface ChatPaletteSlots {
-  default(props?: {}): any
-  prompt(props?: {}): any
+  default?(props?: {}): VNode[]
+  prompt?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/ChatPalette.vue
+++ b/src/runtime/components/ChatPalette.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/chat-palette'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type ChatPalette = ComponentConfig<typeof theme, AppConfig, 'chatPalette'>
 
@@ -17,8 +17,8 @@ export interface ChatPaletteProps {
 }
 
 export interface ChatPaletteSlots {
-  default?(props?: {}): VNode[]
-  prompt?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
+  prompt?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/ChatPrompt.vue
+++ b/src/runtime/components/ChatPrompt.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/chat-prompt'
 import type { TextareaProps, TextareaSlots } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type ChatPrompt = ComponentConfig<typeof theme, AppConfig, 'chatPrompt'>
 
@@ -36,8 +36,8 @@ export interface ChatPromptEmits {
 }
 
 export interface ChatPromptSlots extends TextareaSlots {
-  header?(props?: {}): VNode[]
-  footer?(props?: {}): VNode[]
+  header?(props?: {}): SlotsReturn
+  footer?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/ChatPrompt.vue
+++ b/src/runtime/components/ChatPrompt.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/chat-prompt'
 import type { TextareaProps, TextareaSlots } from '../types'
@@ -35,8 +36,8 @@ export interface ChatPromptEmits {
 }
 
 export interface ChatPromptSlots extends TextareaSlots {
-  header(props?: {}): any
-  footer(props?: {}): any
+  header?(props?: {}): VNode[]
+  footer?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Checkbox.vue
+++ b/src/runtime/components/Checkbox.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { CheckboxRootProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/checkbox'
@@ -53,8 +54,8 @@ export type CheckboxEmits = {
 }
 
 export interface CheckboxSlots {
-  label(props: { label?: string }): any
-  description(props: { description?: string }): any
+  label?(props: { label?: string }): VNode[]
+  description?(props: { description?: string }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Checkbox.vue
+++ b/src/runtime/components/Checkbox.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { CheckboxRootProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/checkbox'
 import type { IconProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Checkbox = ComponentConfig<typeof theme, AppConfig, 'checkbox'>
 
@@ -54,8 +54,8 @@ export type CheckboxEmits = {
 }
 
 export interface CheckboxSlots {
-  label?(props: { label?: string }): VNode[]
-  description?(props: { description?: string }): VNode[]
+  label?(props: { label?: string }): SlotsReturn
+  description?(props: { description?: string }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/CheckboxGroup.vue
+++ b/src/runtime/components/CheckboxGroup.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { CheckboxGroupRootProps, CheckboxGroupRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/checkbox-group'
@@ -67,12 +68,12 @@ export type CheckboxGroupEmits<T extends CheckboxGroupItem[] = CheckboxGroupItem
   change: [event: Event]
 }
 
-type SlotProps<T extends CheckboxGroupItem> = (props: { item: T & { id: string } }) => any
+type SlotProps<T extends CheckboxGroupItem> = (props: { item: T & { id: string } }) => VNode[]
 
 export interface CheckboxGroupSlots<T extends CheckboxGroupItem[] = CheckboxGroupItem[]> {
-  legend(props?: {}): any
-  label: SlotProps<T[number]>
-  description: SlotProps<T[number]>
+  legend?(props?: {}): VNode[]
+  label?: SlotProps<T[number]>
+  description?: SlotProps<T[number]>
 }
 </script>
 

--- a/src/runtime/components/CheckboxGroup.vue
+++ b/src/runtime/components/CheckboxGroup.vue
@@ -1,10 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { CheckboxGroupRootProps, CheckboxGroupRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/checkbox-group'
 import type { CheckboxProps } from '../types'
-import type { AcceptableValue, GetItemKeys, GetModelValue } from '../types/utils'
+import type { AcceptableValue, GetItemKeys, GetModelValue, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type CheckboxGroup = ComponentConfig<typeof theme, AppConfig, 'checkboxGroup'>
@@ -68,10 +67,10 @@ export type CheckboxGroupEmits<T extends CheckboxGroupItem[] = CheckboxGroupItem
   change: [event: Event]
 }
 
-type SlotProps<T extends CheckboxGroupItem> = (props: { item: T & { id: string } }) => VNode[]
+type SlotProps<T extends CheckboxGroupItem> = (props: { item: T & { id: string } }) => SlotsReturn
 
 export interface CheckboxGroupSlots<T extends CheckboxGroupItem[] = CheckboxGroupItem[]> {
-  legend?(props?: {}): VNode[]
+  legend?(props?: {}): SlotsReturn
   label?: SlotProps<T[number]>
   description?: SlotProps<T[number]>
 }

--- a/src/runtime/components/Chip.vue
+++ b/src/runtime/components/Chip.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/chip'
 import type { ComponentConfig } from '../types/tv'
@@ -39,8 +40,8 @@ export interface ChipEmits {
 }
 
 export interface ChipSlots {
-  default(props?: {}): any
-  content(props?: {}): any
+  default?(props?: {}): VNode[]
+  content?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Chip.vue
+++ b/src/runtime/components/Chip.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/chip'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Chip = ComponentConfig<typeof theme, AppConfig, 'chip'>
 
@@ -40,8 +40,8 @@ export interface ChipEmits {
 }
 
 export interface ChipSlots {
-  default?(props?: {}): VNode[]
-  content?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
+  content?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Collapsible.vue
+++ b/src/runtime/components/Collapsible.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { CollapsibleRootProps, CollapsibleRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/collapsible'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Collapsible = ComponentConfig<typeof theme, AppConfig, 'collapsible'>
 
@@ -20,8 +20,8 @@ export interface CollapsibleProps extends Pick<CollapsibleRootProps, 'defaultOpe
 export interface CollapsibleEmits extends CollapsibleRootEmits {}
 
 export interface CollapsibleSlots {
-  default?(props: { open: boolean }): VNode[]
-  content?(props?: {}): VNode[]
+  default?(props: { open: boolean }): SlotsReturn
+  content?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Collapsible.vue
+++ b/src/runtime/components/Collapsible.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { CollapsibleRootProps, CollapsibleRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/collapsible'
@@ -19,8 +20,8 @@ export interface CollapsibleProps extends Pick<CollapsibleRootProps, 'defaultOpe
 export interface CollapsibleEmits extends CollapsibleRootEmits {}
 
 export interface CollapsibleSlots {
-  default(props: { open: boolean }): any
-  content(props?: {}): any
+  default?(props: { open: boolean }): VNode[]
+  content?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -1,6 +1,5 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { ListboxRootProps, ListboxRootEmits } from 'reka-ui'
 import type { FuseResult } from 'fuse.js'
 import type { AppConfig } from '@nuxt/schema'
@@ -8,7 +7,7 @@ import type { UseFuseOptions } from '@vueuse/integrations/useFuse'
 import theme from '#build/ui/command-palette'
 import type { UseComponentIconsProps } from '../composables/useComponentIcons'
 import type { AvatarProps, ButtonProps, ChipProps, KbdProps, InputProps, LinkProps, IconProps } from '../types'
-import type { GetItemKeys } from '../types/utils'
+import type { GetItemKeys, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type CommandPalette = ComponentConfig<typeof theme, AppConfig, 'commandPalette'>
@@ -162,13 +161,13 @@ export type CommandPaletteEmits<T extends CommandPaletteItem = CommandPaletteIte
   'update:open': [value: boolean]
 }
 
-type SlotProps<T> = (props: { item: T, index: number }) => VNode[]
+type SlotProps<T> = (props: { item: T, index: number }) => SlotsReturn
 
 export type CommandPaletteSlots<G extends CommandPaletteGroup<T> = CommandPaletteGroup<any>, T extends CommandPaletteItem = CommandPaletteItem> = {
-  'empty'?(props: { searchTerm?: string }): VNode[]
-  'footer'?(props: { ui: { [K in keyof Required<CommandPalette['slots']>]: (props?: Record<string, any>) => string } }): VNode[]
-  'back'?(props: { ui: { [K in keyof Required<CommandPalette['slots']>]: (props?: Record<string, any>) => string } }): VNode[]
-  'close'?(props: { ui: { [K in keyof Required<CommandPalette['slots']>]: (props?: Record<string, any>) => string } }): VNode[]
+  'empty'?(props: { searchTerm?: string }): SlotsReturn
+  'footer'?(props: { ui: { [K in keyof Required<CommandPalette['slots']>]: (props?: Record<string, any>) => string } }): SlotsReturn
+  'back'?(props: { ui: { [K in keyof Required<CommandPalette['slots']>]: (props?: Record<string, any>) => string } }): SlotsReturn
+  'close'?(props: { ui: { [K in keyof Required<CommandPalette['slots']>]: (props?: Record<string, any>) => string } }): SlotsReturn
   'item'?: SlotProps<T>
   'item-leading'?: SlotProps<T>
   'item-label'?: SlotProps<T>

--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { ListboxRootProps, ListboxRootEmits } from 'reka-ui'
 import type { FuseResult } from 'fuse.js'
 import type { AppConfig } from '@nuxt/schema'
@@ -161,17 +162,17 @@ export type CommandPaletteEmits<T extends CommandPaletteItem = CommandPaletteIte
   'update:open': [value: boolean]
 }
 
-type SlotProps<T> = (props: { item: T, index: number }) => any
+type SlotProps<T> = (props: { item: T, index: number }) => VNode[]
 
 export type CommandPaletteSlots<G extends CommandPaletteGroup<T> = CommandPaletteGroup<any>, T extends CommandPaletteItem = CommandPaletteItem> = {
-  'empty'(props: { searchTerm?: string }): any
-  'footer'(props: { ui: { [K in keyof Required<CommandPalette['slots']>]: (props?: Record<string, any>) => string } }): any
-  'back'(props: { ui: { [K in keyof Required<CommandPalette['slots']>]: (props?: Record<string, any>) => string } }): any
-  'close'(props: { ui: { [K in keyof Required<CommandPalette['slots']>]: (props?: Record<string, any>) => string } }): any
-  'item': SlotProps<T>
-  'item-leading': SlotProps<T>
-  'item-label': SlotProps<T>
-  'item-trailing': SlotProps<T>
+  'empty'?(props: { searchTerm?: string }): VNode[]
+  'footer'?(props: { ui: { [K in keyof Required<CommandPalette['slots']>]: (props?: Record<string, any>) => string } }): VNode[]
+  'back'?(props: { ui: { [K in keyof Required<CommandPalette['slots']>]: (props?: Record<string, any>) => string } }): VNode[]
+  'close'?(props: { ui: { [K in keyof Required<CommandPalette['slots']>]: (props?: Record<string, any>) => string } }): VNode[]
+  'item'?: SlotProps<T>
+  'item-leading'?: SlotProps<T>
+  'item-label'?: SlotProps<T>
+  'item-trailing'?: SlotProps<T>
 } & Record<string, SlotProps<G>> & Record<string, SlotProps<T>>
 
 </script>

--- a/src/runtime/components/Container.vue
+++ b/src/runtime/components/Container.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/container'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Container = ComponentConfig<typeof theme, AppConfig, 'container'>
 
@@ -16,7 +16,7 @@ export interface ContainerProps {
 }
 
 export interface ContainerSlots {
-  default?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Container.vue
+++ b/src/runtime/components/Container.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/container'
 import type { ComponentConfig } from '../types/tv'
@@ -15,7 +16,7 @@ export interface ContainerProps {
 }
 
 export interface ContainerSlots {
-  default(props?: {}): any
+  default?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/ContextMenu.vue
+++ b/src/runtime/components/ContextMenu.vue
@@ -1,11 +1,10 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { ContextMenuRootProps, ContextMenuRootEmits, ContextMenuContentProps, ContextMenuContentEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/context-menu'
 import type { AvatarProps, IconProps, KbdProps, LinkProps } from '../types'
-import type { ArrayOrNested, DynamicSlots, GetItemKeys, MergeTypes, NestedItem, EmitsToProps } from '../types/utils'
+import type { ArrayOrNested, DynamicSlots, GetItemKeys, MergeTypes, NestedItem, EmitsToProps, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type ContextMenu = ComponentConfig<typeof theme, AppConfig, 'contextMenu'>
@@ -83,19 +82,19 @@ export interface ContextMenuProps<T extends ArrayOrNested<ContextMenuItem> = Arr
 
 export interface ContextMenuEmits extends ContextMenuRootEmits {}
 
-type SlotProps<T extends ContextMenuItem> = (props: { item: T, active?: boolean, index: number }) => VNode[]
+type SlotProps<T extends ContextMenuItem> = (props: { item: T, active?: boolean, index: number }) => SlotsReturn
 
 export type ContextMenuSlots<
   A extends ArrayOrNested<ContextMenuItem> = ArrayOrNested<ContextMenuItem>,
   T extends NestedItem<A> = NestedItem<A>
 > = {
-  'default'?(props?: {}): VNode[]
+  'default'?(props?: {}): SlotsReturn
   'item'?: SlotProps<T>
   'item-leading'?: SlotProps<T>
   'item-label'?: SlotProps<T>
   'item-trailing'?: SlotProps<T>
-  'content-top'?: (props?: {}) => VNode[]
-  'content-bottom'?: (props?: {}) => VNode[]
+  'content-top'?: (props?: {}) => SlotsReturn
+  'content-bottom'?: (props?: {}) => SlotsReturn
 } & DynamicSlots<MergeTypes<T>, 'leading' | 'label' | 'trailing', { active?: boolean, index: number }>
 
 </script>

--- a/src/runtime/components/ContextMenu.vue
+++ b/src/runtime/components/ContextMenu.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { ContextMenuRootProps, ContextMenuRootEmits, ContextMenuContentProps, ContextMenuContentEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/context-menu'
@@ -82,19 +83,19 @@ export interface ContextMenuProps<T extends ArrayOrNested<ContextMenuItem> = Arr
 
 export interface ContextMenuEmits extends ContextMenuRootEmits {}
 
-type SlotProps<T extends ContextMenuItem> = (props: { item: T, active?: boolean, index: number }) => any
+type SlotProps<T extends ContextMenuItem> = (props: { item: T, active?: boolean, index: number }) => VNode[]
 
 export type ContextMenuSlots<
   A extends ArrayOrNested<ContextMenuItem> = ArrayOrNested<ContextMenuItem>,
   T extends NestedItem<A> = NestedItem<A>
 > = {
-  'default'(props?: {}): any
-  'item': SlotProps<T>
-  'item-leading': SlotProps<T>
-  'item-label': SlotProps<T>
-  'item-trailing': SlotProps<T>
-  'content-top': (props?: {}) => any
-  'content-bottom': (props?: {}) => any
+  'default'?(props?: {}): VNode[]
+  'item'?: SlotProps<T>
+  'item-leading'?: SlotProps<T>
+  'item-label'?: SlotProps<T>
+  'item-trailing'?: SlotProps<T>
+  'content-top'?: (props?: {}) => VNode[]
+  'content-bottom'?: (props?: {}) => VNode[]
 } & DynamicSlots<MergeTypes<T>, 'leading' | 'label' | 'trailing', { active?: boolean, index: number }>
 
 </script>

--- a/src/runtime/components/DashboardGroup.vue
+++ b/src/runtime/components/DashboardGroup.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dashboard-group'
 import type { UseResizableProps } from '../composables/useResizable'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type DashboardGroup = ComponentConfig<typeof theme, AppConfig, 'dashboardGroup'>
 
@@ -17,7 +17,7 @@ export interface DashboardGroupProps extends Pick<UseResizableProps, 'storage' |
 }
 
 export interface DashboardGroupSlots {
-  default?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/DashboardGroup.vue
+++ b/src/runtime/components/DashboardGroup.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dashboard-group'
 import type { UseResizableProps } from '../composables/useResizable'
@@ -16,7 +17,7 @@ export interface DashboardGroupProps extends Pick<UseResizableProps, 'storage' |
 }
 
 export interface DashboardGroupSlots {
-  default(props?: {}): any
+  default?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/DashboardNavbar.vue
+++ b/src/runtime/components/DashboardNavbar.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
-import type { VNodeChild } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dashboard-navbar'
 import type { DashboardContext } from '../utils/dashboard'
 import type { ButtonProps, IconProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type DashboardNavbar = ComponentConfig<typeof theme, AppConfig, 'dashboardNavbar'>
 
@@ -38,13 +38,13 @@ export interface DashboardNavbarProps {
 type DashboardNavbarSlotsProps = Omit<DashboardContext, 'storage' | 'storageKey' | 'persistent' | 'unit'>
 
 export interface DashboardNavbarSlots {
-  title?(props?: {}): VNodeChild
-  leading?(props: DashboardNavbarSlotsProps): VNodeChild
-  trailing?(props: DashboardNavbarSlotsProps): VNodeChild
-  left?(props: DashboardNavbarSlotsProps): VNodeChild
-  default?(props: DashboardNavbarSlotsProps): VNodeChild
-  right?(props: DashboardNavbarSlotsProps): VNodeChild
-  toggle?(props: DashboardNavbarSlotsProps): VNodeChild
+  title?(props?: {}): SlotsReturn
+  leading?(props: DashboardNavbarSlotsProps): SlotsReturn
+  trailing?(props: DashboardNavbarSlotsProps): SlotsReturn
+  left?(props: DashboardNavbarSlotsProps): SlotsReturn
+  default?(props: DashboardNavbarSlotsProps): SlotsReturn
+  right?(props: DashboardNavbarSlotsProps): SlotsReturn
+  toggle?(props: DashboardNavbarSlotsProps): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/DashboardNavbar.vue
+++ b/src/runtime/components/DashboardNavbar.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { VNode } from 'vue'
+import type { VNodeChild } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dashboard-navbar'
 import type { DashboardContext } from '../utils/dashboard'
@@ -38,13 +38,13 @@ export interface DashboardNavbarProps {
 type DashboardNavbarSlotsProps = Omit<DashboardContext, 'storage' | 'storageKey' | 'persistent' | 'unit'>
 
 export interface DashboardNavbarSlots {
-  title?(props?: {}): VNode[]
-  leading?(props: DashboardNavbarSlotsProps): VNode[]
-  trailing?(props: DashboardNavbarSlotsProps): VNode[]
-  left?(props: DashboardNavbarSlotsProps): VNode[]
-  default?(props: DashboardNavbarSlotsProps): VNode[]
-  right?(props: DashboardNavbarSlotsProps): VNode[]
-  toggle?(props: DashboardNavbarSlotsProps): VNode[]
+  title?(props?: {}): VNodeChild
+  leading?(props: DashboardNavbarSlotsProps): VNodeChild
+  trailing?(props: DashboardNavbarSlotsProps): VNodeChild
+  left?(props: DashboardNavbarSlotsProps): VNodeChild
+  default?(props: DashboardNavbarSlotsProps): VNodeChild
+  right?(props: DashboardNavbarSlotsProps): VNodeChild
+  toggle?(props: DashboardNavbarSlotsProps): VNodeChild
 }
 </script>
 

--- a/src/runtime/components/DashboardNavbar.vue
+++ b/src/runtime/components/DashboardNavbar.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dashboard-navbar'
 import type { DashboardContext } from '../utils/dashboard'
@@ -37,13 +38,13 @@ export interface DashboardNavbarProps {
 type DashboardNavbarSlotsProps = Omit<DashboardContext, 'storage' | 'storageKey' | 'persistent' | 'unit'>
 
 export interface DashboardNavbarSlots {
-  title(props?: {}): any
-  leading(props: DashboardNavbarSlotsProps): any
-  trailing(props: DashboardNavbarSlotsProps): any
-  left(props: DashboardNavbarSlotsProps): any
-  default(props: DashboardNavbarSlotsProps): any
-  right(props: DashboardNavbarSlotsProps): any
-  toggle(props: DashboardNavbarSlotsProps): any
+  title?(props?: {}): VNode[]
+  leading?(props: DashboardNavbarSlotsProps): VNode[]
+  trailing?(props: DashboardNavbarSlotsProps): VNode[]
+  left?(props: DashboardNavbarSlotsProps): VNode[]
+  default?(props: DashboardNavbarSlotsProps): VNode[]
+  right?(props: DashboardNavbarSlotsProps): VNode[]
+  toggle?(props: DashboardNavbarSlotsProps): VNode[]
 }
 </script>
 

--- a/src/runtime/components/DashboardPanel.vue
+++ b/src/runtime/components/DashboardPanel.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dashboard-panel'
 import type { UseResizableProps } from '../composables/useResizable'
@@ -12,11 +13,11 @@ export interface DashboardPanelProps extends Pick<UseResizableProps, 'id' | 'min
 }
 
 export interface DashboardPanelSlots {
-  'default'(props?: {}): any
-  'header'(props?: {}): any
-  'body'(props?: {}): any
-  'footer'(props?: {}): any
-  'resize-handle'(props: { onMouseDown: (e: MouseEvent) => void, onTouchStart: (e: TouchEvent) => void, onDoubleClick: (e: MouseEvent) => void }): any
+  'default'?(props?: {}): VNode[]
+  'header'?(props?: {}): VNode[]
+  'body'?(props?: {}): VNode[]
+  'footer'?(props?: {}): VNode[]
+  'resize-handle'?(props: { onMouseDown: (e: MouseEvent) => void, onTouchStart: (e: TouchEvent) => void, onDoubleClick: (e: MouseEvent) => void }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/DashboardPanel.vue
+++ b/src/runtime/components/DashboardPanel.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dashboard-panel'
 import type { UseResizableProps } from '../composables/useResizable'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type DashboardPanel = ComponentConfig<typeof theme, AppConfig, 'dashboardPanel'>
 
@@ -13,11 +13,11 @@ export interface DashboardPanelProps extends Pick<UseResizableProps, 'id' | 'min
 }
 
 export interface DashboardPanelSlots {
-  'default'?(props?: {}): VNode[]
-  'header'?(props?: {}): VNode[]
-  'body'?(props?: {}): VNode[]
-  'footer'?(props?: {}): VNode[]
-  'resize-handle'?(props: { onMouseDown: (e: MouseEvent) => void, onTouchStart: (e: TouchEvent) => void, onDoubleClick: (e: MouseEvent) => void }): VNode[]
+  'default'?(props?: {}): SlotsReturn
+  'header'?(props?: {}): SlotsReturn
+  'body'?(props?: {}): SlotsReturn
+  'footer'?(props?: {}): SlotsReturn
+  'resize-handle'?(props: { onMouseDown: (e: MouseEvent) => void, onTouchStart: (e: TouchEvent) => void, onDoubleClick: (e: MouseEvent) => void }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/DashboardResizeHandle.vue
+++ b/src/runtime/components/DashboardResizeHandle.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dashboard-resize-handle'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type DashboardResizeHandle = ComponentConfig<typeof theme, AppConfig, 'dashboardResizeHandle'>
 
@@ -16,7 +16,7 @@ export interface DashboardResizeHandleProps {
 }
 
 export interface DashboardResizeHandleSlots {
-  default?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/DashboardResizeHandle.vue
+++ b/src/runtime/components/DashboardResizeHandle.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dashboard-resize-handle'
 import type { ComponentConfig } from '../types/tv'
@@ -15,7 +16,7 @@ export interface DashboardResizeHandleProps {
 }
 
 export interface DashboardResizeHandleSlots {
-  default(props?: {}): any
+  default?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/DashboardSearch.vue
+++ b/src/runtime/components/DashboardSearch.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { UseFuseOptions } from '@vueuse/integrations/useFuse'
 import theme from '#build/ui/dashboard-search'
@@ -67,7 +68,7 @@ export interface DashboardSearchProps<T extends CommandPaletteItem = CommandPale
 }
 
 export type DashboardSearchSlots = CommandPaletteSlots<CommandPaletteGroup<CommandPaletteItem>, CommandPaletteItem> & {
-  content(props?: {}): any
+  content?(props?: {}): VNode[]
 }
 
 </script>

--- a/src/runtime/components/DashboardSearch.vue
+++ b/src/runtime/components/DashboardSearch.vue
@@ -1,11 +1,11 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { UseFuseOptions } from '@vueuse/integrations/useFuse'
 import theme from '#build/ui/dashboard-search'
 import type { ButtonProps, InputProps, ModalProps, CommandPaletteProps, CommandPaletteSlots, CommandPaletteGroup, CommandPaletteItem, IconProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type DashboardSearch = ComponentConfig<typeof theme, AppConfig, 'dashboardSearch'>
 
@@ -68,7 +68,7 @@ export interface DashboardSearchProps<T extends CommandPaletteItem = CommandPale
 }
 
 export type DashboardSearchSlots = CommandPaletteSlots<CommandPaletteGroup<CommandPaletteItem>, CommandPaletteItem> & {
-  content?(props?: {}): VNode[]
+  content?(props?: {}): SlotsReturn
 }
 
 </script>

--- a/src/runtime/components/DashboardSidebar.vue
+++ b/src/runtime/components/DashboardSidebar.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dashboard-sidebar'
 import type { UseResizableProps } from '../composables/useResizable'
@@ -36,12 +37,12 @@ export interface DashboardSidebarProps<T extends DashboardSidebarMode = Dashboar
 }
 
 export interface DashboardSidebarSlots {
-  'header'(props: { collapsed?: boolean, collapse?: (value: boolean) => void }): any
-  'default'(props: { collapsed?: boolean, collapse?: (value: boolean) => void }): any
-  'footer'(props: { collapsed?: boolean, collapse?: (value: boolean) => void }): any
-  'toggle'(props: { open: boolean, toggle: () => void }): any
-  'content'(props?: {}): any
-  'resize-handle'(props: { onMouseDown: (e: MouseEvent) => void, onTouchStart: (e: TouchEvent) => void, onDoubleClick: (e: MouseEvent) => void }): any
+  'header'?(props: { collapsed?: boolean, collapse?: (value: boolean) => void }): VNode[]
+  'default'?(props: { collapsed?: boolean, collapse?: (value: boolean) => void }): VNode[]
+  'footer'?(props: { collapsed?: boolean, collapse?: (value: boolean) => void }): VNode[]
+  'toggle'?(props: { open: boolean, toggle: () => void }): VNode[]
+  'content'?(props?: {}): VNode[]
+  'resize-handle'?(props: { onMouseDown: (e: MouseEvent) => void, onTouchStart: (e: TouchEvent) => void, onDoubleClick: (e: MouseEvent) => void }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/DashboardSidebar.vue
+++ b/src/runtime/components/DashboardSidebar.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dashboard-sidebar'
 import type { UseResizableProps } from '../composables/useResizable'
 import type { ButtonProps, DrawerProps, ModalProps, SlideoverProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type DashboardSidebar = ComponentConfig<typeof theme, AppConfig, 'dashboardSidebar'>
 
@@ -37,12 +37,12 @@ export interface DashboardSidebarProps<T extends DashboardSidebarMode = Dashboar
 }
 
 export interface DashboardSidebarSlots {
-  'header'?(props: { collapsed?: boolean, collapse?: (value: boolean) => void }): VNode[]
-  'default'?(props: { collapsed?: boolean, collapse?: (value: boolean) => void }): VNode[]
-  'footer'?(props: { collapsed?: boolean, collapse?: (value: boolean) => void }): VNode[]
-  'toggle'?(props: { open: boolean, toggle: () => void }): VNode[]
-  'content'?(props?: {}): VNode[]
-  'resize-handle'?(props: { onMouseDown: (e: MouseEvent) => void, onTouchStart: (e: TouchEvent) => void, onDoubleClick: (e: MouseEvent) => void }): VNode[]
+  'header'?(props: { collapsed?: boolean, collapse?: (value: boolean) => void }): SlotsReturn
+  'default'?(props: { collapsed?: boolean, collapse?: (value: boolean) => void }): SlotsReturn
+  'footer'?(props: { collapsed?: boolean, collapse?: (value: boolean) => void }): SlotsReturn
+  'toggle'?(props: { open: boolean, toggle: () => void }): SlotsReturn
+  'content'?(props?: {}): SlotsReturn
+  'resize-handle'?(props: { onMouseDown: (e: MouseEvent) => void, onTouchStart: (e: TouchEvent) => void, onDoubleClick: (e: MouseEvent) => void }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/DashboardToolbar.vue
+++ b/src/runtime/components/DashboardToolbar.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dashboard-toolbar'
 import type { ComponentConfig } from '../types/tv'
@@ -16,9 +17,9 @@ export interface DashboardToolbarProps {
 }
 
 export interface DashboardToolbarSlots {
-  default(props?: {}): any
-  left(props?: {}): any
-  right(props?: {}): any
+  default?(props?: {}): VNode[]
+  left?(props?: {}): VNode[]
+  right?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/DashboardToolbar.vue
+++ b/src/runtime/components/DashboardToolbar.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dashboard-toolbar'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type DashboardToolbar = ComponentConfig<typeof theme, AppConfig, 'dashboardToolbar'>
 
@@ -17,9 +17,9 @@ export interface DashboardToolbarProps {
 }
 
 export interface DashboardToolbarSlots {
-  default?(props?: {}): VNode[]
-  left?(props?: {}): VNode[]
-  right?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
+  left?(props?: {}): SlotsReturn
+  right?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Drawer.vue
+++ b/src/runtime/components/Drawer.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { DrawerRootProps, DrawerRootEmits } from 'vaul-vue'
 import type { DialogContentProps, DialogContentEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
@@ -52,13 +53,13 @@ export interface DrawerEmits extends DrawerRootEmits {
 }
 
 export interface DrawerSlots {
-  default(props?: {}): any
-  content(props?: {}): any
-  header(props?: {}): any
-  title(props?: {}): any
-  description(props?: {}): any
-  body(props?: {}): any
-  footer(props?: {}): any
+  default?(props?: {}): VNode[]
+  content?(props?: {}): VNode[]
+  header?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  body?(props?: {}): VNode[]
+  footer?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Drawer.vue
+++ b/src/runtime/components/Drawer.vue
@@ -1,10 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { DrawerRootProps, DrawerRootEmits } from 'vaul-vue'
 import type { DialogContentProps, DialogContentEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/drawer'
-import type { EmitsToProps } from '../types/utils'
+import type { EmitsToProps, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Drawer = ComponentConfig<typeof theme, AppConfig, 'drawer'>
@@ -53,13 +52,13 @@ export interface DrawerEmits extends DrawerRootEmits {
 }
 
 export interface DrawerSlots {
-  default?(props?: {}): VNode[]
-  content?(props?: {}): VNode[]
-  header?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  body?(props?: {}): VNode[]
-  footer?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
+  content?(props?: {}): SlotsReturn
+  header?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  body?(props?: {}): SlotsReturn
+  footer?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/DropdownMenu.vue
+++ b/src/runtime/components/DropdownMenu.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { DropdownMenuRootProps, DropdownMenuRootEmits, DropdownMenuContentProps, DropdownMenuContentEmits, DropdownMenuArrowProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dropdown-menu'
@@ -90,19 +91,19 @@ export interface DropdownMenuProps<T extends ArrayOrNested<DropdownMenuItem> = A
 
 export interface DropdownMenuEmits extends DropdownMenuRootEmits {}
 
-type SlotProps<T extends DropdownMenuItem> = (props: { item: T, active?: boolean, index: number }) => any
+type SlotProps<T extends DropdownMenuItem> = (props: { item: T, active?: boolean, index: number }) => VNode[]
 
 export type DropdownMenuSlots<
   A extends ArrayOrNested<DropdownMenuItem> = ArrayOrNested<DropdownMenuItem>,
   T extends NestedItem<A> = NestedItem<A>
 > = {
-  'default'(props: { open: boolean }): any
-  'item': SlotProps<T>
-  'item-leading': SlotProps<T>
-  'item-label': SlotProps<T>
-  'item-trailing': SlotProps<T>
-  'content-top': (props?: {}) => any
-  'content-bottom': (props?: {}) => any
+  'default'?(props: { open: boolean }): VNode[]
+  'item'?: SlotProps<T>
+  'item-leading'?: SlotProps<T>
+  'item-label'?: SlotProps<T>
+  'item-trailing'?: SlotProps<T>
+  'content-top'?: (props?: {}) => VNode[]
+  'content-bottom'?: (props?: {}) => VNode[]
 } & DynamicSlots<MergeTypes<T>, 'leading' | 'label' | 'trailing', { active?: boolean, index: number }>
 
 </script>

--- a/src/runtime/components/DropdownMenu.vue
+++ b/src/runtime/components/DropdownMenu.vue
@@ -1,11 +1,10 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { DropdownMenuRootProps, DropdownMenuRootEmits, DropdownMenuContentProps, DropdownMenuContentEmits, DropdownMenuArrowProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/dropdown-menu'
 import type { AvatarProps, IconProps, KbdProps, LinkProps } from '../types'
-import type { ArrayOrNested, DynamicSlots, GetItemKeys, MergeTypes, NestedItem, EmitsToProps } from '../types/utils'
+import type { ArrayOrNested, DynamicSlots, GetItemKeys, MergeTypes, NestedItem, EmitsToProps, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type DropdownMenu = ComponentConfig<typeof theme, AppConfig, 'dropdownMenu'>
@@ -91,19 +90,19 @@ export interface DropdownMenuProps<T extends ArrayOrNested<DropdownMenuItem> = A
 
 export interface DropdownMenuEmits extends DropdownMenuRootEmits {}
 
-type SlotProps<T extends DropdownMenuItem> = (props: { item: T, active?: boolean, index: number }) => VNode[]
+type SlotProps<T extends DropdownMenuItem> = (props: { item: T, active?: boolean, index: number }) => SlotsReturn
 
 export type DropdownMenuSlots<
   A extends ArrayOrNested<DropdownMenuItem> = ArrayOrNested<DropdownMenuItem>,
   T extends NestedItem<A> = NestedItem<A>
 > = {
-  'default'?(props: { open: boolean }): VNode[]
+  'default'?(props: { open: boolean }): SlotsReturn
   'item'?: SlotProps<T>
   'item-leading'?: SlotProps<T>
   'item-label'?: SlotProps<T>
   'item-trailing'?: SlotProps<T>
-  'content-top'?: (props?: {}) => VNode[]
-  'content-bottom'?: (props?: {}) => VNode[]
+  'content-top'?: (props?: {}) => SlotsReturn
+  'content-bottom'?: (props?: {}) => SlotsReturn
 } & DynamicSlots<MergeTypes<T>, 'leading' | 'label' | 'trailing', { active?: boolean, index: number }>
 
 </script>

--- a/src/runtime/components/DropdownMenuContent.vue
+++ b/src/runtime/components/DropdownMenuContent.vue
@@ -1,11 +1,10 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { DropdownMenuContentProps as RekaDropdownMenuContentProps, DropdownMenuContentEmits as RekaDropdownMenuContentEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import type theme from '#build/ui/dropdown-menu'
 import type { KbdProps, AvatarProps, DropdownMenuItem, DropdownMenuSlots, IconProps } from '../types'
-import type { ArrayOrNested, GetItemKeys, NestedItem, DynamicSlots, MergeTypes } from '../types/utils'
+import type { ArrayOrNested, GetItemKeys, NestedItem, DynamicSlots, MergeTypes, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type DropdownMenu = ComponentConfig<typeof theme, AppConfig, 'dropdownMenu'>
@@ -38,7 +37,7 @@ type DropdownMenuContentSlots<
   A extends ArrayOrNested<DropdownMenuItem> = ArrayOrNested<DropdownMenuItem>,
   T extends NestedItem<A> = NestedItem<A>
 > = Pick<DropdownMenuSlots<A>, 'item' | 'item-leading' | 'item-label' | 'item-trailing' | 'content-top' | 'content-bottom'> & {
-  default?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
 } & DynamicSlots<MergeTypes<T>, 'leading' | 'label' | 'trailing', { active?: boolean, index: number }>
 
 </script>

--- a/src/runtime/components/DropdownMenuContent.vue
+++ b/src/runtime/components/DropdownMenuContent.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { DropdownMenuContentProps as RekaDropdownMenuContentProps, DropdownMenuContentEmits as RekaDropdownMenuContentEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import type theme from '#build/ui/dropdown-menu'
@@ -37,7 +38,7 @@ type DropdownMenuContentSlots<
   A extends ArrayOrNested<DropdownMenuItem> = ArrayOrNested<DropdownMenuItem>,
   T extends NestedItem<A> = NestedItem<A>
 > = Pick<DropdownMenuSlots<A>, 'item' | 'item-leading' | 'item-label' | 'item-trailing' | 'content-top' | 'content-bottom'> & {
-  default(props?: {}): any
+  default?(props?: {}): VNode[]
 } & DynamicSlots<MergeTypes<T>, 'leading' | 'label' | 'trailing', { active?: boolean, index: number }>
 
 </script>

--- a/src/runtime/components/Empty.vue
+++ b/src/runtime/components/Empty.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/empty'
 import type { ComponentConfig } from '../types/tv'
@@ -37,13 +38,13 @@ export interface EmptyProps {
 }
 
 export interface EmptySlots {
-  header(props?: {}): any
-  leading(props?: {}): any
-  title(props?: {}): any
-  description(props?: {}): any
-  body(props?: {}): any
-  actions(props?: {}): any
-  footer(props?: {}): any
+  header?(props?: {}): VNode[]
+  leading?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  body?(props?: {}): VNode[]
+  actions?(props?: {}): VNode[]
+  footer?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Empty.vue
+++ b/src/runtime/components/Empty.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/empty'
 import type { ComponentConfig } from '../types/tv'
 import type { ButtonProps, IconProps, AvatarProps } from '../types'
+import type { SlotsReturn } from '../types/utils'
 
 type Empty = ComponentConfig<typeof theme, AppConfig, 'empty'>
 
@@ -38,13 +38,13 @@ export interface EmptyProps {
 }
 
 export interface EmptySlots {
-  header?(props?: {}): VNode[]
-  leading?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  body?(props?: {}): VNode[]
-  actions?(props?: {}): VNode[]
-  footer?(props?: {}): VNode[]
+  header?(props?: {}): SlotsReturn
+  leading?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  body?(props?: {}): SlotsReturn
+  actions?(props?: {}): SlotsReturn
+  footer?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Error.vue
+++ b/src/runtime/components/Error.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { NuxtError } from '#app'
 import theme from '#build/ui/error'
@@ -30,11 +31,11 @@ export interface ErrorProps {
 }
 
 export interface ErrorSlots {
-  default(props?: {}): any
-  statusCode(props?: {}): any
-  statusMessage(props?: {}): any
-  message(props?: {}): any
-  links(props?: {}): any
+  default?(props?: {}): VNode[]
+  statusCode?(props?: {}): VNode[]
+  statusMessage?(props?: {}): VNode[]
+  message?(props?: {}): VNode[]
+  links?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Error.vue
+++ b/src/runtime/components/Error.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { NuxtError } from '#app'
 import theme from '#build/ui/error'
 import type { ButtonProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Error = ComponentConfig<typeof theme, AppConfig, 'error'>
 
@@ -31,11 +31,11 @@ export interface ErrorProps {
 }
 
 export interface ErrorSlots {
-  default?(props?: {}): VNode[]
-  statusCode?(props?: {}): VNode[]
-  statusMessage?(props?: {}): VNode[]
-  message?(props?: {}): VNode[]
-  links?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
+  statusCode?(props?: {}): SlotsReturn
+  statusMessage?(props?: {}): SlotsReturn
+  message?(props?: {}): SlotsReturn
+  links?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/FieldGroup.vue
+++ b/src/runtime/components/FieldGroup.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/field-group'
 import type { ComponentConfig } from '../types/tv'
@@ -25,7 +26,7 @@ export interface FieldGroupProps {
 }
 
 export interface FieldGroupSlots {
-  default(props?: {}): any
+  default?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/FieldGroup.vue
+++ b/src/runtime/components/FieldGroup.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/field-group'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type FieldGroup = ComponentConfig<typeof theme, AppConfig, 'fieldGroup'>
 
@@ -26,7 +26,7 @@ export interface FieldGroupProps {
 }
 
 export interface FieldGroupSlots {
-  default?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/FileUpload.vue
+++ b/src/runtime/components/FileUpload.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { UseFileDialogReturn } from '@vueuse/core'
 import theme from '#build/ui/file-upload'
 import type { ButtonProps, IconProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type FileUpload = ComponentConfig<typeof theme, AppConfig, 'fileUpload'>
 
@@ -107,19 +107,19 @@ export interface FileUploadSlots<M extends boolean = false> {
   'default'?(props: {
     open: UseFileDialogReturn['open']
     removeFile: (index?: number) => void
-  }): VNode[]
-  'leading'?(props?: {}): VNode[]
-  'label'?(props?: {}): VNode[]
-  'description'?(props?: {}): VNode[]
-  'actions'?(props: { files?: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): VNode[]
-  'files'?(props: { files?: FileUploadFiles<M> }): VNode[]
-  'files-top'?(props: { files?: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): VNode[]
-  'files-bottom'?(props: { files?: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): VNode[]
-  'file'?(props: { file: File, index: number }): VNode[]
-  'file-leading'?(props: { file: File, index: number }): VNode[]
-  'file-name'?(props: { file: File, index: number }): VNode[]
-  'file-size'?(props: { file: File, index: number }): VNode[]
-  'file-trailing'?(props: { file: File, index: number }): VNode[]
+  }): SlotsReturn
+  'leading'?(props?: {}): SlotsReturn
+  'label'?(props?: {}): SlotsReturn
+  'description'?(props?: {}): SlotsReturn
+  'actions'?(props: { files?: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): SlotsReturn
+  'files'?(props: { files?: FileUploadFiles<M> }): SlotsReturn
+  'files-top'?(props: { files?: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): SlotsReturn
+  'files-bottom'?(props: { files?: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): SlotsReturn
+  'file'?(props: { file: File, index: number }): SlotsReturn
+  'file-leading'?(props: { file: File, index: number }): SlotsReturn
+  'file-name'?(props: { file: File, index: number }): SlotsReturn
+  'file-size'?(props: { file: File, index: number }): SlotsReturn
+  'file-trailing'?(props: { file: File, index: number }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/FileUpload.vue
+++ b/src/runtime/components/FileUpload.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { UseFileDialogReturn } from '@vueuse/core'
 import theme from '#build/ui/file-upload'
@@ -103,22 +104,22 @@ export interface FileUploadEmits {
 type FileUploadFiles<M> = (M extends true ? File[] : File) | null
 
 export interface FileUploadSlots<M extends boolean = false> {
-  'default'(props: {
+  'default'?(props: {
     open: UseFileDialogReturn['open']
     removeFile: (index?: number) => void
-  }): any
-  'leading'(props?: {}): any
-  'label'(props?: {}): any
-  'description'(props?: {}): any
-  'actions'(props: { files?: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): any
-  'files'(props: { files?: FileUploadFiles<M> }): any
-  'files-top'(props: { files?: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): any
-  'files-bottom'(props: { files?: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): any
-  'file'(props: { file: File, index: number }): any
-  'file-leading'(props: { file: File, index: number }): any
-  'file-name'(props: { file: File, index: number }): any
-  'file-size'(props: { file: File, index: number }): any
-  'file-trailing'(props: { file: File, index: number }): any
+  }): VNode[]
+  'leading'?(props?: {}): VNode[]
+  'label'?(props?: {}): VNode[]
+  'description'?(props?: {}): VNode[]
+  'actions'?(props: { files?: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): VNode[]
+  'files'?(props: { files?: FileUploadFiles<M> }): VNode[]
+  'files-top'?(props: { files?: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): VNode[]
+  'files-bottom'?(props: { files?: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): VNode[]
+  'file'?(props: { file: File, index: number }): VNode[]
+  'file-leading'?(props: { file: File, index: number }): VNode[]
+  'file-name'?(props: { file: File, index: number }): VNode[]
+  'file-size'?(props: { file: File, index: number }): VNode[]
+  'file-trailing'?(props: { file: File, index: number }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Footer.vue
+++ b/src/runtime/components/Footer.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../types/tv'
 import theme from '#build/ui/footer'
@@ -16,11 +17,11 @@ export interface FooterProps {
 }
 
 export interface FooterSlots {
-  left(props?: {}): any
-  default(props?: {}): any
-  right(props?: {}): any
-  top(props?: {}): any
-  bottom(props?: {}): any
+  left?(props?: {}): VNode[]
+  default?(props?: {}): VNode[]
+  right?(props?: {}): VNode[]
+  top?(props?: {}): VNode[]
+  bottom?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Footer.vue
+++ b/src/runtime/components/Footer.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 import theme from '#build/ui/footer'
 
 type Footer = ComponentConfig<typeof theme, AppConfig, 'footer'>
@@ -17,11 +17,11 @@ export interface FooterProps {
 }
 
 export interface FooterSlots {
-  left?(props?: {}): VNode[]
-  default?(props?: {}): VNode[]
-  right?(props?: {}): VNode[]
-  top?(props?: {}): VNode[]
-  bottom?(props?: {}): VNode[]
+  left?(props?: {}): SlotsReturn
+  default?(props?: {}): SlotsReturn
+  right?(props?: {}): SlotsReturn
+  top?(props?: {}): SlotsReturn
+  bottom?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/FooterColumns.vue
+++ b/src/runtime/components/FooterColumns.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/footer-columns'
 import type { IconProps, LinkProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type FooterColumns = ComponentConfig<typeof theme, AppConfig, 'footerColumns'>
 
@@ -33,13 +33,13 @@ export interface FooterColumnsProps<T extends FooterColumnLink = FooterColumnLin
   ui?: FooterColumns['slots']
 }
 
-type SlotProps<T> = (props: { link: T, active: boolean }) => VNode[]
+type SlotProps<T> = (props: { link: T, active: boolean }) => SlotsReturn
 
 export interface FooterColumnsSlots<T extends FooterColumnLink = FooterColumnLink> {
-  'left'?(props?: {}): VNode[]
-  'default'?(props?: {}): VNode[]
-  'right'?(props?: {}): VNode[]
-  'column-label'?: (props: { column: FooterColumn<T> }) => VNode[]
+  'left'?(props?: {}): SlotsReturn
+  'default'?(props?: {}): SlotsReturn
+  'right'?(props?: {}): SlotsReturn
+  'column-label'?: (props: { column: FooterColumn<T> }) => SlotsReturn
   'link'?: SlotProps<T>
   'link-leading'?: SlotProps<T>
   'link-label'?: SlotProps<T>

--- a/src/runtime/components/FooterColumns.vue
+++ b/src/runtime/components/FooterColumns.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/footer-columns'
 import type { IconProps, LinkProps } from '../types'
@@ -32,17 +33,17 @@ export interface FooterColumnsProps<T extends FooterColumnLink = FooterColumnLin
   ui?: FooterColumns['slots']
 }
 
-type SlotProps<T> = (props: { link: T, active: boolean }) => any
+type SlotProps<T> = (props: { link: T, active: boolean }) => VNode[]
 
 export interface FooterColumnsSlots<T extends FooterColumnLink = FooterColumnLink> {
-  'left'(props?: {}): any
-  'default'(props?: {}): any
-  'right'(props?: {}): any
-  'column-label'?: (props: { column: FooterColumn<T> }) => any
-  'link': SlotProps<T>
-  'link-leading': SlotProps<T>
-  'link-label': SlotProps<T>
-  'link-trailing': SlotProps<T>
+  'left'?(props?: {}): VNode[]
+  'default'?(props?: {}): VNode[]
+  'right'?(props?: {}): VNode[]
+  'column-label'?: (props: { column: FooterColumn<T> }) => VNode[]
+  'link'?: SlotProps<T>
+  'link-leading'?: SlotProps<T>
+  'link-label'?: SlotProps<T>
+  'link-trailing'?: SlotProps<T>
 }
 </script>
 

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/form'
 import type { FormSchema, FormError, FormInputEvents, FormErrorEvent, FormSubmitEvent, FormEvent, Form, FormErrorWithId, InferInput, InferOutput, FormData } from '../types/form'
@@ -68,7 +69,7 @@ export interface FormEmits<S extends FormSchema, T extends boolean = true> {
 }
 
 export interface FormSlots {
-  default(props: { errors: FormError[], loading: boolean }): any
+  default(props: { errors: FormError[], loading: boolean }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/form'
 import type { FormSchema, FormError, FormInputEvents, FormErrorEvent, FormSubmitEvent, FormEvent, Form, FormErrorWithId, InferInput, InferOutput, FormData } from '../types/form'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type FormConfig = ComponentConfig<typeof theme, AppConfig, 'form'>
 
@@ -69,7 +69,7 @@ export interface FormEmits<S extends FormSchema, T extends boolean = true> {
 }
 
 export interface FormSlots {
-  default(props: { errors: FormError[], loading: boolean }): VNode[]
+  default(props: { errors: FormError[], loading: boolean }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/FormField.vue
+++ b/src/runtime/components/FormField.vue
@@ -1,8 +1,9 @@
 <script lang="ts">
-import type { Ref, VNode } from 'vue'
+import type { Ref } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/form-field'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type FormField = ComponentConfig<typeof theme, AppConfig, 'formField'>
 
@@ -38,12 +39,12 @@ export interface FormFieldProps {
 }
 
 export interface FormFieldSlots {
-  label?(props: { label?: string }): VNode[]
-  hint?(props: { hint?: string }): VNode[]
-  description?(props: { description?: string }): VNode[]
-  help?(props: { help?: string }): VNode[]
-  error?(props: { error?: boolean | string }): VNode[]
-  default(props: { error?: boolean | string }): VNode[]
+  label?(props: { label?: string }): SlotsReturn
+  hint?(props: { hint?: string }): SlotsReturn
+  description?(props: { description?: string }): SlotsReturn
+  help?(props: { help?: string }): SlotsReturn
+  error?(props: { error?: boolean | string }): SlotsReturn
+  default(props: { error?: boolean | string }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/FormField.vue
+++ b/src/runtime/components/FormField.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { Ref, VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/form-field'
 import type { ComponentConfig } from '../types/tv'
@@ -37,18 +38,17 @@ export interface FormFieldProps {
 }
 
 export interface FormFieldSlots {
-  label(props: { label?: string }): any
-  hint(props: { hint?: string }): any
-  description(props: { description?: string }): any
-  help(props: { help?: string }): any
-  error(props: { error?: boolean | string }): any
-  default(props: { error?: boolean | string }): any
+  label?(props: { label?: string }): VNode[]
+  hint?(props: { hint?: string }): VNode[]
+  description?(props: { description?: string }): VNode[]
+  help?(props: { help?: string }): VNode[]
+  error?(props: { error?: boolean | string }): VNode[]
+  default(props: { error?: boolean | string }): VNode[]
 }
 </script>
 
 <script setup lang="ts">
 import { computed, ref, inject, provide, useId, watch } from 'vue'
-import type { Ref } from 'vue'
 import { Primitive, Label } from 'reka-ui'
 import { useAppConfig } from '#imports'
 import { formFieldInjectionKey, inputIdInjectionKey, formErrorsInjectionKey, formInputsInjectionKey } from '../composables/useFormField'

--- a/src/runtime/components/Header.vue
+++ b/src/runtime/components/Header.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/header'
 import type { ButtonProps, DrawerProps, ModalProps, SlideoverProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Header = ComponentConfig<typeof theme, AppConfig, 'header'>
 
@@ -42,15 +42,15 @@ export interface HeaderProps<T extends HeaderMode = HeaderMode> {
 }
 
 export interface HeaderSlots {
-  title?(props?: {}): VNode[]
-  left?(props?: {}): VNode[]
-  default?(props?: {}): VNode[]
-  right?(props?: {}): VNode[]
-  toggle?(props: { open: boolean, toggle: () => void }): VNode[]
-  top?(props?: {}): VNode[]
-  bottom?(props?: {}): VNode[]
-  body?(props?: {}): VNode[]
-  content?(props?: {}): VNode[]
+  title?(props?: {}): SlotsReturn
+  left?(props?: {}): SlotsReturn
+  default?(props?: {}): SlotsReturn
+  right?(props?: {}): SlotsReturn
+  toggle?(props: { open: boolean, toggle: () => void }): SlotsReturn
+  top?(props?: {}): SlotsReturn
+  bottom?(props?: {}): SlotsReturn
+  body?(props?: {}): SlotsReturn
+  content?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Header.vue
+++ b/src/runtime/components/Header.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/header'
 import type { ButtonProps, DrawerProps, ModalProps, SlideoverProps } from '../types'
@@ -41,15 +42,15 @@ export interface HeaderProps<T extends HeaderMode = HeaderMode> {
 }
 
 export interface HeaderSlots {
-  title(props?: {}): any
-  left(props?: {}): any
-  default(props?: {}): any
-  right(props?: {}): any
-  toggle(props: { open: boolean, toggle: () => void }): any
-  top(props?: {}): any
-  bottom(props?: {}): any
-  body(props?: {}): any
-  content(props?: {}): any
+  title?(props?: {}): VNode[]
+  left?(props?: {}): VNode[]
+  default?(props?: {}): VNode[]
+  right?(props?: {}): VNode[]
+  toggle?(props: { open: boolean, toggle: () => void }): VNode[]
+  top?(props?: {}): VNode[]
+  bottom?(props?: {}): VNode[]
+  body?(props?: {}): VNode[]
+  content?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Input.vue
+++ b/src/runtime/components/Input.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
-import type { InputHTMLAttributes, VNode } from 'vue'
+import type { InputHTMLAttributes } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/input'
 import type { UseComponentIconsProps } from '../composables/useComponentIcons'
 import type { AvatarProps } from '../types'
 import type { ModelModifiers } from '../types/input'
-import type { AcceptableValue } from '../types/utils'
+import type { AcceptableValue, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Input = ComponentConfig<typeof theme, AppConfig, 'input'>
@@ -55,9 +55,9 @@ export interface InputEmits<T extends InputValue = InputValue> {
 }
 
 export interface InputSlots {
-  leading?(props?: {}): VNode[]
-  default?(props?: {}): VNode[]
-  trailing?(props?: {}): VNode[]
+  leading?(props?: {}): SlotsReturn
+  default?(props?: {}): SlotsReturn
+  trailing?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Input.vue
+++ b/src/runtime/components/Input.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { InputHTMLAttributes } from 'vue'
+import type { InputHTMLAttributes, VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/input'
 import type { UseComponentIconsProps } from '../composables/useComponentIcons'
@@ -55,9 +55,9 @@ export interface InputEmits<T extends InputValue = InputValue> {
 }
 
 export interface InputSlots {
-  leading(props?: {}): any
-  default(props?: {}): any
-  trailing(props?: {}): any
+  leading?(props?: {}): VNode[]
+  default?(props?: {}): VNode[]
+  trailing?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { InputHTMLAttributes } from 'vue'
+import type { InputHTMLAttributes, VNode } from 'vue'
 import type { ComboboxRootProps, ComboboxRootEmits, ComboboxContentProps, ComboboxContentEmits, ComboboxArrowProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/input-menu'
@@ -158,7 +158,7 @@ export type InputMenuEmits<A extends ArrayOrNested<InputMenuItem>, VK extends Ge
   'remove-tag': [item: GetModelValue<A, VK, M>]
 } & GetModelValueEmits<A, VK, M>
 
-type SlotProps<T extends InputMenuItem> = (props: { item: T, index: number }) => any
+type SlotProps<T extends InputMenuItem> = (props: { item: T, index: number }) => VNode[]
 
 export interface InputMenuSlots<
   A extends ArrayOrNested<InputMenuItem> = ArrayOrNested<InputMenuItem>,
@@ -166,26 +166,26 @@ export interface InputMenuSlots<
   M extends boolean = false,
   T extends NestedItem<A> = NestedItem<A>
 > {
-  'leading'(props: {
+  'leading'?(props: {
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
     ui: { [K in keyof Required<InputMenu['slots']>]: (props?: Record<string, any>) => string }
-  }): any
-  'trailing'(props: {
+  }): VNode[]
+  'trailing'?(props: {
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
     ui: { [K in keyof Required<InputMenu['slots']>]: (props?: Record<string, any>) => string }
-  }): any
-  'empty'(props: { searchTerm?: string }): any
-  'item': SlotProps<T>
-  'item-leading': SlotProps<T>
-  'item-label': SlotProps<T>
-  'item-trailing': SlotProps<T>
-  'tags-item-text': SlotProps<T>
-  'tags-item-delete': SlotProps<T>
-  'content-top': (props?: {}) => any
-  'content-bottom': (props?: {}) => any
-  'create-item-label'(props: { item: string }): any
+  }): VNode[]
+  'empty'?(props: { searchTerm?: string }): VNode[]
+  'item'?: SlotProps<T>
+  'item-leading'?: SlotProps<T>
+  'item-label'?: SlotProps<T>
+  'item-trailing'?: SlotProps<T>
+  'tags-item-text'?: SlotProps<T>
+  'tags-item-delete'?: SlotProps<T>
+  'content-top'?: (props?: {}) => VNode[]
+  'content-bottom'?: (props?: {}) => VNode[]
+  'create-item-label'?(props: { item: string }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
-import type { InputHTMLAttributes, VNode } from 'vue'
+import type { InputHTMLAttributes } from 'vue'
 import type { ComboboxRootProps, ComboboxRootEmits, ComboboxContentProps, ComboboxContentEmits, ComboboxArrowProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/input-menu'
 import type { UseComponentIconsProps } from '../composables/useComponentIcons'
 import type { AvatarProps, ChipProps, IconProps, InputProps } from '../types'
-import type { AcceptableValue, ArrayOrNested, GetItemKeys, GetItemValue, GetModelValue, GetModelValueEmits, NestedItem, EmitsToProps } from '../types/utils'
+import type { AcceptableValue, ArrayOrNested, GetItemKeys, GetItemValue, GetModelValue, GetModelValueEmits, NestedItem, EmitsToProps, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type InputMenu = ComponentConfig<typeof theme, AppConfig, 'inputMenu'>
@@ -158,7 +158,7 @@ export type InputMenuEmits<A extends ArrayOrNested<InputMenuItem>, VK extends Ge
   'remove-tag': [item: GetModelValue<A, VK, M>]
 } & GetModelValueEmits<A, VK, M>
 
-type SlotProps<T extends InputMenuItem> = (props: { item: T, index: number }) => VNode[]
+type SlotProps<T extends InputMenuItem> = (props: { item: T, index: number }) => SlotsReturn
 
 export interface InputMenuSlots<
   A extends ArrayOrNested<InputMenuItem> = ArrayOrNested<InputMenuItem>,
@@ -170,22 +170,22 @@ export interface InputMenuSlots<
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
     ui: { [K in keyof Required<InputMenu['slots']>]: (props?: Record<string, any>) => string }
-  }): VNode[]
+  }): SlotsReturn
   'trailing'?(props: {
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
     ui: { [K in keyof Required<InputMenu['slots']>]: (props?: Record<string, any>) => string }
-  }): VNode[]
-  'empty'?(props: { searchTerm?: string }): VNode[]
+  }): SlotsReturn
+  'empty'?(props: { searchTerm?: string }): SlotsReturn
   'item'?: SlotProps<T>
   'item-leading'?: SlotProps<T>
   'item-label'?: SlotProps<T>
   'item-trailing'?: SlotProps<T>
   'tags-item-text'?: SlotProps<T>
   'tags-item-delete'?: SlotProps<T>
-  'content-top'?: (props?: {}) => VNode[]
-  'content-bottom'?: (props?: {}) => VNode[]
-  'create-item-label'?(props: { item: string }): VNode[]
+  'content-top'?: (props?: {}) => SlotsReturn
+  'content-bottom'?: (props?: {}) => SlotsReturn
+  'create-item-label'?(props: { item: string }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/InputNumber.vue
+++ b/src/runtime/components/InputNumber.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { NumberFieldRootProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/input-number'
@@ -71,8 +72,8 @@ export interface InputNumberEmits {
 }
 
 export interface InputNumberSlots {
-  increment(props?: {}): any
-  decrement(props?: {}): any
+  increment?(props?: {}): VNode[]
+  decrement?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/InputNumber.vue
+++ b/src/runtime/components/InputNumber.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { NumberFieldRootProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/input-number'
 import type { ButtonProps, IconProps } from '../types'
 import type { ModelModifiers } from '../types/input'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type InputNumber = ComponentConfig<typeof theme, AppConfig, 'inputNumber'>
 
@@ -72,8 +72,8 @@ export interface InputNumberEmits {
 }
 
 export interface InputNumberSlots {
-  increment?(props?: {}): VNode[]
-  decrement?(props?: {}): VNode[]
+  increment?(props?: {}): SlotsReturn
+  decrement?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/InputTags.vue
+++ b/src/runtime/components/InputTags.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { TagsInputRootProps, TagsInputRootEmits, AcceptableInputValue } from 'reka-ui'
 import theme from '#build/ui/input-tags'
 import type { UseComponentIconsProps } from '../composables/useComponentIcons'
 import type { AvatarProps, IconProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type InputTags = ComponentConfig<typeof theme, AppConfig, 'inputTags'>
 
@@ -53,12 +53,12 @@ export interface InputTagsEmits<T extends InputTagItem> extends TagsInputRootEmi
   focus: [event: FocusEvent]
 }
 
-type SlotProps<T extends InputTagItem> = (props: { item: T, index: number }) => VNode[]
+type SlotProps<T extends InputTagItem> = (props: { item: T, index: number }) => SlotsReturn
 
 export interface InputTagsSlots<T extends InputTagItem = InputTagItem> {
-  'leading'?(props?: {}): VNode[]
-  'default'?(props?: {}): VNode[]
-  'trailing'?(props?: {}): VNode[]
+  'leading'?(props?: {}): SlotsReturn
+  'default'?(props?: {}): SlotsReturn
+  'trailing'?(props?: {}): SlotsReturn
   'item-text'?: SlotProps<T>
   'item-delete'?: SlotProps<T>
 }

--- a/src/runtime/components/InputTags.vue
+++ b/src/runtime/components/InputTags.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { TagsInputRootProps, TagsInputRootEmits, AcceptableInputValue } from 'reka-ui'
 import theme from '#build/ui/input-tags'
@@ -52,14 +53,14 @@ export interface InputTagsEmits<T extends InputTagItem> extends TagsInputRootEmi
   focus: [event: FocusEvent]
 }
 
-type SlotProps<T extends InputTagItem> = (props: { item: T, index: number }) => any
+type SlotProps<T extends InputTagItem> = (props: { item: T, index: number }) => VNode[]
 
 export interface InputTagsSlots<T extends InputTagItem = InputTagItem> {
-  'leading'(props?: {}): any
-  'default'(props?: {}): any
-  'trailing'(props?: {}): any
-  'item-text': SlotProps<T>
-  'item-delete': SlotProps<T>
+  'leading'?(props?: {}): VNode[]
+  'default'?(props?: {}): VNode[]
+  'trailing'?(props?: {}): VNode[]
+  'item-text'?: SlotProps<T>
+  'item-delete'?: SlotProps<T>
 }
 </script>
 

--- a/src/runtime/components/Kbd.vue
+++ b/src/runtime/components/Kbd.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/kbd'
 import type { KbdKey } from '../composables/useKbd'
@@ -29,7 +30,7 @@ export interface KbdProps {
 }
 
 export interface KbdSlots {
-  default(props?: {}): any
+  default?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Kbd.vue
+++ b/src/runtime/components/Kbd.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/kbd'
 import type { KbdKey } from '../composables/useKbd'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Kbd = ComponentConfig<typeof theme, AppConfig, 'kbd'>
 
@@ -30,7 +30,7 @@ export interface KbdProps {
 }
 
 export interface KbdSlots {
-  default?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Link.vue
+++ b/src/runtime/components/Link.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { ButtonHTMLAttributes } from 'vue'
+import type { ButtonHTMLAttributes, VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { RouterLinkProps, RouteLocationRaw } from 'vue-router'
 import theme from '#build/ui/link'
@@ -82,7 +82,7 @@ export interface LinkProps extends NuxtLinkProps {
 }
 
 export interface LinkSlots {
-  default(props: { active: boolean }): any
+  default?(props: { active: boolean }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Link.vue
+++ b/src/runtime/components/Link.vue
@@ -1,9 +1,10 @@
 <script lang="ts">
-import type { ButtonHTMLAttributes, VNode } from 'vue'
+import type { ButtonHTMLAttributes } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { RouterLinkProps, RouteLocationRaw } from 'vue-router'
 import theme from '#build/ui/link'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Link = ComponentConfig<typeof theme, AppConfig, 'link'>
 
@@ -82,7 +83,7 @@ export interface LinkProps extends NuxtLinkProps {
 }
 
 export interface LinkSlots {
-  default?(props: { active: boolean }): VNode[]
+  default?(props: { active: boolean }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Main.vue
+++ b/src/runtime/components/Main.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/main'
 import type { ComponentConfig } from '../types/tv'
@@ -15,7 +16,7 @@ export interface MainProps {
 }
 
 export interface MainSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Main.vue
+++ b/src/runtime/components/Main.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/main'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Main = ComponentConfig<typeof theme, AppConfig, 'main'>
 
@@ -16,7 +16,7 @@ export interface MainProps {
 }
 
 export interface MainSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Marquee.vue
+++ b/src/runtime/components/Marquee.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/marquee'
 import type { ComponentConfig } from '../types/tv'
@@ -41,7 +42,7 @@ export interface MarqueeProps {
 }
 
 export interface MarqueeSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Marquee.vue
+++ b/src/runtime/components/Marquee.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/marquee'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Marquee = ComponentConfig<typeof theme, AppConfig, 'marquee'>
 
@@ -42,7 +42,7 @@ export interface MarqueeProps {
 }
 
 export interface MarqueeSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Modal.vue
+++ b/src/runtime/components/Modal.vue
@@ -1,10 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { DialogRootProps, DialogRootEmits, DialogContentProps, DialogContentEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/modal'
 import type { ButtonProps, IconProps } from '../types'
-import type { EmitsToProps } from '../types/utils'
+import type { EmitsToProps, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Modal = ComponentConfig<typeof theme, AppConfig, 'modal'>
@@ -62,15 +61,15 @@ export interface ModalEmits extends DialogRootEmits {
 }
 
 export interface ModalSlots {
-  default?(props: { open: boolean }): VNode[]
-  content?(props: { close: () => void }): VNode[]
-  header?(props: { close: () => void }): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  actions?(props?: {}): VNode[]
-  close?(props: { close: () => void, ui: { [K in keyof Required<Modal['slots']>]: (props?: Record<string, any>) => string } }): VNode[]
-  body?(props: { close: () => void }): VNode[]
-  footer?(props: { close: () => void }): VNode[]
+  default?(props: { open: boolean }): SlotsReturn
+  content?(props: { close: () => void }): SlotsReturn
+  header?(props: { close: () => void }): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  actions?(props?: {}): SlotsReturn
+  close?(props: { close: () => void, ui: { [K in keyof Required<Modal['slots']>]: (props?: Record<string, any>) => string } }): SlotsReturn
+  body?(props: { close: () => void }): SlotsReturn
+  footer?(props: { close: () => void }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Modal.vue
+++ b/src/runtime/components/Modal.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { DialogRootProps, DialogRootEmits, DialogContentProps, DialogContentEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/modal'
@@ -61,15 +62,15 @@ export interface ModalEmits extends DialogRootEmits {
 }
 
 export interface ModalSlots {
-  default(props: { open: boolean }): any
-  content(props: { close: () => void }): any
-  header(props: { close: () => void }): any
-  title(props?: {}): any
-  description(props?: {}): any
-  actions(props?: {}): any
-  close(props: { close: () => void, ui: { [K in keyof Required<Modal['slots']>]: (props?: Record<string, any>) => string } }): any
-  body(props: { close: () => void }): any
-  footer(props: { close: () => void }): any
+  default?(props: { open: boolean }): VNode[]
+  content?(props: { close: () => void }): VNode[]
+  header?(props: { close: () => void }): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  actions?(props?: {}): VNode[]
+  close?(props: { close: () => void, ui: { [K in keyof Required<Modal['slots']>]: (props?: Record<string, any>) => string } }): VNode[]
+  body?(props: { close: () => void }): VNode[]
+  footer?(props: { close: () => void }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/NavigationMenu.vue
+++ b/src/runtime/components/NavigationMenu.vue
@@ -1,11 +1,10 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { NavigationMenuRootProps, NavigationMenuRootEmits, NavigationMenuContentProps, NavigationMenuContentEmits, AccordionRootProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/navigation-menu'
 import type { AvatarProps, BadgeProps, IconProps, LinkProps, PopoverProps, TooltipProps } from '../types'
-import type { ArrayOrNested, DynamicSlots, GetItemKeys, MergeTypes, NestedItem, EmitsToProps } from '../types/utils'
+import type { ArrayOrNested, DynamicSlots, GetItemKeys, MergeTypes, NestedItem, EmitsToProps, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type NavigationMenu = ComponentConfig<typeof theme, AppConfig, 'navigationMenu'>
@@ -145,7 +144,7 @@ export interface NavigationMenuProps<T extends ArrayOrNested<NavigationMenuItem>
 
 export interface NavigationMenuEmits extends NavigationMenuRootEmits {}
 
-type SlotProps<T extends NavigationMenuItem> = (props: { item: T, index: number, active?: boolean }) => VNode[]
+type SlotProps<T extends NavigationMenuItem> = (props: { item: T, index: number, active?: boolean }) => SlotsReturn
 
 export type NavigationMenuSlots<
   A extends ArrayOrNested<NavigationMenuItem> = ArrayOrNested<NavigationMenuItem>,
@@ -156,8 +155,8 @@ export type NavigationMenuSlots<
   'item-label'?: SlotProps<T>
   'item-trailing'?: SlotProps<T>
   'item-content'?: SlotProps<T>
-  'list-leading'?: (props?: {}) => VNode[]
-  'list-trailing'?: (props?: {}) => VNode[]
+  'list-leading'?: (props?: {}) => SlotsReturn
+  'list-trailing'?: (props?: {}) => SlotsReturn
 } & DynamicSlots<MergeTypes<T>, 'leading' | 'label' | 'trailing' | 'content', { index: number, active?: boolean }>
 
 </script>

--- a/src/runtime/components/NavigationMenu.vue
+++ b/src/runtime/components/NavigationMenu.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { NavigationMenuRootProps, NavigationMenuRootEmits, NavigationMenuContentProps, NavigationMenuContentEmits, AccordionRootProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/navigation-menu'
@@ -144,19 +145,19 @@ export interface NavigationMenuProps<T extends ArrayOrNested<NavigationMenuItem>
 
 export interface NavigationMenuEmits extends NavigationMenuRootEmits {}
 
-type SlotProps<T extends NavigationMenuItem> = (props: { item: T, index: number, active?: boolean }) => any
+type SlotProps<T extends NavigationMenuItem> = (props: { item: T, index: number, active?: boolean }) => VNode[]
 
 export type NavigationMenuSlots<
   A extends ArrayOrNested<NavigationMenuItem> = ArrayOrNested<NavigationMenuItem>,
   T extends NestedItem<A> = NestedItem<A>
 > = {
-  'item': SlotProps<T>
-  'item-leading': SlotProps<T>
-  'item-label': SlotProps<T>
-  'item-trailing': SlotProps<T>
-  'item-content': SlotProps<T>
-  'list-leading': (props?: {}) => any
-  'list-trailing': (props?: {}) => any
+  'item'?: SlotProps<T>
+  'item-leading'?: SlotProps<T>
+  'item-label'?: SlotProps<T>
+  'item-trailing'?: SlotProps<T>
+  'item-content'?: SlotProps<T>
+  'list-leading'?: (props?: {}) => VNode[]
+  'list-trailing'?: (props?: {}) => VNode[]
 } & DynamicSlots<MergeTypes<T>, 'leading' | 'label' | 'trailing' | 'content', { index: number, active?: boolean }>
 
 </script>

--- a/src/runtime/components/Page.vue
+++ b/src/runtime/components/Page.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page'
 import type { ComponentConfig } from '../types/tv'
@@ -16,9 +17,9 @@ export interface PageProps {
 }
 
 export interface PageSlots {
-  left(props?: {}): any
-  default(props?: {}): any
-  right(props?: {}): any
+  left?(props?: {}): VNode[]
+  default(props?: {}): VNode[]
+  right?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Page.vue
+++ b/src/runtime/components/Page.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Page = ComponentConfig<typeof theme, AppConfig, 'page'>
 
@@ -17,9 +17,9 @@ export interface PageProps {
 }
 
 export interface PageSlots {
-  left?(props?: {}): VNode[]
-  default(props?: {}): VNode[]
-  right?(props?: {}): VNode[]
+  left?(props?: {}): SlotsReturn
+  default(props?: {}): SlotsReturn
+  right?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/PageAnchors.vue
+++ b/src/runtime/components/PageAnchors.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-anchors'
 import type { IconProps, LinkProps } from '../types'
@@ -27,13 +28,13 @@ export interface PageAnchorsProps<T extends PageAnchor = PageAnchor> {
   ui?: PageAnchors['slots']
 }
 
-type SlotProps<T> = (props: { link: T, active: boolean }) => any
+type SlotProps<T> = (props: { link: T, active: boolean }) => VNode[]
 
 export interface PageAnchorsSlots<T extends PageAnchor = PageAnchor> {
-  'link': SlotProps<T>
-  'link-leading': SlotProps<T>
-  'link-label': SlotProps<T>
-  'link-trailing': SlotProps<T>
+  'link'?: SlotProps<T>
+  'link-leading'?: SlotProps<T>
+  'link-label'?: SlotProps<T>
+  'link-trailing'?: SlotProps<T>
 }
 </script>
 

--- a/src/runtime/components/PageAnchors.vue
+++ b/src/runtime/components/PageAnchors.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-anchors'
 import type { IconProps, LinkProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PageAnchors = ComponentConfig<typeof theme, AppConfig, 'pageAnchors'>
 
@@ -28,7 +28,7 @@ export interface PageAnchorsProps<T extends PageAnchor = PageAnchor> {
   ui?: PageAnchors['slots']
 }
 
-type SlotProps<T> = (props: { link: T, active: boolean }) => VNode[]
+type SlotProps<T> = (props: { link: T, active: boolean }) => SlotsReturn
 
 export interface PageAnchorsSlots<T extends PageAnchor = PageAnchor> {
   'link'?: SlotProps<T>

--- a/src/runtime/components/PageAside.vue
+++ b/src/runtime/components/PageAside.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-aside'
 import type { ComponentConfig } from '../types/tv'
@@ -16,9 +17,9 @@ export interface PageAsideProps {
 }
 
 export interface PageAsideSlots {
-  top(props?: {}): any
-  default(props?: {}): any
-  bottom(props?: {}): any
+  top?(props?: {}): VNode[]
+  default(props?: {}): VNode[]
+  bottom?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/PageAside.vue
+++ b/src/runtime/components/PageAside.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-aside'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PageAside = ComponentConfig<typeof theme, AppConfig, 'pageAside'>
 
@@ -17,9 +17,9 @@ export interface PageAsideProps {
 }
 
 export interface PageAsideSlots {
-  top?(props?: {}): VNode[]
-  default(props?: {}): VNode[]
-  bottom?(props?: {}): VNode[]
+  top?(props?: {}): SlotsReturn
+  default(props?: {}): SlotsReturn
+  bottom?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/PageBody.vue
+++ b/src/runtime/components/PageBody.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-body'
 import type { ComponentConfig } from '../types/tv'
@@ -15,7 +16,7 @@ export interface PageBodyProps {
 }
 
 export interface PageBodySlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/PageBody.vue
+++ b/src/runtime/components/PageBody.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-body'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PageBody = ComponentConfig<typeof theme, AppConfig, 'pageBody'>
 
@@ -16,7 +16,7 @@ export interface PageBodyProps {
 }
 
 export interface PageBodySlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/PageCTA.vue
+++ b/src/runtime/components/PageCTA.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-cta'
 import type { ButtonProps } from '../types'
@@ -38,15 +39,15 @@ export interface PageCTAProps {
 }
 
 export interface PageCTASlots {
-  top(props?: {}): any
-  header(props?: {}): any
-  title(props?: {}): any
-  description(props?: {}): any
-  body(props?: {}): any
-  footer(props?: {}): any
-  links(props?: {}): any
-  default(props?: {}): any
-  bottom(props?: {}): any
+  top?(props?: {}): VNode[]
+  header?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  body?(props?: {}): VNode[]
+  footer?(props?: {}): VNode[]
+  links?(props?: {}): VNode[]
+  default?(props?: {}): VNode[]
+  bottom?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/PageCTA.vue
+++ b/src/runtime/components/PageCTA.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-cta'
 import type { ButtonProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PageCTA = ComponentConfig<typeof theme, AppConfig, 'pageCTA'>
 
@@ -39,15 +39,15 @@ export interface PageCTAProps {
 }
 
 export interface PageCTASlots {
-  top?(props?: {}): VNode[]
-  header?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  body?(props?: {}): VNode[]
-  footer?(props?: {}): VNode[]
-  links?(props?: {}): VNode[]
-  default?(props?: {}): VNode[]
-  bottom?(props?: {}): VNode[]
+  top?(props?: {}): SlotsReturn
+  header?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  body?(props?: {}): SlotsReturn
+  footer?(props?: {}): SlotsReturn
+  links?(props?: {}): SlotsReturn
+  default?(props?: {}): SlotsReturn
+  bottom?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/PageCard.vue
+++ b/src/runtime/components/PageCard.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-card'
 import type { IconProps, LinkProps } from '../types'
@@ -57,13 +58,13 @@ export interface PageCardProps {
 }
 
 export interface PageCardSlots {
-  header(props?: {}): any
-  body(props?: {}): any
-  leading(props?: {}): any
-  title(props?: {}): any
-  description(props?: {}): any
-  footer(props?: {}): any
-  default(props?: {}): any
+  header?(props?: {}): VNode[]
+  body?(props?: {}): VNode[]
+  leading?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  footer?(props?: {}): VNode[]
+  default?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/PageCard.vue
+++ b/src/runtime/components/PageCard.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-card'
 import type { IconProps, LinkProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PageCard = ComponentConfig<typeof theme, AppConfig, 'pageCard'>
 
@@ -58,13 +58,13 @@ export interface PageCardProps {
 }
 
 export interface PageCardSlots {
-  header?(props?: {}): VNode[]
-  body?(props?: {}): VNode[]
-  leading?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  footer?(props?: {}): VNode[]
-  default?(props?: {}): VNode[]
+  header?(props?: {}): SlotsReturn
+  body?(props?: {}): SlotsReturn
+  leading?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  footer?(props?: {}): SlotsReturn
+  default?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/PageColumns.vue
+++ b/src/runtime/components/PageColumns.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-columns'
 import type { ComponentConfig } from '../types/tv'
@@ -15,7 +16,7 @@ export interface PageColumnsProps {
 }
 
 export interface PageColumnsSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/PageColumns.vue
+++ b/src/runtime/components/PageColumns.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-columns'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PageColumns = ComponentConfig<typeof theme, AppConfig, 'pageColumns'>
 
@@ -16,7 +16,7 @@ export interface PageColumnsProps {
 }
 
 export interface PageColumnsSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/PageFeature.vue
+++ b/src/runtime/components/PageFeature.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-feature'
 import type { IconProps, LinkProps } from '../types'
@@ -32,10 +33,10 @@ export interface PageFeatureProps {
 }
 
 export interface PageFeatureSlots {
-  leading(props?: {}): any
-  title(props?: {}): any
-  description(props?: {}): any
-  default(props?: {}): any
+  leading?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  default?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/PageFeature.vue
+++ b/src/runtime/components/PageFeature.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-feature'
 import type { IconProps, LinkProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PageFeature = ComponentConfig<typeof theme, AppConfig, 'pageFeature'>
 
@@ -33,10 +33,10 @@ export interface PageFeatureProps {
 }
 
 export interface PageFeatureSlots {
-  leading?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  default?(props?: {}): VNode[]
+  leading?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  default?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/PageGrid.vue
+++ b/src/runtime/components/PageGrid.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-grid'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PageGrid = ComponentConfig<typeof theme, AppConfig, 'pageGrid'>
 
@@ -16,7 +16,7 @@ export interface PageGridProps {
 }
 
 export interface PageGridSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/PageGrid.vue
+++ b/src/runtime/components/PageGrid.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-grid'
 import type { ComponentConfig } from '../types/tv'
@@ -15,7 +16,7 @@ export interface PageGridProps {
 }
 
 export interface PageGridSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/PageHeader.vue
+++ b/src/runtime/components/PageHeader.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-header'
 import type { ButtonProps } from '../types'
@@ -25,11 +26,11 @@ export interface PageHeaderProps {
 }
 
 export interface PageHeaderSlots {
-  headline(props?: {}): any
-  title(props?: {}): any
-  description(props?: {}): any
-  links(props?: {}): any
-  default(props?: {}): any
+  headline?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  links?(props?: {}): VNode[]
+  default?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/PageHeader.vue
+++ b/src/runtime/components/PageHeader.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-header'
 import type { ButtonProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PageHeader = ComponentConfig<typeof theme, AppConfig, 'pageHeader'>
 
@@ -26,11 +26,11 @@ export interface PageHeaderProps {
 }
 
 export interface PageHeaderSlots {
-  headline?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  links?(props?: {}): VNode[]
-  default?(props?: {}): VNode[]
+  headline?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  links?(props?: {}): SlotsReturn
+  default?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/PageHero.vue
+++ b/src/runtime/components/PageHero.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-hero'
 import type { ButtonProps } from '../types'
@@ -35,16 +36,16 @@ export interface PageHeroProps {
 }
 
 export interface PageHeroSlots {
-  top(props?: {}): any
-  header(props?: {}): any
-  headline(props?: {}): any
-  title(props?: {}): any
-  description(props?: {}): any
-  body(props?: {}): any
-  footer(props?: {}): any
-  links(props?: {}): any
-  default(props?: {}): any
-  bottom(props?: {}): any
+  top?(props?: {}): VNode[]
+  header?(props?: {}): VNode[]
+  headline?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  body?(props?: {}): VNode[]
+  footer?(props?: {}): VNode[]
+  links?(props?: {}): VNode[]
+  default?(props?: {}): VNode[]
+  bottom?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/PageHero.vue
+++ b/src/runtime/components/PageHero.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-hero'
 import type { ButtonProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PageHero = ComponentConfig<typeof theme, AppConfig, 'pageHero'>
 
@@ -36,16 +36,16 @@ export interface PageHeroProps {
 }
 
 export interface PageHeroSlots {
-  top?(props?: {}): VNode[]
-  header?(props?: {}): VNode[]
-  headline?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  body?(props?: {}): VNode[]
-  footer?(props?: {}): VNode[]
-  links?(props?: {}): VNode[]
-  default?(props?: {}): VNode[]
-  bottom?(props?: {}): VNode[]
+  top?(props?: {}): SlotsReturn
+  header?(props?: {}): SlotsReturn
+  headline?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  body?(props?: {}): SlotsReturn
+  footer?(props?: {}): SlotsReturn
+  links?(props?: {}): SlotsReturn
+  default?(props?: {}): SlotsReturn
+  bottom?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/PageLinks.vue
+++ b/src/runtime/components/PageLinks.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-links'
 import type { IconProps, LinkProps } from '../types'
@@ -28,14 +29,14 @@ export interface PageLinksProps<T extends PageLink = PageLink> {
   ui?: PageLinks['slots']
 }
 
-type SlotProps<T> = (props: { link: T, active: boolean }) => any
+type SlotProps<T> = (props: { link: T, active: boolean }) => VNode[]
 
 export interface PageLinksSlots<T extends PageLink = PageLink> {
-  'title'(props?: {}): any
-  'link': SlotProps<T>
-  'link-leading': SlotProps<T>
-  'link-label': SlotProps<T>
-  'link-trailing': SlotProps<T>
+  'title'?(props?: {}): VNode[]
+  'link'?: SlotProps<T>
+  'link-leading'?: SlotProps<T>
+  'link-label'?: SlotProps<T>
+  'link-trailing'?: SlotProps<T>
 }
 </script>
 

--- a/src/runtime/components/PageLinks.vue
+++ b/src/runtime/components/PageLinks.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-links'
 import type { IconProps, LinkProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PageLinks = ComponentConfig<typeof theme, AppConfig, 'pageLinks'>
 
@@ -29,10 +29,10 @@ export interface PageLinksProps<T extends PageLink = PageLink> {
   ui?: PageLinks['slots']
 }
 
-type SlotProps<T> = (props: { link: T, active: boolean }) => VNode[]
+type SlotProps<T> = (props: { link: T, active: boolean }) => SlotsReturn
 
 export interface PageLinksSlots<T extends PageLink = PageLink> {
-  'title'?(props?: {}): VNode[]
+  'title'?(props?: {}): SlotsReturn
   'link'?: SlotProps<T>
   'link-leading'?: SlotProps<T>
   'link-label'?: SlotProps<T>

--- a/src/runtime/components/PageList.vue
+++ b/src/runtime/components/PageList.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-list'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PageList = ComponentConfig<typeof theme, AppConfig, 'pageList'>
 
@@ -17,7 +17,7 @@ export interface PageListProps {
 }
 
 export interface PageListSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/PageList.vue
+++ b/src/runtime/components/PageList.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-list'
 import type { ComponentConfig } from '../types/tv'
@@ -16,7 +17,7 @@ export interface PageListProps {
 }
 
 export interface PageListSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/PageLogos.vue
+++ b/src/runtime/components/PageLogos.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-logos'
 import type { MarqueeProps } from '../types'
@@ -25,7 +26,7 @@ export interface PageLogosProps {
 }
 
 export interface PageLogosSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/PageLogos.vue
+++ b/src/runtime/components/PageLogos.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-logos'
 import type { MarqueeProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PageLogos = ComponentConfig<typeof theme, AppConfig, 'pageLogos'>
 
@@ -26,7 +26,7 @@ export interface PageLogosProps {
 }
 
 export interface PageLogosSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/PageSection.vue
+++ b/src/runtime/components/PageSection.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-section'
 import type { ButtonProps, IconProps, PageFeatureProps } from '../types'
@@ -47,18 +48,18 @@ export interface PageSectionProps {
 }
 
 export interface PageSectionSlots {
-  top(props?: {}): any
-  header(props?: {}): any
-  leading(props?: {}): any
-  headline(props?: {}): any
-  title(props?: {}): any
-  description(props?: {}): any
-  body(props?: {}): any
-  features(props?: {}): any
-  footer(props?: {}): any
-  links(props?: {}): any
-  default(props?: {}): any
-  bottom(props?: {}): any
+  top?(props?: {}): VNode[]
+  header?(props?: {}): VNode[]
+  leading?(props?: {}): VNode[]
+  headline?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  body?(props?: {}): VNode[]
+  features?(props?: {}): VNode[]
+  footer?(props?: {}): VNode[]
+  links?(props?: {}): VNode[]
+  default?(props?: {}): VNode[]
+  bottom?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/PageSection.vue
+++ b/src/runtime/components/PageSection.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/page-section'
 import type { ButtonProps, IconProps, PageFeatureProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PageSection = ComponentConfig<typeof theme, AppConfig, 'pageSection'>
 
@@ -48,18 +48,18 @@ export interface PageSectionProps {
 }
 
 export interface PageSectionSlots {
-  top?(props?: {}): VNode[]
-  header?(props?: {}): VNode[]
-  leading?(props?: {}): VNode[]
-  headline?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  body?(props?: {}): VNode[]
-  features?(props?: {}): VNode[]
-  footer?(props?: {}): VNode[]
-  links?(props?: {}): VNode[]
-  default?(props?: {}): VNode[]
-  bottom?(props?: {}): VNode[]
+  top?(props?: {}): SlotsReturn
+  header?(props?: {}): SlotsReturn
+  leading?(props?: {}): SlotsReturn
+  headline?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  body?(props?: {}): SlotsReturn
+  features?(props?: {}): SlotsReturn
+  footer?(props?: {}): SlotsReturn
+  links?(props?: {}): SlotsReturn
+  default?(props?: {}): SlotsReturn
+  bottom?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Pagination.vue
+++ b/src/runtime/components/Pagination.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { PaginationRootProps, PaginationRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/pagination'
 import type { ButtonProps, IconProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Pagination = ComponentConfig<typeof theme, AppConfig, 'pagination'>
 
@@ -83,11 +83,11 @@ export interface PaginationProps extends Partial<Pick<PaginationRootProps, 'defa
 export interface PaginationEmits extends PaginationRootEmits {}
 
 export interface PaginationSlots {
-  first?(props?: {}): VNode[]
-  prev?(props?: {}): VNode[]
-  next?(props?: {}): VNode[]
-  last?(props?: {}): VNode[]
-  ellipsis?(props?: {}): VNode[]
+  first?(props?: {}): SlotsReturn
+  prev?(props?: {}): SlotsReturn
+  next?(props?: {}): SlotsReturn
+  last?(props?: {}): SlotsReturn
+  ellipsis?(props?: {}): SlotsReturn
   item?(props: {
     page: number
     pageCount: number
@@ -98,7 +98,7 @@ export interface PaginationSlots {
       value: number
     }
     index: number
-  }): VNode[]
+  }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Pagination.vue
+++ b/src/runtime/components/Pagination.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { PaginationRootProps, PaginationRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/pagination'
@@ -82,12 +83,12 @@ export interface PaginationProps extends Partial<Pick<PaginationRootProps, 'defa
 export interface PaginationEmits extends PaginationRootEmits {}
 
 export interface PaginationSlots {
-  first(props?: {}): any
-  prev(props?: {}): any
-  next(props?: {}): any
-  last(props?: {}): any
-  ellipsis(props?: {}): any
-  item(props: {
+  first?(props?: {}): VNode[]
+  prev?(props?: {}): VNode[]
+  next?(props?: {}): VNode[]
+  last?(props?: {}): VNode[]
+  ellipsis?(props?: {}): VNode[]
+  item?(props: {
     page: number
     pageCount: number
     item: {
@@ -97,7 +98,7 @@ export interface PaginationSlots {
       value: number
     }
     index: number
-  }): any
+  }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Popover.vue
+++ b/src/runtime/components/Popover.vue
@@ -1,9 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { PopoverRootProps, HoverCardRootProps, PopoverRootEmits, PopoverContentProps, PopoverContentEmits, PopoverArrowProps, HoverCardTriggerProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/popover'
-import type { EmitsToProps } from '../types/utils'
+import type { EmitsToProps, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Popover = ComponentConfig<typeof theme, AppConfig, 'popover'>
@@ -52,9 +51,9 @@ export interface PopoverEmits extends PopoverRootEmits {
 type SlotProps<M extends PopoverMode = PopoverMode> = [M] extends ['hover'] ? {} : { close: () => void }
 
 export interface PopoverSlots<M extends PopoverMode = PopoverMode> {
-  default(props: { open: boolean }): VNode[]
-  content?(props: SlotProps<M>): VNode[]
-  anchor?(props: SlotProps<M>): VNode[]
+  default(props: { open: boolean }): SlotsReturn
+  content?(props: SlotProps<M>): SlotsReturn
+  anchor?(props: SlotProps<M>): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Popover.vue
+++ b/src/runtime/components/Popover.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { PopoverRootProps, HoverCardRootProps, PopoverRootEmits, PopoverContentProps, PopoverContentEmits, PopoverArrowProps, HoverCardTriggerProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/popover'
@@ -51,9 +52,9 @@ export interface PopoverEmits extends PopoverRootEmits {
 type SlotProps<M extends PopoverMode = PopoverMode> = [M] extends ['hover'] ? {} : { close: () => void }
 
 export interface PopoverSlots<M extends PopoverMode = PopoverMode> {
-  default(props: { open: boolean }): any
-  content(props: SlotProps<M>): any
-  anchor(props: SlotProps<M>): any
+  default(props: { open: boolean }): VNode[]
+  content?(props: SlotProps<M>): VNode[]
+  anchor?(props: SlotProps<M>): VNode[]
 }
 </script>
 

--- a/src/runtime/components/PricingPlan.vue
+++ b/src/runtime/components/PricingPlan.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/pricing-plan'
 import type { BadgeProps, ButtonProps, IconProps } from '../types'
@@ -92,19 +93,19 @@ export interface PricingPlanProps {
 }
 
 export interface PricingPlanSlots {
-  badge(props?: {}): any
-  title(props?: {}): any
-  description(props?: {}): any
-  price(props?: {}): any
-  discount(props?: {}): any
-  billing(props?: {}): any
-  features(props?: {}): any
-  button(props?: {}): any
-  header(props?: {}): any
-  body(props?: {}): any
-  footer(props?: {}): any
-  tagline(props?: {}): any
-  terms(props?: {}): any
+  badge?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  price?(props?: {}): VNode[]
+  discount?(props?: {}): VNode[]
+  billing?(props?: {}): VNode[]
+  features?(props?: {}): VNode[]
+  button?(props?: {}): VNode[]
+  header?(props?: {}): VNode[]
+  body?(props?: {}): VNode[]
+  footer?(props?: {}): VNode[]
+  tagline?(props?: {}): VNode[]
+  terms?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/PricingPlan.vue
+++ b/src/runtime/components/PricingPlan.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/pricing-plan'
 import type { BadgeProps, ButtonProps, IconProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PricingPlan = ComponentConfig<typeof theme, AppConfig, 'pricingPlan'>
 
@@ -93,19 +93,19 @@ export interface PricingPlanProps {
 }
 
 export interface PricingPlanSlots {
-  badge?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  price?(props?: {}): VNode[]
-  discount?(props?: {}): VNode[]
-  billing?(props?: {}): VNode[]
-  features?(props?: {}): VNode[]
-  button?(props?: {}): VNode[]
-  header?(props?: {}): VNode[]
-  body?(props?: {}): VNode[]
-  footer?(props?: {}): VNode[]
-  tagline?(props?: {}): VNode[]
-  terms?(props?: {}): VNode[]
+  badge?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  price?(props?: {}): SlotsReturn
+  discount?(props?: {}): SlotsReturn
+  billing?(props?: {}): SlotsReturn
+  features?(props?: {}): SlotsReturn
+  button?(props?: {}): SlotsReturn
+  header?(props?: {}): SlotsReturn
+  body?(props?: {}): SlotsReturn
+  footer?(props?: {}): SlotsReturn
+  tagline?(props?: {}): SlotsReturn
+  terms?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/PricingPlans.vue
+++ b/src/runtime/components/PricingPlans.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/pricing-plans'
 import type { PricingPlanProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PricingPlans = ComponentConfig<typeof theme, AppConfig, 'pricingPlans'>
 
@@ -34,7 +34,7 @@ export interface PricingPlansProps {
 }
 
 export interface PricingPlansSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 
@@ -56,7 +56,17 @@ const appConfig = useAppConfig() as PricingPlans['AppConfig']
 
 const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.pricingPlans || {}) }))
 
-const count = computed(() => props.plans?.length || slots.default?.()?.flatMap(mapSlot).filter(Boolean)?.length || 3)
+const count = computed(() => {
+  if (props.plans?.length) {
+    return props.plans.length
+  }
+  const children = slots.default?.()
+  if (Array.isArray(children)) {
+    return children.flatMap(mapSlot).filter(Boolean).length || 3
+  } else {
+    return children ? 1 : 3
+  }
+})
 
 function mapSlot(slot: any) {
   if (typeof slot.type === 'symbol') {

--- a/src/runtime/components/PricingPlans.vue
+++ b/src/runtime/components/PricingPlans.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/pricing-plans'
 import type { PricingPlanProps } from '../types'
@@ -33,7 +34,7 @@ export interface PricingPlansProps {
 }
 
 export interface PricingPlansSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/PricingTable.vue
+++ b/src/runtime/components/PricingTable.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/pricing-table'
 import type { PricingPlanProps } from '../types'
@@ -13,7 +14,7 @@ type DynamicSlots<T extends { id: string }, S extends string | undefined = undef
       ? (K | `${K}-${S}`)
       : K
     : never
-  ]?: (props: { tier: Extract<T, { id: K extends `${infer Base}-${S}` ? Base : K }> }) => any
+  ]?: (props: { tier: Extract<T, { id: K extends `${infer Base}-${S}` ? Base : K }> }) => VNode[]
 }
 
 type FeatureDynamicSlots<T extends PricingTableSectionFeature, S extends string | undefined = undefined> = {
@@ -22,7 +23,7 @@ type FeatureDynamicSlots<T extends PricingTableSectionFeature, S extends string 
       ? (`feature-${K}` | `feature-${K}-${S}`)
       : `feature-${K}`
     : never
-  ]?: (props: { feature: T, tier: PricingTableTier, section: PricingTableSection }) => any
+  ]?: (props: { feature: T, tier: PricingTableTier, section: PricingTableSection }) => VNode[]
 }
 
 type SectionDynamicSlots<T extends PricingTableSection, S extends string | undefined = undefined> = {
@@ -31,7 +32,7 @@ type SectionDynamicSlots<T extends PricingTableSection, S extends string | undef
       ? (`section-${K}` | `section-${K}-${S}`)
       : `section-${K}`
     : never
-  ]?: (props: { section: T }) => any
+  ]?: (props: { section: T }) => VNode[]
 }
 
 export type PricingTableTier = Pick<PricingPlanProps, 'title' | 'description' | 'badge' | 'billingCycle' | 'billingPeriod' | 'price' | 'discount' | 'button' | 'highlight'> & {
@@ -78,21 +79,21 @@ export interface PricingTableProps<T extends PricingTableTier = PricingTableTier
   ui?: PricingTable['slots']
 }
 
-type SlotProps<T extends PricingTableTier> = (props: { tier: T }) => any
+type SlotProps<T extends PricingTableTier> = (props: { tier: T }) => VNode[]
 
 export type PricingTableSlots<T extends PricingTableTier = PricingTableTier> = {
-  'caption': (props?: {}) => any
-  'tier': SlotProps<T>
-  'tier-title': SlotProps<T>
-  'tier-description': SlotProps<T>
-  'tier-badge': SlotProps<T>
-  'tier-button': SlotProps<T>
-  'tier-billing': SlotProps<T>
-  'tier-discount': SlotProps<T>
-  'tier-price': SlotProps<T>
-  'section-title': (props: { section: PricingTableSection<T> }) => any
-  'feature-title': (props: { feature: PricingTableSectionFeature<T>, section: PricingTableSection<T> }) => any
-  'feature-value': (props: { feature: PricingTableSectionFeature<T>, tier: T, section: PricingTableSection<T> }) => any
+  'caption'?: (props?: {}) => VNode[]
+  'tier'?: SlotProps<T>
+  'tier-title'?: SlotProps<T>
+  'tier-description'?: SlotProps<T>
+  'tier-badge'?: SlotProps<T>
+  'tier-button'?: SlotProps<T>
+  'tier-billing'?: SlotProps<T>
+  'tier-discount'?: SlotProps<T>
+  'tier-price'?: SlotProps<T>
+  'section-title'?: (props: { section: PricingTableSection<T> }) => VNode[]
+  'feature-title'?: (props: { feature: PricingTableSectionFeature<T>, section: PricingTableSection<T> }) => VNode[]
+  'feature-value'?: (props: { feature: PricingTableSectionFeature<T>, tier: T, section: PricingTableSection<T> }) => VNode[]
 } & DynamicSlots<T, 'title' | 'description' | 'badge' | 'button' | 'billing' | 'discount' | 'price'>
 & FeatureDynamicSlots<PricingTableSectionFeature<T>, 'title' | 'value'>
 & SectionDynamicSlots<PricingTableSection<T>, 'title'>

--- a/src/runtime/components/PricingTable.vue
+++ b/src/runtime/components/PricingTable.vue
@@ -1,10 +1,10 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/pricing-table'
 import type { PricingPlanProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type PricingTable = ComponentConfig<typeof theme, AppConfig, 'pricingTable'>
 
@@ -14,7 +14,7 @@ type DynamicSlots<T extends { id: string }, S extends string | undefined = undef
       ? (K | `${K}-${S}`)
       : K
     : never
-  ]?: (props: { tier: Extract<T, { id: K extends `${infer Base}-${S}` ? Base : K }> }) => VNode[]
+  ]?: (props: { tier: Extract<T, { id: K extends `${infer Base}-${S}` ? Base : K }> }) => SlotsReturn
 }
 
 type FeatureDynamicSlots<T extends PricingTableSectionFeature, S extends string | undefined = undefined> = {
@@ -23,7 +23,7 @@ type FeatureDynamicSlots<T extends PricingTableSectionFeature, S extends string 
       ? (`feature-${K}` | `feature-${K}-${S}`)
       : `feature-${K}`
     : never
-  ]?: (props: { feature: T, tier: PricingTableTier, section: PricingTableSection }) => VNode[]
+  ]?: (props: { feature: T, tier: PricingTableTier, section: PricingTableSection }) => SlotsReturn
 }
 
 type SectionDynamicSlots<T extends PricingTableSection, S extends string | undefined = undefined> = {
@@ -32,7 +32,7 @@ type SectionDynamicSlots<T extends PricingTableSection, S extends string | undef
       ? (`section-${K}` | `section-${K}-${S}`)
       : `section-${K}`
     : never
-  ]?: (props: { section: T }) => VNode[]
+  ]?: (props: { section: T }) => SlotsReturn
 }
 
 export type PricingTableTier = Pick<PricingPlanProps, 'title' | 'description' | 'badge' | 'billingCycle' | 'billingPeriod' | 'price' | 'discount' | 'button' | 'highlight'> & {
@@ -79,10 +79,10 @@ export interface PricingTableProps<T extends PricingTableTier = PricingTableTier
   ui?: PricingTable['slots']
 }
 
-type SlotProps<T extends PricingTableTier> = (props: { tier: T }) => VNode[]
+type SlotProps<T extends PricingTableTier> = (props: { tier: T }) => SlotsReturn
 
 export type PricingTableSlots<T extends PricingTableTier = PricingTableTier> = {
-  'caption'?: (props?: {}) => VNode[]
+  'caption'?: (props?: {}) => SlotsReturn
   'tier'?: SlotProps<T>
   'tier-title'?: SlotProps<T>
   'tier-description'?: SlotProps<T>
@@ -91,9 +91,9 @@ export type PricingTableSlots<T extends PricingTableTier = PricingTableTier> = {
   'tier-billing'?: SlotProps<T>
   'tier-discount'?: SlotProps<T>
   'tier-price'?: SlotProps<T>
-  'section-title'?: (props: { section: PricingTableSection<T> }) => VNode[]
-  'feature-title'?: (props: { feature: PricingTableSectionFeature<T>, section: PricingTableSection<T> }) => VNode[]
-  'feature-value'?: (props: { feature: PricingTableSectionFeature<T>, tier: T, section: PricingTableSection<T> }) => VNode[]
+  'section-title'?: (props: { section: PricingTableSection<T> }) => SlotsReturn
+  'feature-title'?: (props: { feature: PricingTableSectionFeature<T>, section: PricingTableSection<T> }) => SlotsReturn
+  'feature-value'?: (props: { feature: PricingTableSectionFeature<T>, tier: T, section: PricingTableSection<T> }) => SlotsReturn
 } & DynamicSlots<T, 'title' | 'description' | 'badge' | 'button' | 'billing' | 'discount' | 'price'>
 & FeatureDynamicSlots<PricingTableSectionFeature<T>, 'title' | 'value'>
 & SectionDynamicSlots<PricingTableSection<T>, 'title'>

--- a/src/runtime/components/Progress.vue
+++ b/src/runtime/components/Progress.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { ProgressRootProps, ProgressRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/progress'
@@ -44,9 +45,9 @@ export interface ProgressProps extends Pick<ProgressRootProps, 'getValueLabel' |
 export interface ProgressEmits extends ProgressRootEmits {}
 
 export type ProgressSlots = {
-  status(props: { percent?: number }): any
+  status?(props: { percent?: number }): VNode[]
 } & {
-  [key: string]: (props: { step: number }) => any
+  [key: string]: (props: { step: number }) => VNode[]
 }
 
 </script>

--- a/src/runtime/components/Progress.vue
+++ b/src/runtime/components/Progress.vue
@@ -1,10 +1,10 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { ProgressRootProps, ProgressRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/progress'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Progress = ComponentConfig<typeof theme, AppConfig, 'progress'>
 
@@ -45,9 +45,9 @@ export interface ProgressProps extends Pick<ProgressRootProps, 'getValueLabel' |
 export interface ProgressEmits extends ProgressRootEmits {}
 
 export type ProgressSlots = {
-  status?(props: { percent?: number }): VNode[]
+  status?(props: { percent?: number }): SlotsReturn
 } & {
-  [key: string]: (props: { step: number }) => VNode[]
+  [key: string]: (props: { step: number }) => SlotsReturn
 }
 
 </script>

--- a/src/runtime/components/RadioGroup.vue
+++ b/src/runtime/components/RadioGroup.vue
@@ -1,9 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { RadioGroupRootProps, RadioGroupRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/radio-group'
-import type { AcceptableValue, GetItemKeys, GetModelValue } from '../types/utils'
+import type { AcceptableValue, GetItemKeys, GetModelValue, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type RadioGroup = ComponentConfig<typeof theme, AppConfig, 'radioGroup'>
@@ -78,10 +77,10 @@ export type RadioGroupEmits = RadioGroupRootEmits & {
 
 type NormalizeItem<T extends RadioGroupItem> = Exclude<T & { id: string }, RadioGroupValue>
 
-type SlotProps<T extends RadioGroupItem> = (props: { item: NormalizeItem<T>, modelValue?: RadioGroupValue }) => VNode[]
+type SlotProps<T extends RadioGroupItem> = (props: { item: NormalizeItem<T>, modelValue?: RadioGroupValue }) => SlotsReturn
 
 export interface RadioGroupSlots<T extends RadioGroupItem[] = RadioGroupItem[]> {
-  legend?(props?: {}): VNode[]
+  legend?(props?: {}): SlotsReturn
   label?: SlotProps<T[number]>
   description?: SlotProps<T[number]>
 }

--- a/src/runtime/components/RadioGroup.vue
+++ b/src/runtime/components/RadioGroup.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { RadioGroupRootProps, RadioGroupRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/radio-group'
@@ -77,12 +78,12 @@ export type RadioGroupEmits = RadioGroupRootEmits & {
 
 type NormalizeItem<T extends RadioGroupItem> = Exclude<T & { id: string }, RadioGroupValue>
 
-type SlotProps<T extends RadioGroupItem> = (props: { item: NormalizeItem<T>, modelValue?: RadioGroupValue }) => any
+type SlotProps<T extends RadioGroupItem> = (props: { item: NormalizeItem<T>, modelValue?: RadioGroupValue }) => VNode[]
 
 export interface RadioGroupSlots<T extends RadioGroupItem[] = RadioGroupItem[]> {
-  legend(props?: {}): any
-  label: SlotProps<T[number]>
-  description: SlotProps<T[number]>
+  legend?(props?: {}): VNode[]
+  label?: SlotProps<T[number]>
+  description?: SlotProps<T[number]>
 }
 </script>
 

--- a/src/runtime/components/Select.vue
+++ b/src/runtime/components/Select.vue
@@ -1,11 +1,10 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { SelectRootProps, SelectRootEmits, SelectContentProps, SelectContentEmits, SelectArrowProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/select'
 import type { UseComponentIconsProps } from '../composables/useComponentIcons'
 import type { AvatarProps, ChipProps, IconProps, InputProps } from '../types'
-import type { AcceptableValue, ArrayOrNested, GetItemKeys, GetItemValue, GetModelValue, GetModelValueEmits, NestedItem, EmitsToProps } from '../types/utils'
+import type { AcceptableValue, ArrayOrNested, GetItemKeys, GetItemValue, GetModelValue, GetModelValueEmits, NestedItem, EmitsToProps, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Select = ComponentConfig<typeof theme, AppConfig, 'select'>
@@ -106,7 +105,7 @@ export type SelectEmits<A extends ArrayOrNested<SelectItem>, VK extends GetItemK
   focus: [event: FocusEvent]
 } & GetModelValueEmits<A, VK, M>
 
-type SlotProps<T extends SelectItem> = (props: { item: T, index: number }) => VNode[]
+type SlotProps<T extends SelectItem> = (props: { item: T, index: number }) => SlotsReturn
 
 export interface SelectSlots<
   A extends ArrayOrNested<SelectItem> = ArrayOrNested<SelectItem>,
@@ -118,22 +117,22 @@ export interface SelectSlots<
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
     ui: { [K in keyof Required<Select['slots']>]: (props?: Record<string, any>) => string }
-  }): VNode[]
+  }): SlotsReturn
   'default'?(props: {
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
-  }): VNode[]
+  }): SlotsReturn
   'trailing'?(props: {
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
     ui: { [K in keyof Required<Select['slots']>]: (props?: Record<string, any>) => string }
-  }): VNode[]
+  }): SlotsReturn
   'item'?: SlotProps<T>
   'item-leading'?: SlotProps<T>
   'item-label'?: SlotProps<T>
   'item-trailing'?: SlotProps<T>
-  'content-top'?: (props?: {}) => VNode[]
-  'content-bottom'?: (props?: {}) => VNode[]
+  'content-top'?: (props?: {}) => SlotsReturn
+  'content-bottom'?: (props?: {}) => SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Select.vue
+++ b/src/runtime/components/Select.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { SelectRootProps, SelectRootEmits, SelectContentProps, SelectContentEmits, SelectArrowProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/select'
@@ -105,7 +106,7 @@ export type SelectEmits<A extends ArrayOrNested<SelectItem>, VK extends GetItemK
   focus: [event: FocusEvent]
 } & GetModelValueEmits<A, VK, M>
 
-type SlotProps<T extends SelectItem> = (props: { item: T, index: number }) => any
+type SlotProps<T extends SelectItem> = (props: { item: T, index: number }) => VNode[]
 
 export interface SelectSlots<
   A extends ArrayOrNested<SelectItem> = ArrayOrNested<SelectItem>,
@@ -113,26 +114,26 @@ export interface SelectSlots<
   M extends boolean = false,
   T extends NestedItem<A> = NestedItem<A>
 > {
-  'leading'(props: {
+  'leading'?(props: {
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
     ui: { [K in keyof Required<Select['slots']>]: (props?: Record<string, any>) => string }
-  }): any
-  'default'(props: {
+  }): VNode[]
+  'default'?(props: {
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
-  }): any
-  'trailing'(props: {
+  }): VNode[]
+  'trailing'?(props: {
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
     ui: { [K in keyof Required<Select['slots']>]: (props?: Record<string, any>) => string }
-  }): any
-  'item': SlotProps<T>
-  'item-leading': SlotProps<T>
-  'item-label': SlotProps<T>
-  'item-trailing': SlotProps<T>
-  'content-top': (props?: {}) => any
-  'content-bottom': (props?: {}) => any
+  }): VNode[]
+  'item'?: SlotProps<T>
+  'item-leading'?: SlotProps<T>
+  'item-label'?: SlotProps<T>
+  'item-trailing'?: SlotProps<T>
+  'content-top'?: (props?: {}) => VNode[]
+  'content-bottom'?: (props?: {}) => VNode[]
 }
 </script>
 

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { ComboboxRootProps, ComboboxRootEmits, ComboboxContentProps, ComboboxContentEmits, ComboboxArrowProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/select-menu'
@@ -151,7 +152,7 @@ export type SelectMenuEmits<A extends ArrayOrNested<SelectMenuItem>, VK extends 
   } | undefined]
 } & GetModelValueEmits<A, VK, M>
 
-type SlotProps<T extends SelectMenuItem> = (props: { item: T, index: number }) => any
+type SlotProps<T extends SelectMenuItem> = (props: { item: T, index: number }) => VNode[]
 
 export interface SelectMenuSlots<
   A extends ArrayOrNested<SelectMenuItem> = ArrayOrNested<SelectMenuItem>,
@@ -159,28 +160,28 @@ export interface SelectMenuSlots<
   M extends boolean = false,
   T extends NestedItem<A> = NestedItem<A>
 > {
-  'leading'(props: {
+  'leading'?(props: {
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
     ui: { [K in keyof Required<SelectMenu['slots']>]: (props?: Record<string, any>) => string }
-  }): any
-  'default'(props: {
+  }): VNode[]
+  'default'?(props: {
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
-  }): any
-  'trailing'(props: {
+  }): VNode[]
+  'trailing'?(props: {
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
     ui: { [K in keyof Required<SelectMenu['slots']>]: (props?: Record<string, any>) => string }
-  }): any
-  'empty'(props: { searchTerm?: string }): any
-  'item': SlotProps<T>
-  'item-leading': SlotProps<T>
-  'item-label': SlotProps<T>
-  'item-trailing': SlotProps<T>
-  'content-top': (props?: {}) => any
-  'content-bottom': (props?: {}) => any
-  'create-item-label'(props: { item: string }): any
+  }): VNode[]
+  'empty'?(props: { searchTerm?: string }): VNode[]
+  'item'?: SlotProps<T>
+  'item-leading'?: SlotProps<T>
+  'item-label'?: SlotProps<T>
+  'item-trailing'?: SlotProps<T>
+  'content-top'?: (props?: {}) => VNode[]
+  'content-bottom'?: (props?: {}) => VNode[]
+  'create-item-label'?(props: { item: string }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -1,11 +1,10 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { ComboboxRootProps, ComboboxRootEmits, ComboboxContentProps, ComboboxContentEmits, ComboboxArrowProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/select-menu'
 import type { UseComponentIconsProps } from '../composables/useComponentIcons'
 import type { AvatarProps, ChipProps, IconProps, InputProps } from '../types'
-import type { AcceptableValue, ArrayOrNested, GetItemKeys, GetItemValue, GetModelValue, GetModelValueEmits, NestedItem, EmitsToProps } from '../types/utils'
+import type { AcceptableValue, ArrayOrNested, GetItemKeys, GetItemValue, GetModelValue, GetModelValueEmits, NestedItem, EmitsToProps, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type SelectMenu = ComponentConfig<typeof theme, AppConfig, 'selectMenu'>
@@ -152,7 +151,7 @@ export type SelectMenuEmits<A extends ArrayOrNested<SelectMenuItem>, VK extends 
   } | undefined]
 } & GetModelValueEmits<A, VK, M>
 
-type SlotProps<T extends SelectMenuItem> = (props: { item: T, index: number }) => VNode[]
+type SlotProps<T extends SelectMenuItem> = (props: { item: T, index: number }) => SlotsReturn
 
 export interface SelectMenuSlots<
   A extends ArrayOrNested<SelectMenuItem> = ArrayOrNested<SelectMenuItem>,
@@ -164,24 +163,24 @@ export interface SelectMenuSlots<
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
     ui: { [K in keyof Required<SelectMenu['slots']>]: (props?: Record<string, any>) => string }
-  }): VNode[]
+  }): SlotsReturn
   'default'?(props: {
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
-  }): VNode[]
+  }): SlotsReturn
   'trailing'?(props: {
     modelValue?: GetModelValue<A, VK, M>
     open: boolean
     ui: { [K in keyof Required<SelectMenu['slots']>]: (props?: Record<string, any>) => string }
-  }): VNode[]
-  'empty'?(props: { searchTerm?: string }): VNode[]
+  }): SlotsReturn
+  'empty'?(props: { searchTerm?: string }): SlotsReturn
   'item'?: SlotProps<T>
   'item-leading'?: SlotProps<T>
   'item-label'?: SlotProps<T>
   'item-trailing'?: SlotProps<T>
-  'content-top'?: (props?: {}) => VNode[]
-  'content-bottom'?: (props?: {}) => VNode[]
-  'create-item-label'?(props: { item: string }): VNode[]
+  'content-top'?: (props?: {}) => SlotsReturn
+  'content-bottom'?: (props?: {}) => SlotsReturn
+  'create-item-label'?(props: { item: string }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Separator.vue
+++ b/src/runtime/components/Separator.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { SeparatorProps as _SeparatorProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/separator'
@@ -44,7 +45,7 @@ export interface SeparatorProps extends Pick<_SeparatorProps, 'decorative'> {
 }
 
 export interface SeparatorSlots {
-  default(props?: {}): any
+  default?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Separator.vue
+++ b/src/runtime/components/Separator.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { SeparatorProps as _SeparatorProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/separator'
 import type { AvatarProps, IconProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Separator = ComponentConfig<typeof theme, AppConfig, 'separator'>
 
@@ -45,7 +45,7 @@ export interface SeparatorProps extends Pick<_SeparatorProps, 'decorative'> {
 }
 
 export interface SeparatorSlots {
-  default?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Slideover.vue
+++ b/src/runtime/components/Slideover.vue
@@ -1,10 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { DialogRootProps, DialogRootEmits, DialogContentProps, DialogContentEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/slideover'
 import type { ButtonProps, IconProps } from '../types'
-import type { EmitsToProps } from '../types/utils'
+import type { EmitsToProps, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Slideover = ComponentConfig<typeof theme, AppConfig, 'slideover'>
@@ -62,15 +61,15 @@ export interface SlideoverEmits extends DialogRootEmits {
 }
 
 export interface SlideoverSlots {
-  default?(props: { open: boolean }): VNode[]
-  content?(props: { close: () => void }): VNode[]
-  header?(props: { close: () => void }): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  actions?(props?: {}): VNode[]
-  close?(props: { close: () => void, ui: { [K in keyof Required<Slideover['slots']>]: (props?: Record<string, any>) => string } }): VNode[]
-  body?(props: { close: () => void }): VNode[]
-  footer?(props: { close: () => void }): VNode[]
+  default?(props: { open: boolean }): SlotsReturn
+  content?(props: { close: () => void }): SlotsReturn
+  header?(props: { close: () => void }): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  actions?(props?: {}): SlotsReturn
+  close?(props: { close: () => void, ui: { [K in keyof Required<Slideover['slots']>]: (props?: Record<string, any>) => string } }): SlotsReturn
+  body?(props: { close: () => void }): SlotsReturn
+  footer?(props: { close: () => void }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Slideover.vue
+++ b/src/runtime/components/Slideover.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { DialogRootProps, DialogRootEmits, DialogContentProps, DialogContentEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/slideover'
@@ -61,15 +62,15 @@ export interface SlideoverEmits extends DialogRootEmits {
 }
 
 export interface SlideoverSlots {
-  default(props: { open: boolean }): any
-  content(props: { close: () => void }): any
-  header(props: { close: () => void }): any
-  title(props?: {}): any
-  description(props?: {}): any
-  actions(props?: {}): any
-  close(props: { close: () => void, ui: { [K in keyof Required<Slideover['slots']>]: (props?: Record<string, any>) => string } }): any
-  body(props: { close: () => void }): any
-  footer(props: { close: () => void }): any
+  default?(props: { open: boolean }): VNode[]
+  content?(props: { close: () => void }): VNode[]
+  header?(props: { close: () => void }): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  actions?(props?: {}): VNode[]
+  close?(props: { close: () => void, ui: { [K in keyof Required<Slideover['slots']>]: (props?: Record<string, any>) => string } }): VNode[]
+  body?(props: { close: () => void }): VNode[]
+  footer?(props: { close: () => void }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Stepper.vue
+++ b/src/runtime/components/Stepper.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { StepperRootProps, StepperRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/stepper'
@@ -59,13 +60,13 @@ export type StepperEmits<T extends StepperItem = StepperItem> = Omit<StepperRoot
   prev: [value: T]
 }
 
-type SlotProps<T extends StepperItem> = (props: { item: T }) => any
+type SlotProps<T extends StepperItem> = (props: { item: T }) => VNode[]
 
 export type StepperSlots<T extends StepperItem = StepperItem> = {
-  indicator: SlotProps<T>
-  title: SlotProps<T>
-  description: SlotProps<T>
-  content: SlotProps<T>
+  indicator?: SlotProps<T>
+  title?: SlotProps<T>
+  description?: SlotProps<T>
+  content?: SlotProps<T>
 } & DynamicSlots<T>
 
 </script>

--- a/src/runtime/components/Stepper.vue
+++ b/src/runtime/components/Stepper.vue
@@ -1,11 +1,10 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { StepperRootProps, StepperRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/stepper'
 import type { IconProps } from '../types'
-import type { DynamicSlots } from '../types/utils'
+import type { DynamicSlots, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Stepper = ComponentConfig<typeof theme, AppConfig, 'stepper'>
@@ -60,7 +59,7 @@ export type StepperEmits<T extends StepperItem = StepperItem> = Omit<StepperRoot
   prev: [value: T]
 }
 
-type SlotProps<T extends StepperItem> = (props: { item: T }) => VNode[]
+type SlotProps<T extends StepperItem> = (props: { item: T }) => SlotsReturn
 
 export type StepperSlots<T extends StepperItem = StepperItem> = {
   indicator?: SlotProps<T>

--- a/src/runtime/components/Switch.vue
+++ b/src/runtime/components/Switch.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { SwitchRootProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/switch'
@@ -50,8 +51,8 @@ export type SwitchEmits = {
 }
 
 export interface SwitchSlots {
-  label(props: { label?: string }): any
-  description(props: { description?: string }): any
+  label?(props: { label?: string }): VNode[]
+  description?(props: { description?: string }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Switch.vue
+++ b/src/runtime/components/Switch.vue
@@ -1,10 +1,10 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { SwitchRootProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/switch'
 import type { IconProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Switch = ComponentConfig<typeof theme, AppConfig, 'switch'>
 
@@ -51,8 +51,8 @@ export type SwitchEmits = {
 }
 
 export interface SwitchSlots {
-  label?(props: { label?: string }): VNode[]
-  description?(props: { description?: string }): VNode[]
+  label?(props: { label?: string }): SlotsReturn
+  description?(props: { description?: string }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { Ref, WatchOptions } from 'vue'
+import type { Ref, WatchOptions, VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { Cell, Header, RowData, TableMeta } from '@tanstack/table-core'
 import type {
@@ -204,17 +204,17 @@ export interface TableProps<T extends TableData = TableData> extends TableOption
   ui?: Table['slots']
 }
 
-type DynamicHeaderSlots<T, K = keyof T> = Record<string, (props: HeaderContext<T, unknown>) => any> & Record<`${K extends string ? K : never}-header`, (props: HeaderContext<T, unknown>) => any>
-type DynamicFooterSlots<T, K = keyof T> = Record<string, (props: HeaderContext<T, unknown>) => any> & Record<`${K extends string ? K : never}-footer`, (props: HeaderContext<T, unknown>) => any>
-type DynamicCellSlots<T, K = keyof T> = Record<string, (props: CellContext<T, unknown>) => any> & Record<`${K extends string ? K : never}-cell`, (props: CellContext<T, unknown>) => any>
+type DynamicHeaderSlots<T, K = keyof T> = Record<string, (props: HeaderContext<T, unknown>) => VNode[]> & Record<`${K extends string ? K : never}-header`, (props: HeaderContext<T, unknown>) => VNode[]>
+type DynamicFooterSlots<T, K = keyof T> = Record<string, (props: HeaderContext<T, unknown>) => VNode[]> & Record<`${K extends string ? K : never}-footer`, (props: HeaderContext<T, unknown>) => VNode[]>
+type DynamicCellSlots<T, K = keyof T> = Record<string, (props: CellContext<T, unknown>) => VNode[]> & Record<`${K extends string ? K : never}-cell`, (props: CellContext<T, unknown>) => VNode[]>
 
 export type TableSlots<T extends TableData = TableData> = {
-  'expanded': (props: { row: Row<T> }) => any
-  'empty': (props?: {}) => any
-  'loading': (props?: {}) => any
-  'caption': (props?: {}) => any
-  'body-top': (props?: {}) => any
-  'body-bottom': (props?: {}) => any
+  'expanded'?: (props: { row: Row<T> }) => VNode[]
+  'empty'?: (props?: {}) => VNode[]
+  'loading'?: (props?: {}) => VNode[]
+  'caption'?: (props?: {}) => VNode[]
+  'body-top'?: (props?: {}) => VNode[]
+  'body-bottom'?: (props?: {}) => VNode[]
 } & DynamicHeaderSlots<T> & DynamicFooterSlots<T> & DynamicCellSlots<T>
 
 </script>

--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -1,6 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { Ref, WatchOptions, VNode } from 'vue'
+import type { Ref, WatchOptions } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { Cell, Header, RowData, TableMeta } from '@tanstack/table-core'
 import type {
@@ -38,6 +38,7 @@ import type {
 import type { VirtualizerOptions } from '@tanstack/vue-virtual'
 import theme from '#build/ui/table'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 declare module '@tanstack/table-core' {
 
@@ -204,17 +205,17 @@ export interface TableProps<T extends TableData = TableData> extends TableOption
   ui?: Table['slots']
 }
 
-type DynamicHeaderSlots<T, K = keyof T> = Record<string, (props: HeaderContext<T, unknown>) => VNode[]> & Record<`${K extends string ? K : never}-header`, (props: HeaderContext<T, unknown>) => VNode[]>
-type DynamicFooterSlots<T, K = keyof T> = Record<string, (props: HeaderContext<T, unknown>) => VNode[]> & Record<`${K extends string ? K : never}-footer`, (props: HeaderContext<T, unknown>) => VNode[]>
-type DynamicCellSlots<T, K = keyof T> = Record<string, (props: CellContext<T, unknown>) => VNode[]> & Record<`${K extends string ? K : never}-cell`, (props: CellContext<T, unknown>) => VNode[]>
+type DynamicHeaderSlots<T, K = keyof T> = Record<string, (props: HeaderContext<T, unknown>) => SlotsReturn> & Record<`${K extends string ? K : never}-header`, (props: HeaderContext<T, unknown>) => SlotsReturn>
+type DynamicFooterSlots<T, K = keyof T> = Record<string, (props: HeaderContext<T, unknown>) => SlotsReturn> & Record<`${K extends string ? K : never}-footer`, (props: HeaderContext<T, unknown>) => SlotsReturn>
+type DynamicCellSlots<T, K = keyof T> = Record<string, (props: CellContext<T, unknown>) => SlotsReturn> & Record<`${K extends string ? K : never}-cell`, (props: CellContext<T, unknown>) => SlotsReturn>
 
 export type TableSlots<T extends TableData = TableData> = {
-  'expanded'?: (props: { row: Row<T> }) => VNode[]
-  'empty'?: (props?: {}) => VNode[]
-  'loading'?: (props?: {}) => VNode[]
-  'caption'?: (props?: {}) => VNode[]
-  'body-top'?: (props?: {}) => VNode[]
-  'body-bottom'?: (props?: {}) => VNode[]
+  'expanded'?: (props: { row: Row<T> }) => SlotsReturn
+  'empty'?: (props?: {}) => SlotsReturn
+  'loading'?: (props?: {}) => SlotsReturn
+  'caption'?: (props?: {}) => SlotsReturn
+  'body-top'?: (props?: {}) => SlotsReturn
+  'body-bottom'?: (props?: {}) => SlotsReturn
 } & DynamicHeaderSlots<T> & DynamicFooterSlots<T> & DynamicCellSlots<T>
 
 </script>

--- a/src/runtime/components/Tabs.vue
+++ b/src/runtime/components/Tabs.vue
@@ -1,11 +1,11 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { ComponentPublicInstance, VNode } from 'vue'
+import type { ComponentPublicInstance } from 'vue'
 import type { TabsRootProps, TabsRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/tabs'
 import type { AvatarProps, BadgeProps, IconProps } from '../types'
-import type { DynamicSlots, GetItemKeys } from '../types/utils'
+import type { DynamicSlots, GetItemKeys, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Tabs = ComponentConfig<typeof theme, AppConfig, 'tabs'>
@@ -72,15 +72,15 @@ export interface TabsProps<T extends TabsItem = TabsItem> extends Pick<TabsRootP
 
 export interface TabsEmits extends TabsRootEmits<string | number> {}
 
-type SlotProps<T extends TabsItem> = (props: { item: T, index: number }) => VNode[]
+type SlotProps<T extends TabsItem> = (props: { item: T, index: number }) => SlotsReturn
 
 export type TabsSlots<T extends TabsItem = TabsItem> = {
   'leading'?: SlotProps<T>
   'default': SlotProps<T>
   'trailing'?: SlotProps<T>
   'content'?: SlotProps<T>
-  'list-leading'?: (props?: {}) => VNode[]
-  'list-trailing'?: (props?: {}) => VNode[]
+  'list-leading'?: (props?: {}) => SlotsReturn
+  'list-trailing'?: (props?: {}) => SlotsReturn
 } & DynamicSlots<T, undefined, { index: number }>
 
 </script>

--- a/src/runtime/components/Tabs.vue
+++ b/src/runtime/components/Tabs.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { ComponentPublicInstance, VNode } from 'vue'
 import type { TabsRootProps, TabsRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/tabs'
@@ -71,21 +72,20 @@ export interface TabsProps<T extends TabsItem = TabsItem> extends Pick<TabsRootP
 
 export interface TabsEmits extends TabsRootEmits<string | number> {}
 
-type SlotProps<T extends TabsItem> = (props: { item: T, index: number }) => any
+type SlotProps<T extends TabsItem> = (props: { item: T, index: number }) => VNode[]
 
 export type TabsSlots<T extends TabsItem = TabsItem> = {
-  'leading': SlotProps<T>
+  'leading'?: SlotProps<T>
   'default': SlotProps<T>
-  'trailing': SlotProps<T>
-  'content': SlotProps<T>
-  'list-leading': (props?: {}) => any
-  'list-trailing': (props?: {}) => any
+  'trailing'?: SlotProps<T>
+  'content'?: SlotProps<T>
+  'list-leading'?: (props?: {}) => VNode[]
+  'list-trailing'?: (props?: {}) => VNode[]
 } & DynamicSlots<T, undefined, { index: number }>
 
 </script>
 
 <script setup lang="ts" generic="T extends TabsItem">
-import type { ComponentPublicInstance } from 'vue'
 import { ref, computed } from 'vue'
 import { TabsRoot, TabsList, TabsIndicator, TabsTrigger, TabsContent, useForwardPropsEmits } from 'reka-ui'
 import { reactivePick } from '@vueuse/core'

--- a/src/runtime/components/Textarea.vue
+++ b/src/runtime/components/Textarea.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/textarea'
 import type { UseComponentIconsProps } from '../composables/useComponentIcons'
 import type { AvatarProps } from '../types'
 import type { ModelModifiers } from '../types/input'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Textarea = ComponentConfig<typeof theme, AppConfig, 'textarea'>
 
@@ -57,9 +57,9 @@ export interface TextareaEmits<T extends TextareaValue = TextareaValue> {
 }
 
 export interface TextareaSlots {
-  leading?(props?: {}): VNode[]
-  default(props?: {}): VNode[]
-  trailing?(props?: {}): VNode[]
+  leading?(props?: {}): SlotsReturn
+  default(props?: {}): SlotsReturn
+  trailing?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Textarea.vue
+++ b/src/runtime/components/Textarea.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/textarea'
 import type { UseComponentIconsProps } from '../composables/useComponentIcons'
@@ -56,9 +57,9 @@ export interface TextareaEmits<T extends TextareaValue = TextareaValue> {
 }
 
 export interface TextareaSlots {
-  leading(props?: {}): any
-  default(props?: {}): any
-  trailing(props?: {}): any
+  leading?(props?: {}): VNode[]
+  default(props?: {}): VNode[]
+  trailing?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Timeline.vue
+++ b/src/runtime/components/Timeline.vue
@@ -1,10 +1,9 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/timeline'
 import type { AvatarProps, IconProps } from '../types'
-import type { DynamicSlots } from '../types/utils'
+import type { DynamicSlots, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Timeline = ComponentConfig<typeof theme, AppConfig, 'timeline'>
@@ -48,7 +47,7 @@ export interface TimelineProps<T extends TimelineItem = TimelineItem> {
   ui?: Timeline['slots']
 }
 
-type SlotProps<T extends TimelineItem> = (props: { item: T }) => VNode[]
+type SlotProps<T extends TimelineItem> = (props: { item: T }) => SlotsReturn
 
 export type TimelineSlots<T extends TimelineItem = TimelineItem> = {
   indicator?: SlotProps<T>

--- a/src/runtime/components/Timeline.vue
+++ b/src/runtime/components/Timeline.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/timeline'
 import type { AvatarProps, IconProps } from '../types'
@@ -47,13 +48,13 @@ export interface TimelineProps<T extends TimelineItem = TimelineItem> {
   ui?: Timeline['slots']
 }
 
-type SlotProps<T extends TimelineItem> = (props: { item: T }) => any
+type SlotProps<T extends TimelineItem> = (props: { item: T }) => VNode[]
 
 export type TimelineSlots<T extends TimelineItem = TimelineItem> = {
-  indicator: SlotProps<T>
-  date: SlotProps<T>
-  title: SlotProps<T>
-  description: SlotProps<T>
+  indicator?: SlotProps<T>
+  date?: SlotProps<T>
+  title?: SlotProps<T>
+  description?: SlotProps<T>
 } & DynamicSlots<T, 'indicator' | 'date' | 'title' | 'description', { item: T }>
 
 </script>

--- a/src/runtime/components/Toast.vue
+++ b/src/runtime/components/Toast.vue
@@ -1,10 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { ToastRootProps, ToastRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/toast'
 import type { AvatarProps, ButtonProps, IconProps, ProgressProps } from '../types'
-import type { StringOrVNode } from '../types/utils'
+import type { StringOrVNode, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Toast = ComponentConfig<typeof theme, AppConfig, 'toast'>
@@ -63,11 +62,11 @@ export interface ToastProps extends Pick<ToastRootProps, 'defaultOpen' | 'open' 
 export interface ToastEmits extends ToastRootEmits {}
 
 export interface ToastSlots {
-  leading?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  actions?(props?: {}): VNode[]
-  close?(props: { ui: { [K in keyof Required<Toast['slots']>]: (props?: Record<string, any>) => string } }): VNode[]
+  leading?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  actions?(props?: {}): SlotsReturn
+  close?(props: { ui: { [K in keyof Required<Toast['slots']>]: (props?: Record<string, any>) => string } }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Toast.vue
+++ b/src/runtime/components/Toast.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { ToastRootProps, ToastRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/toast'
@@ -62,11 +63,11 @@ export interface ToastProps extends Pick<ToastRootProps, 'defaultOpen' | 'open' 
 export interface ToastEmits extends ToastRootEmits {}
 
 export interface ToastSlots {
-  leading(props?: {}): any
-  title(props?: {}): any
-  description(props?: {}): any
-  actions(props?: {}): any
-  close(props: { ui: { [K in keyof Required<Toast['slots']>]: (props?: Record<string, any>) => string } }): any
+  leading?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  actions?(props?: {}): VNode[]
+  close?(props: { ui: { [K in keyof Required<Toast['slots']>]: (props?: Record<string, any>) => string } }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Toaster.vue
+++ b/src/runtime/components/Toaster.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { ToastProviderProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/toaster'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type Toaster = ComponentConfig<typeof theme, AppConfig, 'toaster'>
 
@@ -38,7 +38,7 @@ export interface ToasterProps extends Omit<ToastProviderProps, 'swipeDirection'>
 }
 
 export interface ToasterSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 
 export default {

--- a/src/runtime/components/Toaster.vue
+++ b/src/runtime/components/Toaster.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { ToastProviderProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/toaster'
@@ -37,7 +38,7 @@ export interface ToasterProps extends Omit<ToastProviderProps, 'swipeDirection'>
 }
 
 export interface ToasterSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 
 export default {

--- a/src/runtime/components/Tooltip.vue
+++ b/src/runtime/components/Tooltip.vue
@@ -1,10 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { TooltipRootProps, TooltipRootEmits, TooltipContentProps, TooltipContentEmits, TooltipArrowProps, TooltipTriggerProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/tooltip'
 import type { KbdProps } from '../types'
-import type { EmitsToProps } from '../types/utils'
+import type { EmitsToProps, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Tooltip = ComponentConfig<typeof theme, AppConfig, 'tooltip'>
@@ -42,8 +41,8 @@ export interface TooltipProps extends TooltipRootProps {
 export interface TooltipEmits extends TooltipRootEmits {}
 
 export interface TooltipSlots {
-  default(props: { open: boolean }): VNode[]
-  content?(props?: {}): VNode[]
+  default(props: { open: boolean }): SlotsReturn
+  content?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/Tooltip.vue
+++ b/src/runtime/components/Tooltip.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { TooltipRootProps, TooltipRootEmits, TooltipContentProps, TooltipContentEmits, TooltipArrowProps, TooltipTriggerProps } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/tooltip'
@@ -41,8 +42,8 @@ export interface TooltipProps extends TooltipRootProps {
 export interface TooltipEmits extends TooltipRootEmits {}
 
 export interface TooltipSlots {
-  default(props: { open: boolean }): any
-  content(props?: {}): any
+  default(props: { open: boolean }): VNode[]
+  content?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { TreeRootProps, TreeRootEmits, TreeItemSelectEvent, TreeItemToggleEvent } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/tree'
@@ -116,16 +117,16 @@ type SlotProps<T extends TreeItem> = (props: {
   indeterminate: boolean | undefined
   handleSelect: () => void
   handleToggle: () => void
-}) => any
+}) => VNode[]
 
 export type TreeSlots<
   T extends TreeItem[] = TreeItem[]
 > = {
-  'item-wrapper': SlotProps<T[number]>
-  'item': SlotProps<T[number]>
-  'item-leading': SlotProps<T[number]>
-  'item-label': SlotProps<T[number]>
-  'item-trailing': SlotProps<T[number]>
+  'item-wrapper'?: SlotProps<T[number]>
+  'item'?: SlotProps<T[number]>
+  'item-leading'?: SlotProps<T[number]>
+  'item-label'?: SlotProps<T[number]>
+  'item-trailing'?: SlotProps<T[number]>
 } & DynamicSlots<T[number], undefined, {
   index: number
   level: number

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -1,11 +1,10 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { TreeRootProps, TreeRootEmits, TreeItemSelectEvent, TreeItemToggleEvent } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/tree'
 import type { IconProps } from '../types'
-import type { DynamicSlots, GetItemKeys } from '../types/utils'
+import type { DynamicSlots, GetItemKeys, SlotsReturn } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
 
 type Tree = ComponentConfig<typeof theme, AppConfig, 'tree'>
@@ -117,7 +116,7 @@ type SlotProps<T extends TreeItem> = (props: {
   indeterminate: boolean | undefined
   handleSelect: () => void
   handleToggle: () => void
-}) => VNode[]
+}) => SlotsReturn
 
 export type TreeSlots<
   T extends TreeItem[] = TreeItem[]

--- a/src/runtime/components/User.vue
+++ b/src/runtime/components/User.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/user'
 import type { AvatarProps, ChipProps, LinkProps } from '../types'
@@ -33,10 +34,10 @@ export interface UserProps {
 }
 
 export interface UserSlots {
-  avatar(props?: {}): any
-  name(props?: {}): any
-  description(props?: {}): any
-  default(props?: {}): any
+  avatar?(props?: {}): VNode[]
+  name?(props?: {}): VNode[]
+  description?(props?: {}): VNode[]
+  default?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/User.vue
+++ b/src/runtime/components/User.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/user'
 import type { AvatarProps, ChipProps, LinkProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
+import type { SlotsReturn } from '../types/utils'
 
 type User = ComponentConfig<typeof theme, AppConfig, 'user'>
 
@@ -34,10 +34,10 @@ export interface UserProps {
 }
 
 export interface UserSlots {
-  avatar?(props?: {}): VNode[]
-  name?(props?: {}): VNode[]
-  description?(props?: {}): VNode[]
-  default?(props?: {}): VNode[]
+  avatar?(props?: {}): SlotsReturn
+  name?(props?: {}): SlotsReturn
+  description?(props?: {}): SlotsReturn
+  default?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/color-mode/ColorModeButton.vue
+++ b/src/runtime/components/color-mode/ColorModeButton.vue
@@ -14,7 +14,7 @@ export interface ColorModeButtonProps extends /** @vue-ignore */ Pick<ButtonProp
 </script>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { type VNode, computed } from 'vue'
 import { useColorMode, useAppConfig } from '#imports'
 import { useLocale } from '../../composables/useLocale'
 import UButton from '../Button.vue'
@@ -26,7 +26,7 @@ withDefaults(defineProps<ColorModeButtonProps>(), {
   variant: 'ghost'
 })
 defineSlots<{
-  fallback(props?: {}): any
+  fallback?(props?: {}): VNode[]
 }>()
 
 const { t } = useLocale()

--- a/src/runtime/components/color-mode/ColorModeButton.vue
+++ b/src/runtime/components/color-mode/ColorModeButton.vue
@@ -14,10 +14,11 @@ export interface ColorModeButtonProps extends /** @vue-ignore */ Pick<ButtonProp
 </script>
 
 <script setup lang="ts">
-import { type VNode, computed } from 'vue'
+import { computed } from 'vue'
 import { useColorMode, useAppConfig } from '#imports'
 import { useLocale } from '../../composables/useLocale'
 import UButton from '../Button.vue'
+import type { SlotsReturn } from '../../types/utils'
 
 defineOptions({ inheritAttrs: false })
 
@@ -26,7 +27,7 @@ withDefaults(defineProps<ColorModeButtonProps>(), {
   variant: 'ghost'
 })
 defineSlots<{
-  fallback?(props?: {}): VNode[]
+  fallback?(props?: {}): SlotsReturn
 }>()
 
 const { t } = useLocale()

--- a/src/runtime/components/content/ContentNavigation.vue
+++ b/src/runtime/components/content/ContentNavigation.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AccordionRootProps, AccordionRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import type { ContentNavigationItem } from '@nuxt/content'
 import theme from '#build/ui/content/content-navigation'
 import type { BadgeProps, IconProps, LinkProps } from '../../types'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ContentNavigation = ComponentConfig<typeof theme, AppConfig, 'contentNavigation'>
 
@@ -81,7 +81,7 @@ export interface ContentNavigationProps<T extends ContentNavigationLink = Conten
 
 export interface ContentNavigationEmits extends AccordionRootEmits {}
 
-type SlotProps<T> = (props: { link: T, active?: boolean }) => VNode[]
+type SlotProps<T> = (props: { link: T, active?: boolean }) => SlotsReturn
 
 export interface ContentNavigationSlots<T extends ContentNavigationLink = ContentNavigationLink> {
   'link'?: SlotProps<T>

--- a/src/runtime/components/content/ContentNavigation.vue
+++ b/src/runtime/components/content/ContentNavigation.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AccordionRootProps, AccordionRootEmits } from 'reka-ui'
 import type { AppConfig } from '@nuxt/schema'
 import type { ContentNavigationItem } from '@nuxt/content'
@@ -80,13 +81,13 @@ export interface ContentNavigationProps<T extends ContentNavigationLink = Conten
 
 export interface ContentNavigationEmits extends AccordionRootEmits {}
 
-type SlotProps<T> = (props: { link: T, active?: boolean }) => any
+type SlotProps<T> = (props: { link: T, active?: boolean }) => VNode[]
 
 export interface ContentNavigationSlots<T extends ContentNavigationLink = ContentNavigationLink> {
-  'link': SlotProps<T>
-  'link-leading': SlotProps<T>
-  'link-title': SlotProps<T>
-  'link-trailing': SlotProps<T>
+  'link'?: SlotProps<T>
+  'link-leading'?: SlotProps<T>
+  'link-title'?: SlotProps<T>
+  'link-trailing'?: SlotProps<T>
 }
 </script>
 

--- a/src/runtime/components/content/ContentSearch.vue
+++ b/src/runtime/components/content/ContentSearch.vue
@@ -1,12 +1,12 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { ContentNavigationItem } from '@nuxt/content'
 import type { AppConfig } from '@nuxt/schema'
 import type { UseFuseOptions } from '@vueuse/integrations/useFuse'
 import theme from '#build/ui/content/content-search'
 import type { ButtonProps, InputProps, LinkProps, ModalProps, CommandPaletteProps, CommandPaletteSlots, CommandPaletteGroup, CommandPaletteItem, IconProps } from '../../types'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ContentSearch = ComponentConfig<typeof theme, AppConfig, 'contentSearch'>
 
@@ -100,7 +100,7 @@ export interface ContentSearchProps<T extends ContentSearchLink = ContentSearchL
 }
 
 export type ContentSearchSlots = CommandPaletteSlots<CommandPaletteGroup<ContentSearchItem>, ContentSearchItem> & {
-  content?(props?: {}): VNode[]
+  content?(props?: {}): SlotsReturn
 }
 
 </script>

--- a/src/runtime/components/content/ContentSearch.vue
+++ b/src/runtime/components/content/ContentSearch.vue
@@ -1,5 +1,6 @@
 <!-- eslint-disable vue/block-tag-newline -->
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { ContentNavigationItem } from '@nuxt/content'
 import type { AppConfig } from '@nuxt/schema'
 import type { UseFuseOptions } from '@vueuse/integrations/useFuse'
@@ -99,7 +100,7 @@ export interface ContentSearchProps<T extends ContentSearchLink = ContentSearchL
 }
 
 export type ContentSearchSlots = CommandPaletteSlots<CommandPaletteGroup<ContentSearchItem>, ContentSearchItem> & {
-  content(props?: {}): any
+  content?(props?: {}): VNode[]
 }
 
 </script>

--- a/src/runtime/components/content/ContentSurround.vue
+++ b/src/runtime/components/content/ContentSurround.vue
@@ -1,10 +1,11 @@
 <script lang="ts">
-import type { PropType, VNode } from 'vue'
+import type { PropType } from 'vue'
 import type { ContentNavigationItem } from '@nuxt/content'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/content/content-surround'
 import type { IconProps } from '../../types'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ContentSurround = ComponentConfig<typeof theme, AppConfig, 'contentSurround'>
 
@@ -41,7 +42,7 @@ export interface ContentSurroundProps<T extends ContentSurroundLink = ContentSur
   ui?: ContentSurround['slots']
 }
 
-type SlotProps<T> = (props: { link: T }) => VNode[]
+type SlotProps<T> = (props: { link: T }) => SlotsReturn
 
 export interface ContentSurroundSlots<T extends ContentSurroundLink = ContentSurroundLink> {
   'link'?: SlotProps<T>

--- a/src/runtime/components/content/ContentSurround.vue
+++ b/src/runtime/components/content/ContentSurround.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { PropType, VNode } from 'vue'
 import type { ContentNavigationItem } from '@nuxt/content'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/content/content-surround'
@@ -40,18 +41,17 @@ export interface ContentSurroundProps<T extends ContentSurroundLink = ContentSur
   ui?: ContentSurround['slots']
 }
 
-type SlotProps<T> = (props: { link: T }) => any
+type SlotProps<T> = (props: { link: T }) => VNode[]
 
 export interface ContentSurroundSlots<T extends ContentSurroundLink = ContentSurroundLink> {
-  'link': SlotProps<T>
-  'link-leading': SlotProps<T>
-  'link-title': SlotProps<T>
-  'link-description': SlotProps<T>
+  'link'?: SlotProps<T>
+  'link-leading'?: SlotProps<T>
+  'link-title'?: SlotProps<T>
+  'link-description'?: SlotProps<T>
 }
 </script>
 
 <script setup lang="ts" generic="T extends ContentSurroundLink">
-import type { PropType } from 'vue'
 import { computed } from 'vue'
 import { Primitive } from 'reka-ui'
 import { createReusableTemplate } from '@vueuse/core'

--- a/src/runtime/components/content/ContentToc.vue
+++ b/src/runtime/components/content/ContentToc.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { CollapsibleRootProps, CollapsibleRootEmits } from 'reka-ui'
 import type { TocLink } from '@nuxt/content'
 import type { AppConfig } from '@nuxt/schema'
@@ -52,16 +53,16 @@ export type ContentTocEmits = CollapsibleRootEmits & {
   move: [id: string]
 }
 
-type SlotProps<T> = (props: { link: T }) => any
+type SlotProps<T> = (props: { link: T }) => VNode[]
 
 export interface ContentTocSlots<T extends ContentTocLink = ContentTocLink> {
-  leading(props: { open: boolean }): any
-  default(props: { open: boolean }): any
-  trailing(props: { open: boolean }): any
-  content(props: { links: T[] }): any
-  link: SlotProps<T>
-  top(props: { links?: T[] }): any
-  bottom(props: { links?: T[] }): any
+  leading?(props: { open: boolean }): VNode[]
+  default?(props: { open: boolean }): VNode[]
+  trailing?(props: { open: boolean }): VNode[]
+  content?(props: { links: T[] }): VNode[]
+  link?: SlotProps<T>
+  top?(props: { links?: T[] }): VNode[]
+  bottom?(props: { links?: T[] }): VNode[]
 }
 </script>
 

--- a/src/runtime/components/content/ContentToc.vue
+++ b/src/runtime/components/content/ContentToc.vue
@@ -1,11 +1,11 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { CollapsibleRootProps, CollapsibleRootEmits } from 'reka-ui'
 import type { TocLink } from '@nuxt/content'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/content/content-toc'
 import type { IconProps } from '../../types'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ContentToc = ComponentConfig<typeof theme, AppConfig, 'contentToc'>
 
@@ -53,16 +53,16 @@ export type ContentTocEmits = CollapsibleRootEmits & {
   move: [id: string]
 }
 
-type SlotProps<T> = (props: { link: T }) => VNode[]
+type SlotProps<T> = (props: { link: T }) => SlotsReturn
 
 export interface ContentTocSlots<T extends ContentTocLink = ContentTocLink> {
-  leading?(props: { open: boolean }): VNode[]
-  default?(props: { open: boolean }): VNode[]
-  trailing?(props: { open: boolean }): VNode[]
-  content?(props: { links: T[] }): VNode[]
+  leading?(props: { open: boolean }): SlotsReturn
+  default?(props: { open: boolean }): SlotsReturn
+  trailing?(props: { open: boolean }): SlotsReturn
+  content?(props: { links: T[] }): SlotsReturn
   link?: SlotProps<T>
-  top?(props: { links?: T[] }): VNode[]
-  bottom?(props: { links?: T[] }): VNode[]
+  top?(props: { links?: T[] }): SlotsReturn
+  bottom?(props: { links?: T[] }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/A.vue
+++ b/src/runtime/components/prose/A.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/a'
 import type { ComponentConfig } from '../../types/tv'
@@ -12,7 +13,7 @@ export interface ProseAProps {
 }
 
 export interface ProseASlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/A.vue
+++ b/src/runtime/components/prose/A.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/a'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ProseA = ComponentConfig<typeof theme, AppConfig, 'a', 'ui.prose'>
 
@@ -13,7 +13,7 @@ export interface ProseAProps {
 }
 
 export interface ProseASlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Accordion.vue
+++ b/src/runtime/components/prose/Accordion.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/accordion'
 import type { AccordionProps } from '../../types'
@@ -13,7 +14,7 @@ export interface ProseAccordionProps {
 }
 
 export interface ProseAccordionSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Accordion.vue
+++ b/src/runtime/components/prose/Accordion.vue
@@ -47,7 +47,7 @@ const items = computed<{
   rerenderCount.value
   let children = slots.default?.()
   if (!Array.isArray(children)) {
-    children = [children]
+    children = children ? [children] : []
   }
   return children?.flatMap(transformSlot).filter(Boolean) || []
 })

--- a/src/runtime/components/prose/Accordion.vue
+++ b/src/runtime/components/prose/Accordion.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/accordion'
 import type { AccordionProps } from '../../types'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ProseAccordion = ComponentConfig<typeof theme, AppConfig, 'accordion', 'ui.prose'>
 
@@ -14,7 +14,7 @@ export interface ProseAccordionProps {
 }
 
 export interface ProseAccordionSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 
@@ -45,7 +45,11 @@ const items = computed<{
 }[]>(() => {
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   rerenderCount.value
-  return slots.default?.()?.flatMap(transformSlot).filter(Boolean) || []
+  let children = slots.default?.()
+  if (!Array.isArray(children)) {
+    children = [children]
+  }
+  return children?.flatMap(transformSlot).filter(Boolean) || []
 })
 
 function transformSlot(slot: any, index: number) {

--- a/src/runtime/components/prose/AccordionItem.vue
+++ b/src/runtime/components/prose/AccordionItem.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/accordion-item'
@@ -12,7 +13,7 @@ export interface ProseAccordionItemProps {
 }
 
 export interface ProseAccordionItemSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/AccordionItem.vue
+++ b/src/runtime/components/prose/AccordionItem.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/accordion-item'
 
 type ProseAccordionItem = ComponentConfig<typeof theme, AppConfig, 'accordionItem', 'ui.prose'>
@@ -13,7 +13,7 @@ export interface ProseAccordionItemProps {
 }
 
 export interface ProseAccordionItemSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Badge.vue
+++ b/src/runtime/components/prose/Badge.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/badge'
 import type { ComponentConfig } from '../../types/tv'
@@ -10,7 +11,7 @@ export interface ProseBadgeProps {
 }
 
 export interface ProseBadgeSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Badge.vue
+++ b/src/runtime/components/prose/Badge.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/badge'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ProseBadge = ComponentConfig<typeof theme, AppConfig, 'badge', 'ui.prose'>
 
@@ -11,7 +11,7 @@ export interface ProseBadgeProps {
 }
 
 export interface ProseBadgeSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Blockquote.vue
+++ b/src/runtime/components/prose/Blockquote.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/blockquote'
@@ -10,7 +11,7 @@ export interface ProseBlockquoteProps {
 }
 
 export interface ProseBlockquoteSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Blockquote.vue
+++ b/src/runtime/components/prose/Blockquote.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/blockquote'
+import type { SlotsReturn } from '../../types/utils'
 
 type ProseBlockquote = ComponentConfig<typeof theme, AppConfig, 'blockquote', 'ui.prose'>
 
@@ -11,7 +11,7 @@ export interface ProseBlockquoteProps {
 }
 
 export interface ProseBlockquoteSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Callout.vue
+++ b/src/runtime/components/prose/Callout.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/callout'
 import type { IconProps, LinkProps } from '../../types'
@@ -19,7 +20,7 @@ export interface ProseCalloutProps {
 }
 
 export interface ProseCalloutSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Callout.vue
+++ b/src/runtime/components/prose/Callout.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/callout'
 import type { IconProps, LinkProps } from '../../types'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ProseCallout = ComponentConfig<typeof theme, AppConfig, 'callout', 'ui.prose'>
 
@@ -20,7 +20,7 @@ export interface ProseCalloutProps {
 }
 
 export interface ProseCalloutSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Card.vue
+++ b/src/runtime/components/prose/Card.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/card'
 import type { IconProps, LinkProps } from '../../types'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ProseCard = ComponentConfig<typeof theme, AppConfig, 'card', 'ui.prose'>
 
@@ -22,8 +22,8 @@ export interface ProseCardProps {
 }
 
 export interface ProseCardSlots {
-  default?(props?: {}): VNode[]
-  title?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
+  title?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Card.vue
+++ b/src/runtime/components/prose/Card.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/card'
 import type { IconProps, LinkProps } from '../../types'
@@ -21,8 +22,8 @@ export interface ProseCardProps {
 }
 
 export interface ProseCardSlots {
-  default(props?: {}): any
-  title(props?: {}): any
+  default?(props?: {}): VNode[]
+  title?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/CardGroup.vue
+++ b/src/runtime/components/prose/CardGroup.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/card-group'
@@ -10,7 +11,7 @@ export interface ProseCardGroupProps {
 }
 
 export interface ProseCardGroupSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/CardGroup.vue
+++ b/src/runtime/components/prose/CardGroup.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/card-group'
 
 type ProseCardGroup = ComponentConfig<typeof theme, AppConfig, 'cardGroup', 'ui.prose'>
@@ -11,7 +11,7 @@ export interface ProseCardGroupProps {
 }
 
 export interface ProseCardGroupSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Code.vue
+++ b/src/runtime/components/prose/Code.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/code'
@@ -15,7 +16,7 @@ export interface ProseCodeProps {
 }
 
 export interface ProseCodeSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Code.vue
+++ b/src/runtime/components/prose/Code.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/code'
 
 type ProseCode = ComponentConfig<typeof theme, AppConfig, 'code', 'ui.prose'>
@@ -16,7 +16,7 @@ export interface ProseCodeProps {
 }
 
 export interface ProseCodeSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/CodeCollapse.vue
+++ b/src/runtime/components/prose/CodeCollapse.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/code-collapse'
 import type { IconProps } from '../../types'
@@ -32,7 +33,7 @@ export interface ProseCodeCollapseProps {
 }
 
 export interface ProseCodeCollapseSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/CodeCollapse.vue
+++ b/src/runtime/components/prose/CodeCollapse.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/code-collapse'
 import type { IconProps } from '../../types'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ProseCodeCollapse = ComponentConfig<typeof theme, AppConfig, 'codeCollapse', 'ui.prose'>
 
@@ -33,7 +33,7 @@ export interface ProseCodeCollapseProps {
 }
 
 export interface ProseCodeCollapseSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/CodeGroup.vue
+++ b/src/runtime/components/prose/CodeGroup.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/code-group'
@@ -20,7 +21,7 @@ export interface ProseCodeGroupProps {
 }
 
 export interface ProseCodeGroupSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/CodeGroup.vue
+++ b/src/runtime/components/prose/CodeGroup.vue
@@ -56,7 +56,7 @@ const items = computed<{
   rerenderCount.value
   let children = slots.default?.()
   if (!Array.isArray(children)) {
-    children = [children]
+    children = children ? [children] : []
   }
   return children?.flatMap(transformSlot).filter(Boolean) || []
 })

--- a/src/runtime/components/prose/CodeGroup.vue
+++ b/src/runtime/components/prose/CodeGroup.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/code-group'
 
 type ProseCodeGroup = ComponentConfig<typeof theme, AppConfig, 'codeGroup', 'ui.prose'>
@@ -21,7 +21,7 @@ export interface ProseCodeGroupProps {
 }
 
 export interface ProseCodeGroupSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 
@@ -54,7 +54,11 @@ const items = computed<{
 }[]>(() => {
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   rerenderCount.value
-  return slots.default?.()?.flatMap(transformSlot).filter(Boolean) || []
+  let children = slots.default?.()
+  if (!Array.isArray(children)) {
+    children = [children]
+  }
+  return children?.flatMap(transformSlot).filter(Boolean) || []
 })
 
 function transformSlot(slot: any, index: number) {

--- a/src/runtime/components/prose/CodePreview.vue
+++ b/src/runtime/components/prose/CodePreview.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/code-preview'
@@ -11,8 +12,8 @@ export interface ProseCodePreviewProps {
 }
 
 export interface ProseCodePreviewSlots {
-  default(props?: {}): any
-  code(props?: {}): any
+  default(props?: {}): VNode[]
+  code?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/CodePreview.vue
+++ b/src/runtime/components/prose/CodePreview.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/code-preview'
 
 type ProseCodePreview = ComponentConfig<typeof theme, AppConfig, 'codePreview', 'ui.prose'>
@@ -12,8 +12,8 @@ export interface ProseCodePreviewProps {
 }
 
 export interface ProseCodePreviewSlots {
-  default(props?: {}): VNode[]
-  code?(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
+  code?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/CodeTree.vue
+++ b/src/runtime/components/prose/CodeTree.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/code-tree'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ProseCodeTree = ComponentConfig<typeof theme, AppConfig, 'codeTree', 'ui.prose'>
 
@@ -28,7 +28,7 @@ export interface ProseCodeTreeProps {
 }
 
 export interface ProseCodeTreeSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 
@@ -65,7 +65,11 @@ const flatItems = computed<{
 }[]>(() => {
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   rerenderCount.value
-  return slots.default?.()?.flatMap(transformSlot).filter(Boolean) || []
+  let children = slots.default?.()
+  if (!Array.isArray(children)) {
+    children = [children]
+  }
+  return children?.flatMap(transformSlot).filter(Boolean) || []
 })
 const items = computed(() => buildTree(flatItems.value))
 

--- a/src/runtime/components/prose/CodeTree.vue
+++ b/src/runtime/components/prose/CodeTree.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/code-tree'
 import type { ComponentConfig } from '../../types/tv'
@@ -27,7 +28,7 @@ export interface ProseCodeTreeProps {
 }
 
 export interface ProseCodeTreeSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/CodeTree.vue
+++ b/src/runtime/components/prose/CodeTree.vue
@@ -67,7 +67,7 @@ const flatItems = computed<{
   rerenderCount.value
   let children = slots.default?.()
   if (!Array.isArray(children)) {
-    children = [children]
+    children = children ? [children] : []
   }
   return children?.flatMap(transformSlot).filter(Boolean) || []
 })

--- a/src/runtime/components/prose/Collapsible.vue
+++ b/src/runtime/components/prose/Collapsible.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/collapsible'
 import type { IconProps, CollapsibleProps } from '../../types'
@@ -32,7 +33,7 @@ export interface ProseCollapsibleProps {
 }
 
 export interface ProseCollapsibleSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Collapsible.vue
+++ b/src/runtime/components/prose/Collapsible.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/collapsible'
 import type { IconProps, CollapsibleProps } from '../../types'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ProseCollapsible = ComponentConfig<typeof theme, AppConfig, 'collapsible', 'ui.prose'>
 
@@ -33,7 +33,7 @@ export interface ProseCollapsibleProps {
 }
 
 export interface ProseCollapsibleSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Em.vue
+++ b/src/runtime/components/prose/Em.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/em'
@@ -10,7 +11,7 @@ export interface ProseEmProps {
 }
 
 export interface ProseEmSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Em.vue
+++ b/src/runtime/components/prose/Em.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/em'
 
 type ProseEm = ComponentConfig<typeof theme, AppConfig, 'em', 'ui.prose'>
@@ -11,7 +11,7 @@ export interface ProseEmProps {
 }
 
 export interface ProseEmSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Field.vue
+++ b/src/runtime/components/prose/Field.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/field'
 
 type ProseField = ComponentConfig<typeof theme, AppConfig, 'field', 'ui.prose'>
@@ -33,7 +33,7 @@ export interface ProseFieldProps {
 }
 
 export interface ProseFieldSlots {
-  default?(props?: {}): VNode[]
+  default?(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Field.vue
+++ b/src/runtime/components/prose/Field.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/field'
@@ -32,7 +33,7 @@ export interface ProseFieldProps {
 }
 
 export interface ProseFieldSlots {
-  default(props?: {}): any
+  default?(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/FieldGroup.vue
+++ b/src/runtime/components/prose/FieldGroup.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/field-group'
 
 type ProseFieldGroup = ComponentConfig<typeof theme, AppConfig, 'fieldGroup', 'ui.prose'>
@@ -16,7 +16,7 @@ export interface ProseFieldGroupProps {
 }
 
 export interface ProseFieldGroupSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/FieldGroup.vue
+++ b/src/runtime/components/prose/FieldGroup.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/field-group'
@@ -15,7 +16,7 @@ export interface ProseFieldGroupProps {
 }
 
 export interface ProseFieldGroupSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/H1.vue
+++ b/src/runtime/components/prose/H1.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/h1'
@@ -12,7 +13,7 @@ export interface ProseH1Props {
 }
 
 export interface ProseH1Slots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/H1.vue
+++ b/src/runtime/components/prose/H1.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/h1'
 
 type ProseH1 = ComponentConfig<typeof theme, AppConfig, 'h1', 'ui.prose'>
@@ -13,7 +13,7 @@ export interface ProseH1Props {
 }
 
 export interface ProseH1Slots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/H2.vue
+++ b/src/runtime/components/prose/H2.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/h2'
 import type { ComponentConfig } from '../../types/tv'
@@ -12,7 +13,7 @@ export interface ProseH2Props {
 }
 
 export interface ProseH2Slots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/H2.vue
+++ b/src/runtime/components/prose/H2.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/h2'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ProseH2 = ComponentConfig<typeof theme, AppConfig, 'h2', 'ui.prose'>
 
@@ -13,7 +13,7 @@ export interface ProseH2Props {
 }
 
 export interface ProseH2Slots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/H3.vue
+++ b/src/runtime/components/prose/H3.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/h3'
 import type { ComponentConfig } from '../../types/tv'
@@ -12,7 +13,7 @@ export interface ProseH3Props {
 }
 
 export interface ProseH3Slots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/H3.vue
+++ b/src/runtime/components/prose/H3.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/h3'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ProseH3 = ComponentConfig<typeof theme, AppConfig, 'h3', 'ui.prose'>
 
@@ -13,7 +13,7 @@ export interface ProseH3Props {
 }
 
 export interface ProseH3Slots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/H4.vue
+++ b/src/runtime/components/prose/H4.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/h4'
@@ -12,7 +13,7 @@ export interface ProseH4Props {
 }
 
 export interface ProseH4Slots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/H4.vue
+++ b/src/runtime/components/prose/H4.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/h4'
 
 type ProseH4 = ComponentConfig<typeof theme, AppConfig, 'h4', 'ui.prose'>
@@ -13,7 +13,7 @@ export interface ProseH4Props {
 }
 
 export interface ProseH4Slots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Li.vue
+++ b/src/runtime/components/prose/Li.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/li'
 
 type ProseLi = ComponentConfig<typeof theme, AppConfig, 'li', 'ui.prose'>
@@ -11,7 +11,7 @@ export interface ProseLiProps {
 }
 
 export interface ProseLiSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Li.vue
+++ b/src/runtime/components/prose/Li.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/li'
@@ -10,7 +11,7 @@ export interface ProseLiProps {
 }
 
 export interface ProseLiSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Ol.vue
+++ b/src/runtime/components/prose/Ol.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/ol'
 
 type ProseOl = ComponentConfig<typeof theme, AppConfig, 'ol', 'ui.prose'>
@@ -11,7 +11,7 @@ export interface ProseOlProps {
 }
 
 export interface ProseOlSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Ol.vue
+++ b/src/runtime/components/prose/Ol.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/ol'
@@ -10,7 +11,7 @@ export interface ProseOlProps {
 }
 
 export interface ProseOlSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/P.vue
+++ b/src/runtime/components/prose/P.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/p'
 
 type ProseP = ComponentConfig<typeof theme, AppConfig, 'p', 'ui.prose'>
@@ -11,7 +11,7 @@ export interface ProsePProps {
 }
 
 export interface ProsePSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/P.vue
+++ b/src/runtime/components/prose/P.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/p'
@@ -10,7 +11,7 @@ export interface ProsePProps {
 }
 
 export interface ProsePSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Pre.vue
+++ b/src/runtime/components/prose/Pre.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/pre'
 import type { IconProps } from '../../types'
@@ -19,7 +20,7 @@ export interface ProsePreProps {
 }
 
 export interface ProsePreSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Pre.vue
+++ b/src/runtime/components/prose/Pre.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/pre'
 import type { IconProps } from '../../types'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ProsePre = ComponentConfig<typeof theme, AppConfig, 'pre', 'ui.prose'>
 
@@ -20,7 +20,7 @@ export interface ProsePreProps {
 }
 
 export interface ProsePreSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Steps.vue
+++ b/src/runtime/components/prose/Steps.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/steps'
@@ -15,7 +16,7 @@ export interface ProseStepsProps {
 }
 
 export interface ProseStepsSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Steps.vue
+++ b/src/runtime/components/prose/Steps.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/steps'
 
 type ProseSteps = ComponentConfig<typeof theme, AppConfig, 'steps', 'ui.prose'>
@@ -16,7 +16,7 @@ export interface ProseStepsProps {
 }
 
 export interface ProseStepsSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Strong.vue
+++ b/src/runtime/components/prose/Strong.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/strong'
 
 type ProseStrong = ComponentConfig<typeof theme, AppConfig, 'strong', 'ui.prose'>
@@ -11,7 +11,7 @@ export interface ProseStrongProps {
 }
 
 export interface ProseStrongSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Strong.vue
+++ b/src/runtime/components/prose/Strong.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/strong'
@@ -10,7 +11,7 @@ export interface ProseStrongProps {
 }
 
 export interface ProseStrongSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Table.vue
+++ b/src/runtime/components/prose/Table.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/table'
@@ -11,7 +12,7 @@ export interface ProseTableProps {
 }
 
 export interface ProseTableSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Table.vue
+++ b/src/runtime/components/prose/Table.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/table'
 
 type ProseTable = ComponentConfig<typeof theme, AppConfig, 'table', 'ui.prose'>
@@ -12,7 +12,7 @@ export interface ProseTableProps {
 }
 
 export interface ProseTableSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Tabs.vue
+++ b/src/runtime/components/prose/Tabs.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/tabs'
 import type { TabsProps } from '../../types'
@@ -25,7 +26,7 @@ export interface ProseTabsProps {
 }
 
 export interface ProseTabsSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Tabs.vue
+++ b/src/runtime/components/prose/Tabs.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/tabs'
 import type { TabsProps } from '../../types'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type ProseTabs = ComponentConfig<typeof theme, AppConfig, 'tabs', 'ui.prose'>
 
@@ -26,7 +26,7 @@ export interface ProseTabsProps {
 }
 
 export interface ProseTabsSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 
@@ -59,7 +59,11 @@ const items = computed<{
 }[]>(() => {
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
   rerenderCount.value
-  return slots.default?.()?.flatMap(transformSlot).filter(Boolean) || []
+  let children = slots.default?.()
+  if (!Array.isArray(children)) {
+    children = [children]
+  }
+  return children?.flatMap(transformSlot).filter(Boolean) || []
 })
 
 function transformSlot(slot: any, index: number) {

--- a/src/runtime/components/prose/Tabs.vue
+++ b/src/runtime/components/prose/Tabs.vue
@@ -61,7 +61,7 @@ const items = computed<{
   rerenderCount.value
   let children = slots.default?.()
   if (!Array.isArray(children)) {
-    children = [children]
+    children = children ? [children] : []
   }
   return children?.flatMap(transformSlot).filter(Boolean) || []
 })

--- a/src/runtime/components/prose/TabsItem.vue
+++ b/src/runtime/components/prose/TabsItem.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/tabs-item'
@@ -12,7 +13,7 @@ export interface ProseTabsItemProps {
 }
 
 export interface ProseTabsItemSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/TabsItem.vue
+++ b/src/runtime/components/prose/TabsItem.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/tabs-item'
 
 type ProseTabsItem = ComponentConfig<typeof theme, AppConfig, 'tabsItem', 'ui.prose'>
@@ -13,7 +13,7 @@ export interface ProseTabsItemProps {
 }
 
 export interface ProseTabsItemSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Tbody.vue
+++ b/src/runtime/components/prose/Tbody.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/tbody'
 
 type ProseTbody = ComponentConfig<typeof theme, AppConfig, 'tbody', 'ui.prose'>
@@ -11,7 +11,7 @@ export interface ProseTbodyProps {
 }
 
 export interface ProseTbodySlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Tbody.vue
+++ b/src/runtime/components/prose/Tbody.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/tbody'
@@ -10,7 +11,7 @@ export interface ProseTbodyProps {
 }
 
 export interface ProseTbodySlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Td.vue
+++ b/src/runtime/components/prose/Td.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/td'
 
 type ProseTd = ComponentConfig<typeof theme, AppConfig, 'td', 'ui.prose'>
@@ -11,7 +11,7 @@ export interface ProseTdProps {
 }
 
 export interface ProseTdSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Td.vue
+++ b/src/runtime/components/prose/Td.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/td'
@@ -10,7 +11,7 @@ export interface ProseTdProps {
 }
 
 export interface ProseTdSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Th.vue
+++ b/src/runtime/components/prose/Th.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/th'
@@ -10,7 +11,7 @@ export interface ProseThProps {
 }
 
 export interface ProseThSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Th.vue
+++ b/src/runtime/components/prose/Th.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/th'
 
 type ProseTh = ComponentConfig<typeof theme, AppConfig, 'th', 'ui.prose'>
@@ -11,7 +11,7 @@ export interface ProseThProps {
 }
 
 export interface ProseThSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Thead.vue
+++ b/src/runtime/components/prose/Thead.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/thead'
@@ -10,7 +11,7 @@ export interface ProseTheadProps {
 }
 
 export interface ProseTheadSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Thead.vue
+++ b/src/runtime/components/prose/Thead.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/thead'
 
 type ProseThead = ComponentConfig<typeof theme, AppConfig, 'thead', 'ui.prose'>
@@ -11,7 +11,7 @@ export interface ProseTheadProps {
 }
 
 export interface ProseTheadSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Tr.vue
+++ b/src/runtime/components/prose/Tr.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/tr'
@@ -10,7 +11,7 @@ export interface ProseTrProps {
 }
 
 export interface ProseTrSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/components/prose/Tr.vue
+++ b/src/runtime/components/prose/Tr.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/tr'
 
 type ProseTr = ComponentConfig<typeof theme, AppConfig, 'tr', 'ui.prose'>
@@ -11,7 +11,7 @@ export interface ProseTrProps {
 }
 
 export interface ProseTrSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Ul.vue
+++ b/src/runtime/components/prose/Ul.vue
@@ -1,7 +1,7 @@
 <script lang="ts">
-import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 import theme from '#build/ui/prose/ul'
 
 type ProseUl = ComponentConfig<typeof theme, AppConfig, 'ul', 'ui.prose'>
@@ -11,7 +11,7 @@ export interface ProseUlProps {
 }
 
 export interface ProseUlSlots {
-  default(props?: {}): VNode[]
+  default(props?: {}): SlotsReturn
 }
 </script>
 

--- a/src/runtime/components/prose/Ul.vue
+++ b/src/runtime/components/prose/Ul.vue
@@ -1,4 +1,5 @@
 <script lang="ts">
+import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { ComponentConfig } from '../../types/tv'
 import theme from '#build/ui/prose/ul'
@@ -10,7 +11,7 @@ export interface ProseUlProps {
 }
 
 export interface ProseUlSlots {
-  default(props?: {}): any
+  default(props?: {}): VNode[]
 }
 </script>
 

--- a/src/runtime/inertia/components/Link.vue
+++ b/src/runtime/inertia/components/Link.vue
@@ -1,9 +1,10 @@
 <script lang="ts">
-import type { ButtonHTMLAttributes, VNode } from 'vue'
+import type { ButtonHTMLAttributes } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { InertiaLinkProps } from '@inertiajs/vue3'
 import theme from '#build/ui/link'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type Link = ComponentConfig<typeof theme, AppConfig, 'link'>
 
@@ -53,7 +54,7 @@ export interface LinkProps extends NuxtLinkProps {
 }
 
 export interface LinkSlots {
-  default(props: { active: boolean }): VNode[]
+  default(props: { active: boolean }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/inertia/components/Link.vue
+++ b/src/runtime/inertia/components/Link.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { ButtonHTMLAttributes } from 'vue'
+import type { ButtonHTMLAttributes, VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { InertiaLinkProps } from '@inertiajs/vue3'
 import theme from '#build/ui/link'
@@ -53,7 +53,7 @@ export interface LinkProps extends NuxtLinkProps {
 }
 
 export interface LinkSlots {
-  default(props: { active: boolean }): any
+  default(props: { active: boolean }): VNode[]
 }
 </script>
 

--- a/src/runtime/types/utils.ts
+++ b/src/runtime/types/utils.ts
@@ -17,9 +17,9 @@ export type DynamicSlots<
   Suffix extends string | undefined = undefined,
   ExtraProps extends object = {}
 > = {
-  [K in DynamicSlotsKeys<T['slot'], Suffix>]: (
+  [K in DynamicSlotsKeys<T['slot'], Suffix>]?: (
     props: { item: Extract<T, { slot: K extends `${infer Base}-${Suffix}` ? Base : K }> } & ExtraProps
-  ) => any
+  ) => VNode[]
 }
 
 export type GetObjectField<MaybeObject, Key extends string> = MaybeObject extends Record<string, any>

--- a/src/runtime/types/utils.ts
+++ b/src/runtime/types/utils.ts
@@ -5,6 +5,9 @@ export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P] | undefined
 }
 
+export type MaybeArray<T> = T | T[]
+export type SlotsReturn = MaybeArray<VNode | string | number | boolean | null | undefined>
+
 export type DynamicSlotsKeys<Name extends string | undefined, Suffix extends string | undefined = undefined> = (
   Name extends string
     ? Suffix extends string
@@ -19,7 +22,7 @@ export type DynamicSlots<
 > = {
   [K in DynamicSlotsKeys<T['slot'], Suffix>]?: (
     props: { item: Extract<T, { slot: K extends `${infer Base}-${Suffix}` ? Base : K }> } & ExtraProps
-  ) => VNode[]
+  ) => SlotsReturn
 }
 
 export type GetObjectField<MaybeObject, Key extends string> = MaybeObject extends Record<string, any>

--- a/src/runtime/vue/components/Link.vue
+++ b/src/runtime/vue/components/Link.vue
@@ -1,9 +1,10 @@
 <script lang="ts">
-import type { ButtonHTMLAttributes, VNode } from 'vue'
+import type { ButtonHTMLAttributes } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { RouterLinkProps, RouteLocationRaw } from 'vue-router'
 import theme from '#build/ui/link'
 import type { ComponentConfig } from '../../types/tv'
+import type { SlotsReturn } from '../../types/utils'
 
 type Link = ComponentConfig<typeof theme, AppConfig, 'link'>
 
@@ -82,7 +83,7 @@ export interface LinkProps extends NuxtLinkProps {
 }
 
 export interface LinkSlots {
-  default(props: { active: boolean }): VNode[]
+  default(props: { active: boolean }): SlotsReturn
 }
 </script>
 

--- a/src/runtime/vue/components/Link.vue
+++ b/src/runtime/vue/components/Link.vue
@@ -1,5 +1,5 @@
 <script lang="ts">
-import type { ButtonHTMLAttributes } from 'vue'
+import type { ButtonHTMLAttributes, VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import type { RouterLinkProps, RouteLocationRaw } from 'vue-router'
 import theme from '#build/ui/link'
@@ -82,7 +82,7 @@ export interface LinkProps extends NuxtLinkProps {
 }
 
 export interface LinkSlots {
-  default(props: { active: boolean }): any
+  default(props: { active: boolean }): VNode[]
 }
 </script>
 

--- a/test/components/Accordion.spec.ts
+++ b/test/components/Accordion.spec.ts
@@ -60,7 +60,7 @@ describe('Accordion', () => {
     ['with body slot', { props: { ...props, modelValue: '1' }, slots: { body: () => 'Body slot' } }],
     ['with custom slot', { props: { ...props, modelValue: '5' }, slots: { custom: () => 'Custom slot' } }],
     ['with custom body slot', { props: { ...props, modelValue: '5' }, slots: { 'custom-body': () => 'Custom body slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: AccordionProps, slots?: Partial<AccordionSlots & { custom: () => 'Custom slot' } & { 'custom-body': () => 'Custom body slot' }> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: AccordionProps, slots?: AccordionSlots & { custom?: () => 'Custom slot' } & { 'custom-body'?: () => 'Custom body slot' } }) => {
     const html = await ComponentRender(nameOrHtml, options, Accordion)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Alert.spec.ts
+++ b/test/components/Alert.spec.ts
@@ -32,7 +32,7 @@ describe('Alert', () => {
     ['with title slot', { props, slots: { title: () => 'Title slot' } }],
     ['with description slot', { props, slots: { description: () => 'Description slot' } }],
     ['with close slot', { props, slots: { close: () => 'Close slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: AlertProps, slots?: Partial<AlertSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: AlertProps, slots?: AlertSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Alert)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/AuthForm.spec.ts
+++ b/test/components/AuthForm.spec.ts
@@ -42,7 +42,7 @@ describe('AuthForm', () => {
     ['with validation slot', { props, slots: { validation: () => 'Validation' } }],
     ['with submit slot', { props, slots: { submit: () => 'Submit' } }],
     ['with footer slot', { props, slots: { footer: () => 'Footer' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props: AuthFormProps, slots?: Partial<AuthFormSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props: AuthFormProps, slots?: AuthFormSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, AuthForm)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/AvatarGroup.spec.ts
+++ b/test/components/AvatarGroup.spec.ts
@@ -32,7 +32,7 @@ describe('AvatarGroup', () => {
     ['with ui', { props: { ui: { base: 'rounded-lg' } } }],
     // Slots
     ['with default slot', {}]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: AvatarGroupProps, slots?: Partial<AvatarGroupSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: AvatarGroupProps, slots?: AvatarGroupSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, AvatarGroupWrapper)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Badge.spec.ts
+++ b/test/components/Badge.spec.ts
@@ -32,7 +32,7 @@ describe('Badge', () => {
     ['with default slot', { slots: { default: () => 'Default slot' } }],
     ['with leading slot', { slots: { leading: () => 'Leading slot' } }],
     ['with trailing slot', { slots: { trailing: () => 'Trailing slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: BadgeProps, slots?: Partial<BadgeSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: BadgeProps, slots?: BadgeSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Badge)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Banner.spec.ts
+++ b/test/components/Banner.spec.ts
@@ -27,7 +27,7 @@ describe('Banner', () => {
     ['with title slot', { props, slots: { title: () => 'Title slot' } }],
     ['with actions slot', { props, slots: { actions: () => 'Actions slot' } }],
     ['with close slot', { props, slots: { close: () => 'Close slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: BannerProps, slots?: Partial<BannerSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: BannerProps, slots?: BannerSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Banner)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/BlogPost.spec.ts
+++ b/test/components/BlogPost.spec.ts
@@ -58,7 +58,7 @@ describe('BlogPost', () => {
     ['with header slot', { props, slots: { header: () => 'Header slot' } }],
     ['with body slot', { props, slots: { body: () => 'Body slot' } }],
     ['with footer slot', { props, slots: { footer: () => 'Footer slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: BlogPostProps, slots?: Partial<BlogPostSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: BlogPostProps, slots?: BlogPostSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, BlogPost)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/BlogPosts.spec.ts
+++ b/test/components/BlogPosts.spec.ts
@@ -33,7 +33,7 @@ describe('BlogPosts', () => {
     ['with class', { props: { ...props, class: 'gap-y-12' } }],
     // Slots
     ['with default slot', { props, slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: BlogPostsProps, slots?: Partial<BlogPostsSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: BlogPostsProps, slots?: BlogPostsSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, BlogPosts)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Breadcrumb.spec.ts
+++ b/test/components/Breadcrumb.spec.ts
@@ -41,7 +41,7 @@ describe('Breadcrumb', () => {
     ['with item-trailing slot', { props, slots: { 'item-trailing': () => 'Item trailing slot' } }],
     ['with custom slot', { props, slots: { custom: () => 'Custom slot' } }],
     ['with separator slot', { props, slots: { separator: () => '/' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: BreadcrumbProps, slots?: Partial<BreadcrumbSlots & { custom: () => 'Custom slot' }> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: BreadcrumbProps, slots?: BreadcrumbSlots & { custom?: () => 'Custom slot' } }) => {
     const html = await ComponentRender(nameOrHtml, options, Breadcrumb)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Button.spec.ts
+++ b/test/components/Button.spec.ts
@@ -46,7 +46,7 @@ describe('Button', () => {
     ['with default slot', { slots: { default: () => 'Default slot' } }],
     ['with leading slot', { slots: { leading: () => 'Leading slot' } }],
     ['with trailing slot', { slots: { trailing: () => 'Trailing slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ButtonProps, slots?: Partial<ButtonSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ButtonProps, slots?: ButtonSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Button)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Calendar.spec.ts
+++ b/test/components/Calendar.spec.ts
@@ -46,9 +46,9 @@ describe('Calendar', () => {
     ['with ui', { props: { ui: { header: 'gap-4' } } }],
     // Slots
     ['with heading slot', { slots: { heading: () => 'Heading' } }],
-    ['with day slot', { slots: { day: ({ day }: Parameters<CalendarSlots['day']>[0]) => day.day } }],
-    ['with week-day slot', { slots: { 'week-day': ({ day }: Parameters<CalendarSlots['week-day']>[0]) => day } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: CalendarProps<false, false>, slots?: Partial<CalendarSlots> }) => {
+    ['with day slot', { slots: { day: ({ day }: Parameters<Required<CalendarSlots>['day']>[0]) => day.day } }],
+    ['with week-day slot', { slots: { 'week-day': ({ day }: Parameters<Required<CalendarSlots>['week-day']>[0]) => day } }]
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: CalendarProps<false, false>, slots?: CalendarSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Calendar)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Card.spec.ts
+++ b/test/components/Card.spec.ts
@@ -19,7 +19,7 @@ describe('Card', () => {
     ['with default slot', { slots: { default: () => 'Default slot' } }],
     ['with header slot', { slots: { header: () => 'Header slot' } }],
     ['with footer slot', { slots: { footer: () => 'Footer slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: CardProps, slots?: Partial<CardSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: CardProps, slots?: CardSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Card)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Carousel.spec.ts
+++ b/test/components/Carousel.spec.ts
@@ -40,7 +40,7 @@ describe('Carousel', () => {
     ['with as', { props: { ...props, as: 'nav' } }],
     ['with class', { props: { ...props, class: 'w-full max-w-xs' } }],
     ['with ui', { props: { ...props, ui: { viewport: 'h-[320px]' } } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: CarouselProps, slots?: Partial<CarouselSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: CarouselProps, slots?: CarouselSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, CarouselWrapper)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/ChangelogVersion.spec.ts
+++ b/test/components/ChangelogVersion.spec.ts
@@ -35,7 +35,7 @@ describe('ChangelogVersion', () => {
     ['with authors slot', { slots: { authors: () => 'Authors slot' } }],
     ['with actions slot', { slots: { actions: () => 'Actions slot' } }],
     ['with indicator slot', { slots: { indicator: () => 'Indicator slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ChangelogVersionProps, slots?: Partial<ChangelogVersionSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ChangelogVersionProps, slots?: ChangelogVersionSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, ChangelogVersion)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/ChangelogVersions.spec.ts
+++ b/test/components/ChangelogVersions.spec.ts
@@ -36,7 +36,7 @@ describe('ChangelogVersions', () => {
     // Slots
     ['with default slot', { props, slots: { default: () => 'Default slot' } }],
     ['with indicator slot', { props, slots: { indicator: () => 'Indicator slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ChangelogVersionsProps, slots?: Partial<ChangelogVersionsSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ChangelogVersionsProps, slots?: ChangelogVersionsSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, ChangelogVersions)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/ChatMessage.spec.ts
+++ b/test/components/ChatMessage.spec.ts
@@ -29,7 +29,7 @@ describe('ChatMessage', () => {
     ['with ui', { props: { ...props, ui: {} } }],
     // Slots
     ['with content slot', { props, slots: { content: () => 'Content slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ChatMessageProps, slots?: Partial<ChatMessageSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ChatMessageProps, slots?: ChatMessageSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, ChatMessage)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/ChatMessages.spec.ts
+++ b/test/components/ChatMessages.spec.ts
@@ -34,7 +34,7 @@ describe('ChatMessages', () => {
     ['with indicator slot', { props: { ...props, status: 'submitted' }, slots: { indicator: () => 'Indicator slot' } }],
     ['with viewport slot', { props, slots: { viewport: () => 'Viewport slot' } }],
     ['with content slot', { props, slots: { content: () => 'Content slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ChatMessagesProps, slots?: Partial<ChatMessagesSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ChatMessagesProps, slots?: ChatMessagesSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, ChatMessages)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/ChatPalette.spec.ts
+++ b/test/components/ChatPalette.spec.ts
@@ -14,7 +14,7 @@ describe('ChatPalette', () => {
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }],
     ['with prompt slot', { slots: { prompt: () => 'Prompt slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ChatPaletteProps, slots?: Partial<ChatPaletteSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ChatPaletteProps, slots?: ChatPaletteSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, ChatPalette)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/ChatPrompt.spec.ts
+++ b/test/components/ChatPrompt.spec.ts
@@ -20,7 +20,7 @@ describe('ChatPrompt', () => {
     // Slots
     ['with header slot', { slots: { header: () => 'Header slot' } }],
     ['with footer slot', { slots: { footer: () => 'Footer slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ChatPromptProps, slots?: Partial<ChatPromptSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ChatPromptProps, slots?: ChatPromptSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, ChatPrompt)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Checkbox.spec.ts
+++ b/test/components/Checkbox.spec.ts
@@ -39,7 +39,7 @@ describe('Checkbox', () => {
     // Slots
     ['with label slot', { slots: { label: () => 'Label slot' } }],
     ['with description slot', { slots: { label: () => 'Description slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: CheckboxProps, slots?: Partial<CheckboxSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: CheckboxProps, slots?: CheckboxSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Checkbox)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/CheckboxGroup.spec.ts
+++ b/test/components/CheckboxGroup.spec.ts
@@ -46,7 +46,7 @@ describe('CheckboxGroup', () => {
     ['with legend slot', { props, slots: { legend: () => 'Legend slot' } }],
     ['with label slot', { props, slots: { label: () => 'Label slot' } }],
     ['with description slot', { props, slots: { description: () => 'Description slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: CheckboxGroupProps, slots?: Partial<CheckboxGroupSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: CheckboxGroupProps, slots?: CheckboxGroupSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, CheckboxGroup)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Chip.spec.ts
+++ b/test/components/Chip.spec.ts
@@ -24,7 +24,7 @@ describe('Chip', () => {
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }],
     ['with content slot', { slots: { content: () => 'Content slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ChipProps, slots?: Partial<ChipSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ChipProps, slots?: ChipSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Chip)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Collapsible.spec.ts
+++ b/test/components/Collapsible.spec.ts
@@ -19,7 +19,7 @@ describe('Collapsible', () => {
     // Slots
     ['with default slot', { props, slots: { default: () => 'Default slot' } }],
     ['with content slot', { props, slots: { content: () => 'Content slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: CollapsibleProps, slots?: Partial<CollapsibleSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: CollapsibleProps, slots?: CollapsibleSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Collapsible)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/CommandPalette.spec.ts
+++ b/test/components/CommandPalette.spec.ts
@@ -95,7 +95,7 @@ describe('CommandPalette', () => {
     ['with custom slot', { props, slots: { custom: () => 'Custom slot' } }],
     ['with close slot', { props: { ...props, close: true }, slots: { close: () => 'Close slot' } }],
     ['with footer slot', { props, slots: { footer: () => 'Footer slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: CommandPaletteProps, slots?: Partial<CommandPaletteSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: CommandPaletteProps, slots?: CommandPaletteSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, CommandPalette)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Container.spec.ts
+++ b/test/components/Container.spec.ts
@@ -12,7 +12,7 @@ describe('Container', () => {
     ['with class', { props: { class: 'max-w-5xl' } }],
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ContainerProps, slots?: Partial<ContainerSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ContainerProps, slots?: ContainerSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Container)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/ContextMenu.spec.ts
+++ b/test/components/ContextMenu.spec.ts
@@ -98,7 +98,7 @@ describe('ContextMenu', () => {
     ['with item-label slot', { props, slots: { 'item-label': () => 'Item label slot' } }],
     ['with item-trailing slot', { props, slots: { 'item-trailing': () => 'Item trailing slot' } }],
     ['with custom slot', { props, slots: { custom: () => 'Custom slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ContextMenuProps, slots?: Partial<ContextMenuSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ContextMenuProps, slots?: ContextMenuSlots }) => {
     const wrapper = await mountSuspended(ContextMenuWrapper, options as any)
 
     await wrapper.find('span').trigger('click.right')

--- a/test/components/DashboardGroup.spec.ts
+++ b/test/components/DashboardGroup.spec.ts
@@ -12,7 +12,7 @@ describe('DashboardGroup', () => {
     ['with class', { props: { class: 'inset-4' } }],
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: DashboardGroupProps, slots?: Partial<DashboardGroupSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: DashboardGroupProps, slots?: DashboardGroupSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, DashboardGroup)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/DashboardNavbar.spec.ts
+++ b/test/components/DashboardNavbar.spec.ts
@@ -4,12 +4,12 @@ import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import DashboardGroup from '../../src/runtime/components/DashboardGroup.vue'
 import DashboardNavbar from '../../src/runtime/components/DashboardNavbar.vue'
-import type { DashboardNavbarProps, DashboardNavbarSlots } from '../../src/runtime/components/DashboardNavbar.vue'
+import type { DashboardNavbarProps } from '../../src/runtime/components/DashboardNavbar.vue'
 
 const DashboardWrapper = defineComponent({
   components: {
-    UDashboardGroup: DashboardGroup as any,
-    UDashboardNavbar: DashboardNavbar as any
+    UDashboardGroup: DashboardGroup,
+    UDashboardNavbar: DashboardNavbar
   },
   inheritAttrs: false,
   template: `<UDashboardGroup>
@@ -40,7 +40,7 @@ describe('DashboardNavbar', () => {
     ['with default slot', { slots: { default: () => 'Default slot' } }],
     ['with right slot', { slots: { right: () => 'Right slot' } }],
     ['with toggle slot', { slots: { toggle: () => 'Toggle slot' } }]
-  ])('renders %s correctly', async (_: string, options: { props?: DashboardNavbarProps, slots?: Partial<DashboardNavbarSlots> }) => {
+  ])('renders %s correctly', async (_: string, options: { props?: DashboardNavbarProps, slots?: typeof DashboardWrapper['slots'] }) => {
     const wrapper = await mountSuspended(DashboardWrapper, options)
     expect(wrapper.html()).toMatchSnapshot()
   })

--- a/test/components/DashboardPanel.spec.ts
+++ b/test/components/DashboardPanel.spec.ts
@@ -4,12 +4,12 @@ import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import DashboardGroup from '../../src/runtime/components/DashboardGroup.vue'
 import DashboardPanel from '../../src/runtime/components/DashboardPanel.vue'
-import type { DashboardPanelProps, DashboardPanelSlots } from '../../src/runtime/components/DashboardPanel.vue'
+import type { DashboardPanelProps } from '../../src/runtime/components/DashboardPanel.vue'
 
 const DashboardWrapper = defineComponent({
   components: {
-    UDashboardGroup: DashboardGroup as any,
-    UDashboardPanel: DashboardPanel as any
+    UDashboardGroup: DashboardGroup,
+    UDashboardPanel: DashboardPanel
   },
   inheritAttrs: false,
   template: `<UDashboardGroup>
@@ -37,7 +37,7 @@ describe('DashboardPanel', () => {
     ['with header slot', { slots: { header: () => 'Header slot' } }],
     ['with footer slot', { slots: { footer: () => 'Footer slot' } }],
     ['with resize-handle slot', { slots: { 'resize-handle': () => 'Resize handle slot' } }]
-  ])('renders %s correctly', async (_: string, options: { props?: DashboardPanelProps, slots?: Partial<DashboardPanelSlots> }) => {
+  ])('renders %s correctly', async (_: string, options: { props?: DashboardPanelProps, slots?: typeof DashboardWrapper['slots'] }) => {
     const wrapper = await mountSuspended(DashboardWrapper, options)
     expect(wrapper.html()).toMatchSnapshot()
   })

--- a/test/components/DashboardResizeHandle.spec.ts
+++ b/test/components/DashboardResizeHandle.spec.ts
@@ -4,12 +4,12 @@ import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import DashboardGroup from '../../src/runtime/components/DashboardGroup.vue'
 import DashboardResizeHandle from '../../src/runtime/components/DashboardResizeHandle.vue'
-import type { DashboardResizeHandleProps, DashboardResizeHandleSlots } from '../../src/runtime/components/DashboardResizeHandle.vue'
+import type { DashboardResizeHandleProps } from '../../src/runtime/components/DashboardResizeHandle.vue'
 
 const DashboardWrapper = defineComponent({
   components: {
-    UDashboardGroup: DashboardGroup as any,
-    UDashboardResizeHandle: DashboardResizeHandle as any
+    UDashboardGroup: DashboardGroup,
+    UDashboardResizeHandle: DashboardResizeHandle
   },
   inheritAttrs: false,
   template: `<UDashboardGroup>
@@ -28,7 +28,7 @@ describe('DashboardResizeHandle', () => {
     ['with class', { props: { class: 'absolute' } }],
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (_: string, options: { props?: DashboardResizeHandleProps, slots?: Partial<DashboardResizeHandleSlots> }) => {
+  ])('renders %s correctly', async (_: string, options: { props?: DashboardResizeHandleProps, slots?: typeof DashboardWrapper['slots'] }) => {
     const wrapper = await mountSuspended(DashboardWrapper, options)
     expect(wrapper.html()).toMatchSnapshot()
   })

--- a/test/components/DashboardSidebar.spec.ts
+++ b/test/components/DashboardSidebar.spec.ts
@@ -4,12 +4,12 @@ import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import DashboardGroup from '../../src/runtime/components/DashboardGroup.vue'
 import DashboardSidebar from '../../src/runtime/components/DashboardSidebar.vue'
-import type { DashboardSidebarProps, DashboardSidebarSlots } from '../../src/runtime/components/DashboardSidebar.vue'
+import type { DashboardSidebarProps } from '../../src/runtime/components/DashboardSidebar.vue'
 
 const DashboardWrapper = defineComponent({
   components: {
-    UDashboardGroup: DashboardGroup as any,
-    UDashboardSidebar: DashboardSidebar as any
+    UDashboardGroup: DashboardGroup,
+    UDashboardSidebar: DashboardSidebar
   },
   inheritAttrs: false,
   template: `<UDashboardGroup>
@@ -47,7 +47,7 @@ describe('DashboardSidebar', () => {
     ['with toggle slot', { slots: { toggle: () => 'Toggle slot' } }],
     ['with content slot', { slots: { content: () => 'Content slot' } }],
     ['with resize-handle slot', { slots: { 'resize-handle': () => 'Resize handle slot' } }]
-  ])('renders %s correctly', async (_: string, options: { props?: DashboardSidebarProps, slots?: Partial<DashboardSidebarSlots> }) => {
+  ])('renders %s correctly', async (_: string, options: { props?: DashboardSidebarProps, slots?: typeof DashboardWrapper['slots'] }) => {
     const wrapper = await mountSuspended(DashboardWrapper, options)
     expect(wrapper.html()).toMatchSnapshot()
   })

--- a/test/components/DashboardToolbar.spec.ts
+++ b/test/components/DashboardToolbar.spec.ts
@@ -15,7 +15,7 @@ describe('DashboardToolbar', () => {
     ['with default slot', { slots: { default: (): string => 'Default slot' } }],
     ['with left slot', { slots: { left: (): string => 'Left slot' } }],
     ['with right slot', { slots: { right: (): string => 'Right slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: DashboardToolbarProps, slots?: Partial<DashboardToolbarSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: DashboardToolbarProps, slots?: DashboardToolbarSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, DashboardToolbar)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Drawer.spec.ts
+++ b/test/components/Drawer.spec.ts
@@ -29,7 +29,7 @@ describe('Drawer', () => {
     ['with description slot', { props, slots: { description: () => 'Description slot' } }],
     ['with body slot', { props, slots: { body: () => 'Body slot' } }],
     ['with footer slot', { props, slots: { footer: () => 'Footer slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: DrawerProps, slots?: Partial<DrawerSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: DrawerProps, slots?: DrawerSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Drawer)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/DropdownMenu.spec.ts
+++ b/test/components/DropdownMenu.spec.ts
@@ -110,7 +110,7 @@ describe('DropdownMenu', () => {
     ['with item-label slot', { props, slots: { 'item-label': () => 'Item label slot' } }],
     ['with item-trailing slot', { props, slots: { 'item-trailing': () => 'Item trailing slot' } }],
     ['with custom slot', { props, slots: { custom: () => 'Custom slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: DropdownMenuProps, slots?: Partial<DropdownMenuSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: DropdownMenuProps, slots?: DropdownMenuSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, DropdownMenu)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Empty.spec.ts
+++ b/test/components/Empty.spec.ts
@@ -37,7 +37,7 @@ describe('Empty', () => {
     ['with body slot', { props, slots: { body: () => 'Body slot' } }],
     ['with actions slot', { props, slots: { actions: () => 'Actions slot' } }],
     ['with footer slot', { props, slots: { footer: () => 'Footer slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: EmptyProps, slots?: Partial<EmptySlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: EmptyProps, slots?: EmptySlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Empty)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Error.spec.ts
+++ b/test/components/Error.spec.ts
@@ -28,7 +28,7 @@ describe('Error', () => {
     ['with statusMessage slot', { props, slots: { statusMessage: () => 'Status message slot' } }],
     ['with message slot', { props, slots: { message: () => 'Message slot' } }],
     ['with links slot', { props, slots: { links: () => 'Links slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ErrorProps, slots?: Partial<ErrorSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ErrorProps, slots?: ErrorSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Error)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/FieldGroup.spec.ts
+++ b/test/components/FieldGroup.spec.ts
@@ -43,7 +43,7 @@ describe('FieldGroup', () => {
         }
       }]
     )
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: FieldGroupProps, slots?: Partial<FieldGroupSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: FieldGroupProps, slots?: FieldGroupSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, FieldGroup)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/FileUpload.spec.ts
+++ b/test/components/FileUpload.spec.ts
@@ -86,7 +86,7 @@ describe('FileUpload', () => {
     ['with file-name slot', { props, slots: { 'file-name': () => 'File name slot' } }],
     ['with file-size slot', { props, slots: { 'file-size': () => 'File size slot' } }],
     ['with file-trailing slot', { props, slots: { 'file-trailing': () => 'File trailing slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: FileUploadProps, slots?: Partial<FileUploadSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: FileUploadProps, slots?: FileUploadSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, FileUpload)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Footer.spec.ts
+++ b/test/components/Footer.spec.ts
@@ -17,7 +17,7 @@ describe('Footer', () => {
     ['with right slot', { slots: { right: () => 'Right slot' } }],
     ['with top slot', { slots: { top: () => 'Top slot' } }],
     ['with bottom slot', { slots: { bottom: () => 'Bottom slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: FooterProps, slots?: Partial<FooterSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: FooterProps, slots?: FooterSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Footer)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/FooterColumns.spec.ts
+++ b/test/components/FooterColumns.spec.ts
@@ -71,7 +71,7 @@ describe('FooterColumns', () => {
     ['with link-leading slot', { props, slots: { 'link-leading': () => 'Link leading slot' } }],
     ['with link-label slot', { props, slots: { 'link-label': () => 'Link label slot' } }],
     ['with link-trailing slot', { props, slots: { 'link-trailing': () => 'Link trailing slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: FooterColumnsProps, slots?: Partial<FooterColumnsSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: FooterColumnsProps, slots?: FooterColumnsSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, FooterColumns)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Form.spec.ts
+++ b/test/components/Form.spec.ts
@@ -16,7 +16,7 @@ describe('Form', () => {
   it.each([
     ['with state', { props: { state: {} } }],
     ['with default slot', { props: { state: {} }, slots: { default: () => 'Form slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props: FormProps<any>, slots?: Partial<FormSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props: FormProps<any>, slots?: FormSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, UForm)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/FormField.spec.ts
+++ b/test/components/FormField.spec.ts
@@ -80,7 +80,7 @@ describe('FormField', () => {
     ['with error slot', { slots: { error: () => 'Error slot' } }],
     ['with hint slot', { slots: { hint: () => 'Hint slot' } }],
     ['with help slot', { slots: { help: () => 'Help slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: FormFieldProps, slots?: Partial<FormFieldSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: FormFieldProps, slots?: FormFieldSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, FormFieldWrapper)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Header.spec.ts
+++ b/test/components/Header.spec.ts
@@ -29,7 +29,7 @@ describe('Header', () => {
     ['with bottom slot', { slots: { bottom: () => 'Bottom slot' } }],
     ['with body slot', { slots: { body: () => 'Body slot' } }],
     ['with content slot', { slots: { content: () => 'Content slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: HeaderProps, slots?: Partial<HeaderSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: HeaderProps, slots?: HeaderSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Header)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Input.spec.ts
+++ b/test/components/Input.spec.ts
@@ -46,7 +46,7 @@ describe('Input', () => {
     ['with default slot', { slots: { default: () => 'Default slot' } }],
     ['with leading slot', { slots: { leading: () => 'Leading slot' } }],
     ['with trailing slot', { slots: { trailing: () => 'Trailing slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: InputProps, slots?: Partial<InputSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: InputProps, slots?: InputSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Input)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/InputMenu.spec.ts
+++ b/test/components/InputMenu.spec.ts
@@ -85,7 +85,7 @@ describe('InputMenu', () => {
     ['with item-label slot', { props, slots: { 'item-label': () => 'Item label slot' } }],
     ['with item-trailing slot', { props, slots: { 'item-trailing': () => 'Item trailing slot' } }],
     ['with create-item-label slot', { props: { ...props, searchTerm: 'New value', createItem: true }, slots: { 'create-item-label': () => 'Create item slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: InputMenuProps, slots?: Partial<InputMenuSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: InputMenuProps, slots?: InputMenuSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, InputMenu)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/InputNumber.spec.ts
+++ b/test/components/InputNumber.spec.ts
@@ -34,7 +34,7 @@ describe('InputNumber', () => {
     // Slots
     ['with increment slot', { slots: { increment: () => '+' } }],
     ['with decrement slot', { slots: { decrement: () => '-' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: InputNumberProps, slots?: Partial<InputNumberSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: InputNumberProps, slots?: InputNumberSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, InputNumber)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/InputTags.spec.ts
+++ b/test/components/InputTags.spec.ts
@@ -38,7 +38,7 @@ describe('InputTags', () => {
     ['with trailing slot', { slots: { trailing: () => 'Trailing slot' } }],
     ['with item-text slot', { slots: { ['item-text']: () => 'Item Text slot' } }],
     ['with item-delete slot', { slots: { ['item-delete']: () => 'Item Delete slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: InputTagsProps, slots?: Partial<InputTagsSlots>, attrs?: Record<string, unknown> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: InputTagsProps, slots?: InputTagsSlots, attrs?: Record<string, unknown> }) => {
     const html = await ComponentRender(nameOrHtml, options, InputTags)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Kbd.spec.ts
+++ b/test/components/Kbd.spec.ts
@@ -20,7 +20,7 @@ describe('Kbd', () => {
     ['with class', { props: { value: 'K', class: 'font-bold' } }],
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: KbdProps, slots?: Partial<KbdSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: KbdProps, slots?: KbdSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Kbd)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Link.spec.ts
+++ b/test/components/Link.spec.ts
@@ -20,7 +20,7 @@ describe('Link', () => {
     ['with class', { props: { class: 'font-medium' } }],
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: LinkProps, slots?: Partial<LinkSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: LinkProps, slots?: LinkSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Link)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Main.spec.ts
+++ b/test/components/Main.spec.ts
@@ -12,7 +12,7 @@ describe('Main', () => {
     ['with class', { props: { class: 'min-h-full' } }],
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: MainProps, slots?: Partial<MainSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: MainProps, slots?: MainSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Main)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Marquee.spec.ts
+++ b/test/components/Marquee.spec.ts
@@ -18,7 +18,7 @@ describe('Marquee', () => {
     ['with ui', { props: { ui: { content: 'gap-4' } } }],
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: MarqueeProps, slots?: Partial<MarqueeSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: MarqueeProps, slots?: MarqueeSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Marquee)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Modal.spec.ts
+++ b/test/components/Modal.spec.ts
@@ -30,7 +30,7 @@ describe('Modal', () => {
     ['with close slot', { props, slots: { close: () => 'Close slot' } }],
     ['with body slot', { props, slots: { body: () => 'Body slot' } }],
     ['with footer slot', { props, slots: { footer: () => 'Footer slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ModalProps, slots?: Partial<ModalSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ModalProps, slots?: ModalSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Modal)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/NavigationMenu.spec.ts
+++ b/test/components/NavigationMenu.spec.ts
@@ -111,7 +111,7 @@ describe('NavigationMenu', () => {
     ['with item-label slot', { props, slots: { 'item-label': () => 'Item label slot' } }],
     ['with item-trailing slot', { props, slots: { 'item-trailing': () => 'Item trailing slot' } }],
     ['with custom slot', { props, slots: { custom: () => 'Custom slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: NavigationMenuProps, slots?: Partial<NavigationMenuSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: NavigationMenuProps, slots?: NavigationMenuSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, NavigationMenu)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PageAnchors.spec.ts
+++ b/test/components/PageAnchors.spec.ts
@@ -39,7 +39,7 @@ describe('PageAnchors', () => {
     ['with link-leading slot', { props, slots: { 'link-leading': () => 'Link leading slot' } }],
     ['with link-label slot', { props, slots: { 'link-label': () => 'Link label slot' } }],
     ['with link-trailing slot', { props, slots: { 'link-trailing': () => 'Link trailing slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageAnchorsProps, slots?: Partial<PageAnchorsSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageAnchorsProps, slots?: PageAnchorsSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PageAnchors)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PageBody.spec.ts
+++ b/test/components/PageBody.spec.ts
@@ -12,7 +12,7 @@ describe('PageBody', () => {
     ['with class', { props: { class: 'mt-12' } }],
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageBodyProps, slots?: Partial<PageBodySlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageBodyProps, slots?: PageBodySlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PageBody)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PageCTA.spec.ts
+++ b/test/components/PageCTA.spec.ts
@@ -32,7 +32,7 @@ describe('PageCTA', () => {
     ['with links slot', { slots: { links: () => 'Links slot' } }],
     ['with default slot', { slots: { default: () => 'Default slot' } }],
     ['with bottom slot', { slots: { bottom: () => 'Bottom slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageCTAProps, slots?: Partial<PageCTASlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageCTAProps, slots?: PageCTASlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PageCTA)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PageCard.spec.ts
+++ b/test/components/PageCard.spec.ts
@@ -46,7 +46,7 @@ describe('PageCard', () => {
     ['with description slot', { props, slots: { description: () => 'Description slot' } }],
     ['with footer slot', { props, slots: { footer: () => 'Footer slot' } }],
     ['with default slot', { props, slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageCardProps, slots?: Partial<PageCardSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageCardProps, slots?: PageCardSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PageCard)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PageColumns.spec.ts
+++ b/test/components/PageColumns.spec.ts
@@ -12,7 +12,7 @@ describe('PageColumns', () => {
     ['with class', { props: { class: 'xl:columns-4' } }],
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageColumnsProps, slots?: Partial<PageColumnsSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageColumnsProps, slots?: PageColumnsSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PageColumns)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PageFeature.spec.ts
+++ b/test/components/PageFeature.spec.ts
@@ -30,7 +30,7 @@ describe('PageFeature', () => {
     ['with title slot', { props, slots: { title: () => 'Title slot' } }],
     ['with description slot', { props, slots: { description: () => 'Description slot' } }],
     ['with default slot', { props, slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageFeatureProps, slots?: Partial<PageFeatureSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageFeatureProps, slots?: PageFeatureSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PageFeature)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PageGrid.spec.ts
+++ b/test/components/PageGrid.spec.ts
@@ -12,7 +12,7 @@ describe('PageGrid', () => {
     ['with class', { props: { class: 'xl:grid-cols-4' } }],
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageGridProps, slots?: Partial<PageGridSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageGridProps, slots?: PageGridSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PageGrid)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PageHeader.spec.ts
+++ b/test/components/PageHeader.spec.ts
@@ -21,7 +21,7 @@ describe('PageHeader', () => {
     ['with headline slot', { slots: { headline: () => 'Headline slot' } }],
     ['with links slot', { slots: { links: () => 'Links slot' } }],
     ['with default slot', { slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageHeaderProps, slots?: Partial<PageHeaderSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageHeaderProps, slots?: PageHeaderSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PageHeader)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PageHero.spec.ts
+++ b/test/components/PageHero.spec.ts
@@ -29,7 +29,7 @@ describe('PageHero', () => {
     ['with links slot', { slots: { links: () => 'Links slot' } }],
     ['with default slot', { slots: { default: () => 'Default slot' } }],
     ['with bottom slot', { slots: { bottom: () => 'Bottom slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageHeroProps, slots?: Partial<PageHeroSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageHeroProps, slots?: PageHeroSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PageHero)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PageLinks.spec.ts
+++ b/test/components/PageLinks.spec.ts
@@ -41,7 +41,7 @@ describe('PageLinks', () => {
     ['with link-leading slot', { props, slots: { 'link-leading': () => 'Link leading slot' } }],
     ['with link-label slot', { props, slots: { 'link-label': () => 'Link label slot' } }],
     ['with link-trailing slot', { props, slots: { 'link-trailing': () => 'Link trailing slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageLinksProps, slots?: Partial<PageLinksSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageLinksProps, slots?: PageLinksSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PageLinks)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PageList.spec.ts
+++ b/test/components/PageList.spec.ts
@@ -13,7 +13,7 @@ describe('PageList', () => {
     ['with class', { props: { class: 'gap-2' } }],
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageListProps, slots?: Partial<PageListSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageListProps, slots?: PageListSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PageList)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PageLogos.spec.ts
+++ b/test/components/PageLogos.spec.ts
@@ -21,7 +21,7 @@ describe('PageLogos', () => {
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }],
     ['with default slot', { slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageLogosProps, slots?: Partial<PageLogosSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageLogosProps, slots?: PageLogosSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PageLogos)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PageSection.spec.ts
+++ b/test/components/PageSection.spec.ts
@@ -38,7 +38,7 @@ describe('PageSection', () => {
     ['with links slot', { slots: { links: () => 'Links slot' } }],
     ['with default slot', { slots: { default: () => 'Default slot' } }],
     ['with bottom slot', { slots: { bottom: () => 'Bottom slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageSectionProps, slots?: Partial<PageSectionSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PageSectionProps, slots?: PageSectionSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PageSection)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Pagination.spec.ts
+++ b/test/components/Pagination.spec.ts
@@ -42,7 +42,7 @@ describe('Pagination', () => {
     ['with last slot', { props, slots: { last: () => 'Last slot' } }],
     ['with ellipsis slot', { props: { ...props, siblingCount: 1, showEdges: true, page: 5 }, slots: { ellipsis: () => 'Ellipsis slot' } }],
     ['with item slot', { props, slots: { item: () => 'Item slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PaginationProps, slots?: Partial<PaginationSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PaginationProps, slots?: PaginationSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Pagination)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PricingPlan.spec.ts
+++ b/test/components/PricingPlan.spec.ts
@@ -66,7 +66,7 @@ describe('PricingPlan', () => {
     ['with header slot', { props, slots: { header: () => 'Header slot' } }],
     ['with body slot', { props, slots: { body: () => 'Body slot' } }],
     ['with footer slot', { props, slots: { footer: () => 'Footer slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PricingPlanProps, slots?: Partial<PricingPlanSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PricingPlanProps, slots?: PricingPlanSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PricingPlan)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PricingPlans.spec.ts
+++ b/test/components/PricingPlans.spec.ts
@@ -35,7 +35,7 @@ describe('PricingPlans', () => {
     ['with class', { props: { ...props, class: 'gap-y-12' } }],
     // Slots
     ['with default slot', { props, slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PricingPlansProps, slots?: Partial<PricingPlansSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: PricingPlansProps, slots?: PricingPlansSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PricingPlans)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/PricingTable.spec.ts
+++ b/test/components/PricingTable.spec.ts
@@ -80,7 +80,7 @@ describe('PricingTable', () => {
     ['with tier-billing slot', { props, slots: { 'tier-billing': () => 'Tier billing slot' } }],
     ['with tier-discount slot', { props, slots: { 'tier-discount': () => 'Tier discount slot' } }],
     ['with tier-price slot', { props, slots: { 'tier-price': () => 'Tier price slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props: PricingTableProps, slots?: Partial<PricingTableSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props: PricingTableProps, slots?: PricingTableSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, PricingTable)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Progress.spec.ts
+++ b/test/components/Progress.spec.ts
@@ -28,7 +28,7 @@ describe('Progress', () => {
     ['with ui', { props: { ui: { base: 'bg-default' } } }],
     // Slots
     ['with status slot', { slots: { status: () => 'Status slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ProgressProps, slots?: Partial<ProgressSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ProgressProps, slots?: ProgressSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Progress)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/RadioGroup.spec.ts
+++ b/test/components/RadioGroup.spec.ts
@@ -45,7 +45,7 @@ describe('RadioGroup', () => {
     ['with legend slot', { props, slots: { label: () => 'Legend slot' } }],
     ['with label slot', { props, slots: { label: () => 'Label slot' } }],
     ['with description slot', { props, slots: { label: () => 'Description slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: RadioGroupProps, slots?: Partial<RadioGroupSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: RadioGroupProps, slots?: RadioGroupSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, RadioGroup)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Select.spec.ts
+++ b/test/components/Select.spec.ts
@@ -81,7 +81,7 @@ describe('Select', () => {
     ['with item-leading slot', { props, slots: { 'item-leading': () => 'Item leading slot' } }],
     ['with item-label slot', { props, slots: { 'item-label': () => 'Item label slot' } }],
     ['with item-trailing slot', { props, slots: { 'item-trailing': () => 'Item trailing slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: SelectProps, slots?: Partial<SelectSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: SelectProps, slots?: SelectSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Select)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/SelectMenu.spec.ts
+++ b/test/components/SelectMenu.spec.ts
@@ -87,7 +87,7 @@ describe('SelectMenu', () => {
     ['with item-label slot', { props, slots: { 'item-label': () => 'Item label slot' } }],
     ['with item-trailing slot', { props, slots: { 'item-trailing': () => 'Item trailing slot' } }],
     ['with create-item-label slot', { props: { ...props, searchTerm: 'New value', createItem: true }, slots: { 'create-item-label': () => 'Create item slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: SelectMenuProps, slots?: Partial<SelectMenuSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: SelectMenuProps, slots?: SelectMenuSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, SelectMenu)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Separator.spec.ts
+++ b/test/components/Separator.spec.ts
@@ -23,7 +23,7 @@ describe('Separator', () => {
     ['with as', { props: { as: 'span' } }],
     ['with class', { props: { class: 'flex-row-reverse' } }],
     ['with ui', { props: { ui: { label: 'text-lg' } } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: SeparatorProps, slots?: Partial<SeparatorSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: SeparatorProps, slots?: SeparatorSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Separator)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Slideover.spec.ts
+++ b/test/components/Slideover.spec.ts
@@ -32,7 +32,7 @@ describe('Slideover', () => {
     ['with close slot', { props, slots: { close: () => 'Close slot' } }],
     ['with body slot', { props, slots: { body: () => 'Body slot' } }],
     ['with footer slot', { props, slots: { footer: () => 'Footer slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: SlideoverProps, slots?: Partial<SlideoverSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: SlideoverProps, slots?: SlideoverSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Slideover)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Stepper.spec.ts
+++ b/test/components/Stepper.spec.ts
@@ -46,7 +46,7 @@ describe('Stepper', () => {
     ['with description slot', { props, slots: { description: () => 'Description slot' } }],
     ['with content slot', { props, slots: { content: () => 'Content slot' } }],
     ['with custom slot', { props, slots: { custom: () => 'Custom slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: StepperProps, slots?: Partial<StepperSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: StepperProps, slots?: StepperSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Stepper)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Switch.spec.ts
+++ b/test/components/Switch.spec.ts
@@ -36,7 +36,7 @@ describe('Switch', () => {
     // Slots
     ['with label slot', { slots: { label: () => 'Label slot' } }],
     ['with description slot', { slots: { label: () => 'Description slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: SwitchProps, slots?: Partial<SwitchSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: SwitchProps, slots?: SwitchSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Switch)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Table.spec.ts
+++ b/test/components/Table.spec.ts
@@ -182,7 +182,7 @@ describe('Table', () => {
     ['with caption slot', { props, slots: { caption: () => 'Caption slot' } }],
     ['with body-top slot', { props, slots: { 'body-top': () => 'Body top slot' } }],
     ['with body-bottom slot', { props, slots: { 'body-bottom': () => 'Body bottom slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: TableProps, slots?: Partial<TableSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: TableProps, slots?: TableSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Table)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Tabs.spec.ts
+++ b/test/components/Tabs.spec.ts
@@ -52,7 +52,7 @@ describe('Tabs', () => {
     ['with trailing slot', { props, slots: { trailing: () => 'Trailing slot' } }],
     ['with content slot', { props, slots: { content: () => 'Content slot' } }],
     ['with custom slot', { props, slots: { custom: () => 'Custom slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: TabsProps, slots?: Partial<TabsSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: TabsProps, slots?: TabsSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Tabs)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Textarea.spec.ts
+++ b/test/components/Textarea.spec.ts
@@ -46,7 +46,7 @@ describe('Textarea', () => {
     ['with default slot', { slots: { default: () => 'Default slot' } }],
     ['with leading slot', { slots: { leading: () => 'Leading slot' } }],
     ['with trailing slot', { slots: { trailing: () => 'Trailing slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: TextareaProps, slots?: Partial<TextareaSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: TextareaProps, slots?: TextareaSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Textarea)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Timeline.spec.ts
+++ b/test/components/Timeline.spec.ts
@@ -56,7 +56,7 @@ describe('Timeline', () => {
     ['with date slot', { props, slots: { date: () => 'Date slot' } }],
     ['with title slot', { props, slots: { title: () => 'Title slot' } }],
     ['with description slot', { props, slots: { description: () => 'Description slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: TimelineProps, slots?: Partial<TimelineSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: TimelineProps, slots?: TimelineSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Timeline)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Toast.spec.ts
+++ b/test/components/Toast.spec.ts
@@ -50,7 +50,7 @@ describe('Toast', () => {
     ['with title slot', { props, slots: { title: () => 'Title slot' } }],
     ['with description slot', { props, slots: { description: () => 'Description slot' } }],
     ['with close slot', { props, slots: { close: () => 'Close slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ToastProps, slots?: Partial<ToastSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ToastProps, slots?: ToastSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, ToastWrapper)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/Tree.spec.ts
+++ b/test/components/Tree.spec.ts
@@ -71,7 +71,7 @@ describe('Tree', () => {
     ['with item-leading slot', { props, slots: { 'item-leading': () => 'leading slot' } }],
     ['with item-trailing slot', { props, slots: { 'item-trailing': () => 'trailing slot' } }],
     ['with dynamic slot', { props, slots: { app: () => 'dynamic slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: Partial<TreeProps>, slots?: Partial<TreeSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: Partial<TreeProps>, slots?: TreeSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, Tree)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/User.spec.ts
+++ b/test/components/User.spec.ts
@@ -33,7 +33,7 @@ describe('User', () => {
     ['with name slot', { props, slots: { name: () => 'Name slot' } }],
     ['with description slot', { props, slots: { description: () => 'Description slot' } }],
     ['with default slot', { props, slots: { default: () => 'Default slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: UserProps, slots?: Partial<UserSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: UserProps, slots?: UserSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, User)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/content/ContentNavigation.spec.ts
+++ b/test/components/content/ContentNavigation.spec.ts
@@ -68,7 +68,7 @@ describe('ContentNavigation', () => {
     ['with item-label slot', { props, slots: { 'item-label': () => 'Item label slot' } }],
     ['with item-trailing slot', { props, slots: { 'item-trailing': () => 'Item trailing slot' } }],
     ['with custom slot', { props, slots: { custom: () => 'Custom slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ContentNavigationProps, slots?: Partial<ContentNavigationSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ContentNavigationProps, slots?: ContentNavigationSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, ContentNavigation)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/content/ContentSurround.spec.ts
+++ b/test/components/content/ContentSurround.spec.ts
@@ -28,7 +28,7 @@ describe('ContentSurround', () => {
     ['with link slot', { props, slots: { link: () => 'Link slot' } }],
     ['with link-leading slot', { props, slots: { 'link-leading': () => 'Link leading slot' } }],
     ['with link-title slot', { props, slots: { 'link-title': () => 'Link title slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ContentSurroundProps, slots?: Partial<ContentSurroundSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ContentSurroundProps, slots?: ContentSurroundSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, ContentSurround)
     expect(html).toMatchSnapshot()
   })

--- a/test/components/content/ContentToc.spec.ts
+++ b/test/components/content/ContentToc.spec.ts
@@ -66,7 +66,7 @@ describe('ContentToc', () => {
     ['with link slot', { props, slots: { link: () => 'Link slot' } }],
     ['with top slot', { props, slots: { top: () => 'Top slot' } }],
     ['with bottom slot', { props, slots: { bottom: () => 'Bottom slot' } }]
-  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ContentTocProps, slots?: Partial<ContentTocSlots> }) => {
+  ])('renders %s correctly', async (nameOrHtml: string, options: { props?: ContentTocProps, slots?: ContentTocSlots }) => {
     const html = await ComponentRender(nameOrHtml, options, ContentToc)
     expect(html).toMatchSnapshot()
   })

--- a/test/utils/types.ts
+++ b/test/utils/types.ts
@@ -18,7 +18,7 @@ export function expectSlotProps<T extends VNode, S extends keyof Slots<T>>(_name
 type Ctx<V extends VNode> = V extends { __ctx?: infer C } ? NonNullable<C> : never
 
 type Slots<V extends VNode> = Ctx<V> extends { slots: infer S } ? {
-  [K in keyof S as S[K] extends never ? never : K]: S[K] extends (props: infer P) => any ? P : never
+  [K in keyof Required<S> as Required<S>[K] extends never ? never : K]: Required<S>[K] extends (props: infer P) => any ? P : never
 } : never
 
 type Events<V extends VNode> = Ctx<V> extends { props: infer Props } ? {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #5232

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Until the last update for the builder we weren't able to properly and strongly type various aspects about props, slots and emits. Now the issue has been fixed, but slots were left unchanged (all being required and return was `any`). With this change normal use in the template won't change, but does greatly increase the typing experience when using render functions (required for the current UTable implementation).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
