### PR TITLE
fix(vue): check `import.meta.env.SSR` to support `vite-ssg`

### DIFF
--- a/src/runtime/vue/stubs.ts
+++ b/src/runtime/vue/stubs.ts
@@ -66,7 +66,7 @@ const hooks = createHooks()
 export function useNuxtApp() {
   return {
     isHydrating: true,
-    payload: { serverRendered: import.meta.SSR || false },
+    payload: { serverRendered: import.meta.env.SSR || false },
     hooks,
     hook: hooks.hook
   }

--- a/src/runtime/vue/stubs.ts
+++ b/src/runtime/vue/stubs.ts
@@ -66,7 +66,7 @@ const hooks = createHooks()
 export function useNuxtApp() {
   return {
     isHydrating: true,
-    payload: { serverRendered: false },
+    payload: { serverRendered: import.meta.SSR || false },
     hooks,
     hook: hooks.hook
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Hello 👋,

I'm currently using Nuxt UI within a Vite + Vue application. I'm also using [Vite SSG](https://github.com/antfu-collective/vite-ssg) to statically generate pages.

Vite SSG injects [`import.meta.env.SSR`](https://github.com/antfu-collective/vite-ssg?tab=readme-ov-file#how-to-allow-rollup-tree-shake-your-client-code) when building the server app.

Currently, the [`colors`](https://github.com/nuxt/ui/blob/v4/src/runtime/plugins/colors.ts#L52) plugin injects colors into the head when on the client, but the detection doesn’t work as `import.meta.client` is not set to `false` when using Vite SSG.

So instead of changing the condition, I just set `serverRendered` to `import.meta.env.SSR` to make sure it’s correctly set everywhere it’s used.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
