### PR TITLE
docs(getting-started/installation): fix init command for ui template

### DIFF
--- a/docs/content/docs/1.getting-started/2.installation/1.nuxt.md
+++ b/docs/content/docs/1.getting-started/2.installation/1.nuxt.md
@@ -112,7 +112,7 @@ The `App` component provides global configurations and is required for **Toast**
 To quickly get started with Nuxt UI, you can use the [starter template](https://github.com/nuxt-ui-templates/starter) by running:
 
 ```bash [Terminal]
-npm create nuxt@latest -- -t ui
+npm create nuxt@latest <project-name> -- -t ui
 ```
 
 You can also get started with one of our [official templates](/templates):


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The command currently displayed is not working; you need to include the project name before the parameters, otherwise it creates a project named "-t" instead of using the correct template.

### 📝 Checklist

- [ x] I have updated the documentation accordingly.
