### PR TITLE
fix(ProseCallout): add `inline-block` class to icon

### DIFF
--- a/src/theme/prose/callout.ts
+++ b/src/theme/prose/callout.ts
@@ -3,7 +3,7 @@ import type { NuxtOptions } from '@nuxt/schema'
 export default (options: Required<NuxtOptions['ui']>) => ({
   slots: {
     base: ['group relative block px-4 py-3 rounded-md text-sm/6 my-5 last:mb-0 [&_code]:text-xs/5 [&_code]:bg-default [&_pre]:bg-default [&>div]:my-2.5 [&_ul]:my-2.5 [&_ol]:my-2.5 [&>*]:last:!mb-0 [&_ul]:ps-4.5 [&_ol]:ps-4.5 [&_li]:my-0', options.theme.transitions && 'transition-colors'],
-    icon: ['size-4 shrink-0 align-sub me-1.5', options.theme.transitions && 'transition-colors'],
+    icon: ['size-4 shrink-0 align-sub me-1.5 inline-block', options.theme.transitions && 'transition-colors'],
     externalIcon: ['size-4 align-top absolute right-2 top-2 pointer-events-none', options.theme.transitions && 'transition-colors']
   },
   variants: {


### PR DESCRIPTION
### 🔗 Linked issue


### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I've added the `inline-block` class to the icon in the `ProseCallout` component.

Using Nuxt icon in svg mode the text will be displayed below the icon, like on this screenshot:

<img width="1503" height="194" alt="Screenshot from 2025-10-26 21-21-57" src="https://github.com/user-attachments/assets/9e3d2072-e98a-4479-8afd-82f5370573f9" />

This is resolved by adding the `inline-block` class to the icon.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
