### PR TITLE
Refactor theming configuration to use colors object

### DIFF
--- a/docs/content/1.getting-started/3.theming.md
+++ b/docs/content/1.getting-started/3.theming.md
@@ -13,8 +13,10 @@ Components are based on a `primary` and a `gray` color. You can change them in y
 ```ts [app.config.ts]
 export default defineAppConfig({
   ui: {
-    primary: 'green',
-    gray: 'cool'
+    colors: {
+      primary: 'green',
+      gray: 'cool'
+    }
   }
 })
 ```


### PR DESCRIPTION
Current configuration definition is not compatible with AppConfigUI which requires the colors property.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
The new AppConfigUI  expect a the primary and secondary colors to be defined under the colors property, but this is not what the documentation example is doing.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
