### PR TITLE
fix(AuthForm): ensure header is shown with `leading` slot

### DIFF
--- a/src/runtime/components/AuthForm.vue
+++ b/src/runtime/components/AuthForm.vue
@@ -187,7 +187,7 @@ defineExpose({
 
 <template>
   <Primitive :as="as" :class="ui.root({ class: [props.ui?.root, props.class] })">
-    <div v-if="(icon || !!slots.icon) || (title || !!slots.title) || (description || !!slots.description) || !!slots.header || !!slots.leading" :class="ui.header({ class: props.ui?.header })">
+    <div v-if="(icon || !!slots.leading) || (title || !!slots.title) || (description || !!slots.description) || !!slots.header" :class="ui.header({ class: props.ui?.header })">
       <slot name="header">
         <div v-if="icon || !!slots.leading" :class="ui.leading({ class: props.ui?.leading })">
           <slot name="leading" :ui="ui">

--- a/src/runtime/components/AuthForm.vue
+++ b/src/runtime/components/AuthForm.vue
@@ -187,7 +187,7 @@ defineExpose({
 
 <template>
   <Primitive :as="as" :class="ui.root({ class: [props.ui?.root, props.class] })">
-    <div v-if="(icon || !!slots.icon) || (title || !!slots.title) || (description || !!slots.description) || !!slots.header" :class="ui.header({ class: props.ui?.header })">
+    <div v-if="(icon || !!slots.icon) || (title || !!slots.title) || (description || !!slots.description) || !!slots.header || !!slots.leading" :class="ui.header({ class: props.ui?.header })">
       <slot name="header">
         <div v-if="icon || !!slots.leading" :class="ui.leading({ class: props.ui?.leading })">
           <slot name="leading" :ui="ui">

--- a/test/components/__snapshots__/AuthForm-vue.spec.ts.snap
+++ b/test/components/__snapshots__/AuthForm-vue.spec.ts.snap
@@ -428,7 +428,11 @@ exports[`AuthForm > renders with icon correctly 1`] = `
 
 exports[`AuthForm > renders with leading slot correctly 1`] = `
 "<div class="w-full space-y-6">
-  <!--v-if-->
+  <div class="flex flex-col text-center">
+    <div class="mb-2">Leading</div>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
   <div class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->

--- a/test/components/__snapshots__/AuthForm.spec.ts.snap
+++ b/test/components/__snapshots__/AuthForm.spec.ts.snap
@@ -446,7 +446,11 @@ exports[`AuthForm > renders with icon correctly 1`] = `
 
 exports[`AuthForm > renders with leading slot correctly 1`] = `
 "<div class="w-full space-y-6">
-  <!--v-if-->
+  <div class="flex flex-col text-center">
+    <div class="mb-2">Leading</div>
+    <!--v-if-->
+    <!--v-if-->
+  </div>
   <div class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #5404

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Added a new condition to show the leading slot if not title or no desc or no icon or no heading prop

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
