### PR TITLE
fix(Table): Fix data reactivity

### DIFF
--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -327,7 +327,9 @@ const tableRef = ref<HTMLTableElement | null>(null)
 
 const tableApi = useVueTable({
   ...reactiveOmit(props, 'as', 'data', 'columns', 'virtualize', 'caption', 'sticky', 'loading', 'loadingColor', 'loadingAnimation', 'class', 'ui'),
-  data,
+  get data() {
+    return data.value
+  },
   get columns() {
     return columns.value
   },


### PR DESCRIPTION
### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `UTable` component intermittently fails to display data, especially when the underlying computations for the `data` prop are complex or involve asynchronous operations. Although not consistently reproducible with simple examples, the problem consistently appears with more elaborate data transformations (maybe because tanstack internally uses a `shallowRef`?). The fix ensures proper reactivity by explicitly wrapping the `data` prop within a getter like it has been done with the column or state fields.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
