### PR TITLE
fix: !important on display property

### DIFF
--- a/src/runtime/components/color-mode/ColorModeButton.vue
+++ b/src/runtime/components/color-mode/ColorModeButton.vue
@@ -55,8 +55,8 @@ const isDark = computed({
     @click="isDark = !isDark"
   >
     <template #leading="{ ui }">
-      <UIcon :class="ui.leadingIcon({ class: props.ui?.leadingIcon })" class="hidden dark:inline" :name="appConfig.ui.icons.dark" />
-      <UIcon :class="ui.leadingIcon({ class: props.ui?.leadingIcon })" class="inline dark:hidden" :name="appConfig.ui.icons.light" />
+      <UIcon :class="ui.leadingIcon({ class: props.ui?.leadingIcon })" class="hidden! dark:inline!" :name="appConfig.ui.icons.dark" />
+      <UIcon :class="ui.leadingIcon({ class: props.ui?.leadingIcon })" class="inline! dark:hidden!" :name="appConfig.ui.icons.light" />
     </template>
   </UButton>
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #5492 

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

without the important, the property display is overrided by `:where(.i-lucide\:sun)` property and `:where(.i-lucide\:moon)` property

before:
<img width="81" height="44" alt="image" src="https://github.com/user-attachments/assets/c7c59048-8e91-4132-9fce-48f02d3e1b53" />

after (as expected):

<img width="67" height="44" alt="image" src="https://github.com/user-attachments/assets/66efa6db-a571-4058-9a60-17a53eab4e0f" />


### 📝 Checklist

- [x] I have linked an issue or discussion.
