### PR TITLE
fix(SelectMenu): correct virtualization height estimation when using item-description slot

### DIFF
--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -226,7 +226,7 @@ const arrowProps = toRef(() => props.arrow as ComboboxArrowProps)
 const virtualizerProps = toRef(() => {
   if (!props.virtualize) return false
 
-  const hasDescriptions = items.value.some(item =>
+  const hasDescriptions = filteredItems.value.some(item =>
     isSelectItem(item) && (get(item, props.descriptionKey as string) || !!slots['item-description'])
   )
 

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -223,15 +223,33 @@ const rootProps = useForwardPropsEmits(reactivePick(props, 'modelValue', 'defaul
 const portalProps = usePortal(toRef(() => props.portal))
 const contentProps = toRef(() => defu(props.content, { side: 'bottom', sideOffset: 8, collisionPadding: 8, position: 'popper' }) as ComboboxContentProps)
 const arrowProps = toRef(() => props.arrow as ComboboxArrowProps)
-const virtualizerProps = toRef(() => !!props.virtualize && defu(typeof props.virtualize === 'boolean' ? {} : props.virtualize, {
-  estimateSize: ({
+const virtualizerProps = toRef(() => {
+  if (!props.virtualize) return false
+
+  const hasDescriptions = items.value.some(item =>
+    isSelectItem(item) && (get(item, props.descriptionKey as string) || !!slots['item-description'])
+  )
+
+  const baseSize = {
     xs: 24,
     sm: 28,
     md: 32,
     lg: 36,
     xl: 40
-  })[props.size || 'md']
-}))
+  }[props.size || 'md']
+
+  const sizeWithDescription = {
+    xs: 44,
+    sm: 48,
+    md: 52,
+    lg: 56,
+    xl: 60
+  }[props.size || 'md']
+
+  return defu(typeof props.virtualize === 'boolean' ? {} : props.virtualize, {
+    estimateSize: hasDescriptions ? sizeWithDescription : baseSize
+  })
+})
 const searchInputProps = toRef(() => defu(props.searchInput, { placeholder: t('selectMenu.search'), variant: 'none' }) as InputProps)
 
 const { emitFormBlur, emitFormFocus, emitFormInput, emitFormChange, size: formGroupSize, color, id, name, highlight, disabled, ariaAttrs } = useFormField<InputProps>(props)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
This PR fixes a virtualization bug when using `item-description` slot with SelectMenu. No existing issue was filed as the bug was discovered and fixed directly.

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

**Problem:**
When using the `item-description` slot with `virtualize` enabled in SelectMenu, items overlap and scrolling breaks due to incorrect height estimation.

**Visual Evidence:**

**Before (Broken):**
<img width="344" height="469" alt="image" src="https://github.com/user-attachments/assets/a988936b-77a8-4df7-a92a-353d603f3979" />
*Items overlap because virtualizer estimates 32px height but actual rendered height is 52px with descriptions*

**After (Fixed):**
<img width="335" height="477" alt="image" src="https://github.com/user-attachments/assets/4def1890-9ff6-49c4-a7f6-6d57d83e6806" />
*Items render correctly with proper 52px spacing when descriptions are present*

**Reproduction:**

```vue
<script setup lang="ts">
import type { SelectMenuItem } from '@nuxt/ui'

const items: SelectMenuItem[] = Array(1000)
  .fill(0)
  .map((_, i) => ({
    label: `item-${i}`,
    value: i
  }))
</script>

<template>
  <USelectMenu
    :items="items"
    virtualize
    class="w-48"
  >
    <template #item-description="{ item }">
      Custom description for {{ item.label }}
    </template>
  </USelectMenu>
</template>
```

**Root Cause**:

The original `virtualizerProps` used a fixed `estimateSize` of 24-40px (based on size) for all items, regardless of whether they had descriptions:
```ts
// Before- always used small sizes
const virtualizerProps = toRef(() => !!props.virtualize && defu(typeof props.virtualize === 'boolean' ? {} : props.virtualize, {
  estimateSize: ({
    xs: 24,
    sm: 28,
    md: 32,
    lg: 36,
    xl: 40
  })[props.size || 'md']
}))
```
However, the template renders descriptions when either data exists OR the slot is used:
```vue
<span v-if="isSelectItem(item) && (get(item, props.descriptionKey as string) || !!slots['item-description'])">
  <slot name="item-description" :item="item" :index="index">
    {{ get(item, props.descriptionKey as string) }}
  </slot>
</span>
```
This mismatch caused the virtualizer to estimate 32px heights even when descriptions were being rendered (requiring 52px), resulting in overlapping items and broken scrolling.

**Solution:**

The fix detects whether any item will have a description rendered (either from data OR from the slot) and adjusts the `estimateSize` accordingly (look at code diff)

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.