### PR TITLE
docs(mcp): add nuxt ui agent as a mcp tool

### DIFF
--- a/docs/content/docs/1.getting-started/7.ai/1.mcp.md
+++ b/docs/content/docs/1.getting-started/7.ai/1.mcp.md
@@ -54,6 +54,14 @@ The Nuxt UI MCP server provides the following tools organized by category:
 
 - **`get_migration_guide`**: Retrieves version-specific migration guides and upgrade instructions
 
+### Assistant Tools
+
+- **`ask_nuxt_ui_agent`**: Ask the Nuxt UI assistant for a concise direct answer (returns only the final content, no intermediate steps).
+
+::note{icon="i-lucide-info"}
+Disabled when using the Agent from the Nuxt UI website.
+::
+
 ## Available Prompts
 
 The Nuxt UI MCP server provides guided prompts for common workflows:

--- a/docs/server/api/search.ts
+++ b/docs/server/api/search.ts
@@ -40,14 +40,14 @@ Guidelines:
 - Format responses in a conversational way, not as documentation sections.
     `,
     messages: convertToModelMessages(messages),
-    stopWhen: stepCountIs(6),
+    stopWhen: stepCountIs(6)
   }
 
   // If not streaming, it's called from the MCP route as a tool.
   if (stream === false) {
     const { text } = await generateText({
       ...options,
-      tools,
+      tools
     })
 
     await httpClient.close()
@@ -55,7 +55,7 @@ Guidelines:
     return text
   }
 
-    // Remove the ask_nuxt_ui_agent tool to avoid infinite loops
+  // Remove the ask_nuxt_ui_agent tool to avoid infinite loops
   delete tools['ask_nuxt_ui_agent']
 
   return streamText({

--- a/docs/server/api/search.ts
+++ b/docs/server/api/search.ts
@@ -14,6 +14,9 @@ export default defineEventHandler(async (event) => {
   })
   const tools = await httpClient.tools()
 
+  // Remove the ask_nuxt_ui_agent tool to avoid infinite loops
+  delete tools['ask_nuxt_ui_agent']
+
   const options = {
     model: gateway('anthropic/claude-sonnet-4.5'),
     maxOutputTokens: 10_000,
@@ -54,9 +57,6 @@ Guidelines:
 
     return text
   }
-
-  // Remove the ask_nuxt_ui_agent tool to avoid infinite loops
-  delete tools['ask_nuxt_ui_agent']
 
   return streamText({
     ...options,

--- a/docs/server/api/search.ts
+++ b/docs/server/api/search.ts
@@ -1,10 +1,10 @@
 import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js'
-import { streamText, convertToModelMessages, stepCountIs } from 'ai'
+import { streamText, convertToModelMessages, stepCountIs, generateText } from 'ai'
 import { experimental_createMCPClient } from '@ai-sdk/mcp'
 import { gateway } from '@ai-sdk/gateway'
 
 export default defineEventHandler(async (event) => {
-  const { messages } = await readBody(event)
+  const { messages, stream = true } = await readBody(event)
 
   const httpTransport = new StreamableHTTPClientTransport(
     new URL(import.meta.dev ? 'http://localhost:3000/mcp' : 'https://ui.nuxt.com/mcp')
@@ -14,9 +14,9 @@ export default defineEventHandler(async (event) => {
   })
   const tools = await httpClient.tools()
 
-  return streamText({
+  const options = {
     model: gateway('anthropic/claude-sonnet-4.5'),
-    maxOutputTokens: 10000,
+    maxOutputTokens: 10_000,
     system: `You are a helpful assistant for Nuxt UI, a UI library for Nuxt and Vue. Use your knowledge base tools to search for relevant information before answering questions.
 
 Guidelines:
@@ -41,6 +41,25 @@ Guidelines:
     `,
     messages: convertToModelMessages(messages),
     stopWhen: stepCountIs(6),
+  }
+
+  // If not streaming, it's called from the MCP route as a tool.
+  if (stream === false) {
+    const { text } = await generateText({
+      ...options,
+      tools,
+    })
+
+    await httpClient.close()
+
+    return text
+  }
+
+    // Remove the ask_nuxt_ui_agent tool to avoid infinite loops
+  delete tools['ask_nuxt_ui_agent']
+
+  return streamText({
+    ...options,
     tools,
     onFinish: async () => {
       await httpClient.close()

--- a/docs/server/routes/mcp.ts
+++ b/docs/server/routes/mcp.ts
@@ -5,6 +5,7 @@
 import { z } from 'zod/v3'
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js'
 import { StreamableHTTPServerTransport } from '@modelcontextprotocol/sdk/server/streamableHttp.js'
+import type { UIMessage } from 'ai'
 
 function createServer() {
   const server = new McpServer({
@@ -409,6 +410,36 @@ function createServer() {
       const result = await $fetch('/api/mcp/search-components-by-category', { query: params })
       return {
         content: [{ type: 'text' as const, text: JSON.stringify(result, null, 2) }]
+      }
+    }
+  )
+
+  server.registerTool(
+    'ask_nuxt_ui_agent',
+    {
+      title: 'Ask Nuxt UI Agent',
+      description: 'Asks the Nuxt UI agent a question',
+      inputSchema: {
+        // @ts-expect-error - need to wait for support for zod 4, this works correctly just a type mismatch from zod 3 to zod 4 (https://github.com/modelcontextprotocol/typescript-sdk/pull/869)
+        query: z.string().describe('The question to ask the agent')
+      }
+    },
+    async (params: { query: string }) => {
+      const result = await $fetch<string>('/api/search', {
+        method: 'POST',
+        timeout: 60_000,
+        body: {
+          stream: false,
+          messages: [{
+            role: 'user',
+            parts: [{ type: 'text', text: params.query }]
+          }] satisfies Array<Omit<UIMessage, 'id'>> }
+      })
+
+      console.log(result)
+
+      return {
+        content: [{ type: 'text' as const, text: result }]
       }
     }
   )


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Heyyyy 👋,

This introduce the Nuxt UI Agent as a MCP tool.

When asking an Agent a query like "How to install Nuxt UI in a Vue project", it will list all pages and then read the installation page. This will completely fill the context with a lot of useless content. By using an Agent as a tool, the main Agent will query the second (Nuxt UI Agent) with the user query (or an improved version) and then returned only the useful content.

At the end, I'm sure that most of the tool could be disabled (from a end-user point of view) except the Ask Nuxt UI Agent.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
