### PR TITLE
fix(form): propagate dirty and touched fields to parent form

### DIFF
--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -162,6 +162,11 @@ onMounted(async () => {
     if (event.type === 'change' || event.type === 'input') {
       dirtyFields.add(event.name)
     }
+
+    // Propagate dirty and touched fields to parent form
+    if ((event.type === 'change' || event.type === 'input' || event.type === 'focus' || event.type === 'blur') && parentBus) {
+      parentBus.emit(event)
+    }
   })
 })
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #5144

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
If current form component has a parent form, emit `'input'`, `'change'`, `'focus'` or `'blur'` via the parent form event bus.
<!-- Why is this change required? What problem does it solve? -->
Prior to this change, `dirtyFields` and `touchedFields` didn't take into account `nestedForms`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
