### PR TITLE
test(FileUpload): add `aria-label` to axe test case

### DIFF
--- a/test/components/FileUpload.spec.ts
+++ b/test/components/FileUpload.spec.ts
@@ -98,23 +98,13 @@ describe('FileUpload', () => {
         label: 'Upload files',
         description: 'Select files to upload',
         required: true
+      },
+      attrs: {
+        'aria-label': 'Choose a file'
       }
     })
 
-    expect(await axe(wrapper.element, {
-      rules: {
-        // "Form elements must have labels (label)"
-        // Fix any of the following:
-        //  Element does not have an implicit (wrapped) <label>
-        //  Element does not have an explicit <label>
-        //  aria-label attribute does not exist or is empty
-        //  aria-labelledby attribute does not exist, references elements that do not exist or references elements that are empty
-        //  Element has no title attribute
-        //  Element has no placeholder attribute
-        //  Element's default semantics were not overridden with role="none" or role="presentation"
-        label: { enabled: false }
-      }
-    })).toHaveNoViolations()
+    expect(await axe(wrapper.element)).toHaveNoViolations()
   })
 
   describe('emits', () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
The user has control over this label, no reason to disable the rule inside the test.
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
