### PR TITLE
docs: Fix email validation schema in AuthFormExample.vue & AuthFormPa…

### DIFF
--- a/docs/app/components/content/examples/auth-form/AuthFormExample.vue
+++ b/docs/app/components/content/examples/auth-form/AuthFormExample.vue
@@ -37,7 +37,7 @@ const providers = [{
 }]
 
 const schema = z.object({
-  email: z.email('Invalid email'),
+  email: z.string().email('Invalid email'),
   password: z.string('Password is required').min(8, 'Must be at least 8 characters')
 })
 

--- a/docs/app/components/content/examples/auth-form/AuthFormPageExample.vue
+++ b/docs/app/components/content/examples/auth-form/AuthFormPageExample.vue
@@ -37,7 +37,7 @@ const providers = [{
 }]
 
 const schema = z.object({
-  email: z.email('Invalid email'),
+  email: z.string().email('Invalid email'),
   password: z.string('Password is required').min(8, 'Must be at least 8 characters')
 })
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #5281

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The PR adds the `.string()` missing before `.email('Invalid email')` at https://ui.nuxt.com/docs/components/auth-form

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
