### PR TITLE
fix(vite): write theme templates

### DIFF
--- a/docs/content/docs/1.getting-started/2.installation/2.vue.md
+++ b/docs/content/docs/1.getting-started/2.installation/2.vue.md
@@ -138,7 +138,7 @@ Internally, Nuxt UI relies on custom alias to resolve the theme types. If you're
   "compilerOptions": {
     "paths": {
       "#build/ui": [
-        "./node_modules/@nuxt/ui/.nuxt/ui"
+        "./node_modules/.nuxt-ui/ui"
       ]
     }
   }

--- a/package.json
+++ b/package.json
@@ -83,8 +83,6 @@
   "style": "./dist/runtime/index.css",
   "main": "./dist/module.mjs",
   "files": [
-    ".nuxt/ui",
-    ".nuxt/ui.css",
     "dist",
     "cli",
     "vue-plugin.d.ts"

--- a/package.json
+++ b/package.json
@@ -77,10 +77,6 @@
       ]
     }
   },
-  "imports": {
-    "#build/ui/*": "./.nuxt/ui/*.ts",
-    "#build/ui.css": "./.nuxt/ui.css"
-  },
   "bin": {
     "nuxt-ui": "./cli/index.mjs"
   },

--- a/playgrounds/vue/tsconfig.node.json
+++ b/playgrounds/vue/tsconfig.node.json
@@ -16,7 +16,14 @@
     "strict": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true
+    "noFallthroughCasesInSwitch": true,
+
+    /* Aliases */
+    "paths": {
+      "#build/ui": [
+        "./node_modules/.nuxt-ui/ui"
+      ]
+    }
   },
   "include": ["vite.config.ts"]
 }

--- a/src/plugins/templates.ts
+++ b/src/plugins/templates.ts
@@ -1,8 +1,8 @@
+import fs from 'node:fs'
+import path from 'node:path'
 import type { UnpluginOptions } from 'unplugin'
 import type { NuxtUIOptions } from '../unplugin'
 import { getTemplates } from '../templates'
-import path from 'node:path'
-import fs from 'node:fs'
 
 /**
  * This plugin is responsible for getting the generated virtual templates and
@@ -24,7 +24,8 @@ export default function TemplatePlugin(options: NuxtUIOptions, appConfig: Record
         fs.mkdirSync(path.dirname(filePath), { recursive: true })
       }
       fs.writeFileSync(filePath, await template.getContents!({} as any))
-      map['#build/' + template.filename] = filePath
+
+      map[`#build/${template.filename}`] = filePath
     }
     return map
   }
@@ -34,9 +35,11 @@ export default function TemplatePlugin(options: NuxtUIOptions, appConfig: Record
     enforce: 'pre',
     vite: {
       async config(config) {
+        const alias = await writeTemplates(config.root || process.cwd())
+
         return {
           resolve: {
-            alias: await writeTemplates(config.root || process.cwd())
+            alias
           }
         }
       }

--- a/src/plugins/templates.ts
+++ b/src/plugins/templates.ts
@@ -1,6 +1,8 @@
 import type { UnpluginOptions } from 'unplugin'
 import type { NuxtUIOptions } from '../unplugin'
 import { getTemplates } from '../templates'
+import path from 'node:path'
+import fs from 'node:fs'
 
 /**
  * This plugin is responsible for getting the generated virtual templates and
@@ -10,9 +12,35 @@ export default function TemplatePlugin(options: NuxtUIOptions, appConfig: Record
   const templates = getTemplates(options, appConfig.ui)
   const templateKeys = new Set(templates.map(t => `#build/${t.filename}`))
 
+  async function writeTemplates(root: string) {
+    const map: Record<string, string> = {}
+    const dir = path.join(root, 'node_modules', '.nuxt-ui')
+    for (const template of templates) {
+      if (!template.write || !template.filename) {
+        continue
+      }
+      const filePath = path.join(dir, template.filename)
+      if (!fs.existsSync(path.dirname(filePath))) {
+        fs.mkdirSync(path.dirname(filePath), { recursive: true })
+      }
+      fs.writeFileSync(filePath, await template.getContents!({} as any))
+      map['#build/' + template.filename] = filePath
+    }
+    return map
+  }
+
   return {
     name: 'nuxt:ui:templates',
     enforce: 'pre',
+    vite: {
+      async config(config) {
+        return {
+          resolve: {
+            alias: await writeTemplates(config.root || process.cwd())
+          }
+        }
+      }
+    },
     resolveId(id) {
       if (templateKeys.has(id + '.ts')) {
         return id.replace('#build/', 'virtual:nuxt-ui-templates/') + '.ts'


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
Resolves #4951

Peered with @benjamincanac 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
Fixes the Vite plugin where theme files were incorrectly shipped inside `.nuxt/` on NPM (`#build/ui.css` import was not working). They are now properly generated as real files that Tailwind CSS can read, ensuring custom theme colors and user configuration work correctly.

Since theme template files are written on disk, you have to update your `tsconfig.node.json` alias:

```diff
{
  "compilerOptions": {
    "paths": {
      "#build/ui": [
-       "./node_modules/@nuxt/ui/.nuxt/ui"
+       "./node_modules/.nuxt-ui/ui"
      ]
    }
  }
}
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.