### PR TITLE
fix(Table): respect `enableRowSelection` in `data-selectable` attribute

### DIFF
--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -520,7 +520,7 @@ defineExpose({
   <DefineRowTemplate v-slot="{ row, style }">
     <tr
       :data-selected="row.getIsSelected()"
-      :data-selectable="!!props.onSelect || !!props.onHover || !!props.onContextmenu"
+      :data-selectable="!!props.rowSelectionOptions?.enableRowSelection ? row.getCanSelect() : !!props.onSelect || !!props.onHover || !!props.onContextmenu"
       :data-expanded="row.getIsExpanded()"
       :role="props.onSelect ? 'button' : undefined"
       :tabindex="props.onSelect ? 0 : undefined"

--- a/test/components/Table.spec.ts
+++ b/test/components/Table.spec.ts
@@ -245,4 +245,64 @@ describe('Table', () => {
 
     expect(wrapper.find('[data-test-th="amount"]').exists()).toBeTruthy()
   })
+
+  it('data-selectable attribute with rowSelectionOptions.enableRowSelection', async () => {
+    const testData = [
+      { id: '1', amount: 100, status: 'success', email: 'test1@test.com', canSelect: true },
+      { id: '2', amount: 200, status: 'failed', email: 'test2@test.com', canSelect: false },
+      { id: '3', amount: 300, status: 'success', email: 'test3@test.com', canSelect: true }
+    ]
+
+    const wrapper = await mountSuspended(Table, {
+      props: {
+        data: testData,
+        columns: [{
+          accessorKey: 'id'
+        }],
+        rowSelectionOptions: {
+          enableRowSelection: (row: TableRow<typeof testData[number]>) => row.original.canSelect
+        }
+      }
+    })
+
+    await flushPromises()
+
+    const rows = wrapper.findAll('tbody tr')
+    expect(rows).toHaveLength(3)
+
+    expect(rows[0]?.attributes('data-selectable')).toBe('true')
+    expect(rows[1]?.attributes('data-selectable')).toBe('false')
+    expect(rows[2]?.attributes('data-selectable')).toBe('true')
+  })
+
+  it('data-selectable attribute fallback behavior', async () => {
+    const wrapperWithOnSelect = await mountSuspended(Table, {
+      props: {
+        data,
+        columns: [{
+          accessorKey: 'id'
+        }],
+        onSelect: () => {}
+      }
+    })
+
+    await flushPromises()
+
+    const rowsWithOnSelect = wrapperWithOnSelect.findAll('tbody tr')
+    expect(rowsWithOnSelect[0]?.attributes('data-selectable')).toBe('true')
+
+    const wrapperWithoutHandlers = await mountSuspended(Table, {
+      props: {
+        data,
+        columns: [{
+          accessorKey: 'id'
+        }]
+      }
+    })
+
+    await flushPromises()
+
+    const rowsWithoutHandlers = wrapperWithoutHandlers.findAll('tbody tr')
+    expect(rowsWithoutHandlers[0]?.attributes('data-selectable')).toBe('false')
+  })
 })

--- a/test/components/Table.spec.ts
+++ b/test/components/Table.spec.ts
@@ -260,7 +260,7 @@ describe('Table', () => {
           accessorKey: 'id'
         }],
         rowSelectionOptions: {
-          enableRowSelection: (row: TableRow<typeof testData[number]>) => row.original.canSelect
+          enableRowSelection: (row: any) => row.original.canSelect
         }
       }
     })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves [#4968](https://github.com/nuxt/ui/issues/4968)

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `data-selectable` attribute on table rows was not respecting the `rowSelectionOptions.enableRowSelection` option. When `enableRowSelection` is defined (e.g., to
  conditionally disable selection on certain rows), the attribute should reflect whether each individual row can be selected via `row.getCanSelect()`.

**Before:** `data-selectable` only checked for `onSelect`, `onHover`, or `onContextmenu` props
**After:** `data-selectable` first checks if `enableRowSelection` is defined, and if so, uses `row.getCanSelect()`, otherwise falls back to the original behavior

This fix ensures that rows with disabled selection get `data-selectable="false"`.

**Testing:** added tests 'data-selectable attribute with rowSelectionOptions.enableRowSelection' and 'data-selectable attribute fallback behavior' to test that the new behavior and old behavior work correctly.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
