### PR TITLE
docs(locale-select): use `model-value` instead of `v-model` in examples

### DIFF
--- a/docs/content/docs/2.components/locale-select.md
+++ b/docs/content/docs/2.components/locale-select.md
@@ -52,7 +52,7 @@ const locale = ref('en')
 </script>
 
 <template>
-  <ULocaleSelect v-model="locale" :locales="[en, es, fr]" />
+  <ULocaleSelect :model-value="locale" :locales="[en, es, fr]" />
 </template>
 ```
 
@@ -72,7 +72,7 @@ const { locale, setLocale } = useI18n()
 
 <template>
   <ULocaleSelect
-    v-model="locale"
+    :model-value="locale"
     :locales="Object.values(locales)"
     @update:model-value="setLocale($event)"
   />
@@ -95,7 +95,7 @@ const { locale, setLocale } = useI18n()
 
 <template>
   <ULocaleSelect
-    v-model="locale"
+    :model-value="locale"
     :locales="Object.values(locales)"
     @update:model-value="setLocale($event)"
   />

--- a/docs/content/docs/2.components/locale-select.md
+++ b/docs/content/docs/2.components/locale-select.md
@@ -52,7 +52,7 @@ const locale = ref('en')
 </script>
 
 <template>
-  <ULocaleSelect :model-value="locale" :locales="[en, es, fr]" />
+  <ULocaleSelect v-model="locale" :locales="[en, es, fr]" />
 </template>
 ```
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #5021 

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

the `v-model` in LocaleSelect is broken and doesn't update the local entirely, weirdly enough using `:model-value` is updating correctly. So either fix the v-model issue or let users know that it works with `:model-value` to prevent further confusion from users

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
