### PR TITLE
fix(module): put back `#build/ui.css` alias

### DIFF
--- a/package.json
+++ b/package.json
@@ -96,6 +96,7 @@
   "style": "./dist/runtime/index.css",
   "main": "./dist/module.mjs",
   "files": [
+    ".nuxt/ui.css",
     "dist",
     "cli",
     "vue-plugin.d.ts"

--- a/package.json
+++ b/package.json
@@ -87,6 +87,9 @@
       ]
     }
   },
+  "imports": {
+    "#build/ui.css": "./.nuxt/ui.css"
+  },
   "bin": {
     "nuxt-ui": "./cli/index.mjs"
   },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
Resolves #5487, resolves #5501

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

When Prettier or Tailwind CSS IntelliSense reads a CSS file that imports `@nuxt/ui`, they fail to resolve the `#build/ui.css` import from [`src/runtime/index.css`](https://github.com/nuxt/ui/blob/v4/src/runtime/index.css#L1).

This virtual file is dynamically generated for [Nuxt](https://github.com/nuxt/ui/blob/v4/src/templates.ts#L171) and [Vite](https://github.com/nuxt/ui/blob/v4/src/plugins/templates.ts#L37-L45) based on theme configuration, but Prettier and IntelliSense don't have access to Vite's alias resolution.

This PR adds a static alias using Node.js [subpath imports](https://nodejs.org/api/packages.html#subpath-imports) so tooling can resolve it via standard module resolution.

Runtime (Nuxt/Vite) continues using dynamic resolution, while tooling uses the static fallback. The static file is built at package publish time with default theme configuration, so custom themes won't be reflected in IntelliSense. It's not perfect but better than nothing for now.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
