### PR TITLE
fix(inertia): set serverRendered dynamically to prevent SSR crash

### DIFF
--- a/src/runtime/inertia/stubs.ts
+++ b/src/runtime/inertia/stubs.ts
@@ -78,7 +78,7 @@ const hooks = createHooks()
 export function useNuxtApp() {
   return {
     isHydrating: true,
-    payload: { serverRendered: false },
+    payload: { serverRendered: typeof window === 'undefined' },
     hooks,
     hook: hooks.hook
   }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #5254

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
The Inertia stub currently hardcodes the payload.serverRendered value to false. This causes the application to crash during Server-Side Rendering (SSR). This change replaces the hardcoded value with a dynamic check (typeof window === "undefined") to accurately determine if the code is running on the server.
<!-- Why is this change required? What problem does it solve? -->
This solve SSR crashing with `ReferenceError: document is not defined`

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
