### PR TITLE
docs(header): add tip for title link's aria-label

### DIFF
--- a/docs/content/docs/2.components/header.md
+++ b/docs/content/docs/2.components/header.md
@@ -51,6 +51,10 @@ class: '!px-0 !pt-0'
 
 You can also use the `title` slot to add your own logo.
 
+::tip{to="#props"}
+You should still add the `title` prop to replace the default `aria-label` of the link.
+::
+
 ::component-code
 ---
 prettier: true


### PR DESCRIPTION


<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
NA
<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
Using the `title` slot of the header component doesn't change the `aria-label` of the link from its default value of `Nuxt UI`.

Add an explicit tip to still add the `title` prop along with the `title` slot for changing the `aria-label`.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
