### PR TITLE
feat(FileUpload): add directUpdate option to skip upload preview

### DIFF
--- a/src/runtime/components/FileUpload.vue
+++ b/src/runtime/components/FileUpload.vue
@@ -72,6 +72,11 @@ export interface FileUploadProps<M extends boolean = false> {
    * @defaultValue true
    */
   interactive?: boolean
+  /**
+   * Skip preview and directly emit update event.
+   * @defaultValue false
+   */
+  directUpdate?: boolean
   required?: boolean
   disabled?: boolean
   /**
@@ -144,6 +149,7 @@ const props = withDefaults(defineProps<FileUploadProps<M>>(), {
   dropzone: true,
   interactive: true,
   fileDelete: true,
+  directUpdate: false,
   layout: 'grid',
   position: 'outside'
 })
@@ -213,6 +219,14 @@ function formatFileSize(bytes: number): string {
 }
 
 function onUpdate(files: File[], reset = false) {
+  // @ts-expect-error - 'target' does not exist in type 'EventInit'
+  let event = new Event('change', { target: { value: files } })
+
+  if (props.directUpdate) {
+    emits('change', event)
+    return
+  }
+
   if (props.multiple) {
     if (reset) {
       modelValue.value = files as (M extends true ? File[] : File) | null
@@ -225,7 +239,7 @@ function onUpdate(files: File[], reset = false) {
   }
 
   // @ts-expect-error - 'target' does not exist in type 'EventInit'
-  const event = new Event('change', { target: { value: modelValue.value } })
+  event = new Event('change', { target: { value: modelValue.value } })
   emits('change', event)
   emitFormChange()
   emitFormInput()


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
Resolves #5367

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
In some cases, we would like to skip the preview step and simply emit the change event. For example, in a Google Drive-like environment, the file should be uploaded immediately upon drop, removing the need for an explicit submission of the queue or a preview.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
