### PR TITLE
feat(extractShortcuts): add `separator` option

### DIFF
--- a/docs/content/docs/3.composables/extract-shortcuts.md
+++ b/docs/content/docs/3.composables/extract-shortcuts.md
@@ -5,7 +5,7 @@ description: 'A utility to extract keyboard shortcuts from menu items.'
 
 ## Usage
 
-Use the auto-imported `extractShortcuts` utility to automatically define keyboard shortcuts from menu items.
+Use the auto-imported `extractShortcuts` utility to define keyboard shortcuts from menu items. It extracts shortcuts from components like [DropdownMenu](/docs/components/dropdown-menu), [ContextMenu](/docs/components/context-menu) or [CommandPalette](/docs/components/command-palette) where items have `kbds` defined.
 
 ```vue
 <script setup lang="ts">
@@ -29,15 +29,13 @@ defineShortcuts(extractShortcuts(items))
 </script>
 ```
 
-This is particularly useful when working with components like [DropdownMenu](/docs/components/dropdown-menu), [ContextMenu](/docs/components/context-menu), or [CommandPalette](/docs/components/command-palette) where menu items already define their keyboard shortcuts.
-
 ::tip{to="/docs/composables/define-shortcuts"}
 Learn more about keyboard shortcuts in the **defineShortcuts** composable documentation.
 ::
 
 ## API
 
-`extractShortcuts(items: any[] | any[][]): ShortcutsConfig`{lang="ts-type"}
+`extractShortcuts(items: any[] | any[][], separator?: '_' | '-'): ShortcutsConfig`{lang="ts-type"}
 
 Extracts keyboard shortcuts from an array of menu items and returns a configuration object compatible with `defineShortcuts`.
 
@@ -71,13 +69,19 @@ Extracts keyboard shortcuts from an array of menu items and returns a configurat
     ::
   ::
   ::
+
+  ::field{name="separator" type="'_' | '-'"}
+  The separator used to join keyboard keys. Use `'_'` for key combinations (e.g., `meta_k`) or `'-'` for key sequences (e.g., `g-d`). Defaults to `'_'`.
+  ::
 ::
 
 **Returns:** A `ShortcutsConfig` object that can be passed directly to `defineShortcuts`.
 
-## Example
+## Examples
 
-You can use the `extractShortcuts` utility to extract shortcuts from a [DropdownMenu](/docs/components/dropdown-menu), [ContextMenu](/docs/components/context-menu), [CommandPalette](/docs/components/command-palette), etc. The utility recursively traverses `children` and `items` properties to extract shortcuts from nested menu structures.
+### With nested items
+
+The utility recursively traverses `children` and `items` properties to extract shortcuts from nested menu structures.
 
 ```vue
 <script setup lang="ts">
@@ -132,4 +136,29 @@ defineShortcuts(extractShortcuts(items))
     <UButton label="Actions" />
   </UDropdownMenu>
 </template>
+```
+
+### With key sequences
+
+Use the `separator` parameter to create key sequences instead of key combinations.
+
+```vue
+<script setup lang="ts">
+const items = [{
+  label: 'Go to Dashboard',
+  kbds: ['G', 'D'],
+  onSelect() {
+    navigateTo('/dashboard')
+  }
+}, {
+  label: 'Go to Settings',
+  kbds: ['G', 'S'],
+  onSelect() {
+    navigateTo('/settings')
+  }
+}]
+
+// Using '-' creates key sequences: 'g-d', 'g-s'
+defineShortcuts(extractShortcuts(items, '-'))
+</script>
 ```

--- a/src/runtime/composables/defineShortcuts.ts
+++ b/src/runtime/composables/defineShortcuts.ts
@@ -70,13 +70,13 @@ function convertKeyToCode(key: string): string {
   return specialKeys[key.toLowerCase()] || key
 }
 
-export function extractShortcuts(items: any[] | any[][]) {
+export function extractShortcuts(items: any[] | any[][], separator: '_' | '-' = '_') {
   const shortcuts: Record<string, Handler> = {}
 
   function traverse(items: any[]) {
     items.forEach((item) => {
       if (item.kbds?.length && (item.onSelect || item.onClick)) {
-        const shortcutKey = item.kbds.join('_')
+        const shortcutKey = item.kbds.join(separator)
         shortcuts[shortcutKey] = item.onSelect || item.onClick
       }
       if (item.children) {


### PR DESCRIPTION
### 🔗 Linked issue

None.

### ❓ Type of change


- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This feature allows users to specify the desired shortcut key separator.
Previously, only an underscore (`_`) was used. That is, the `extractShortcuts` utility has always been creating _key combinations_.
Now, it can also create _key sequences_ if users pass a dash (`-`) as a separator.

### 📝 Checklist

I think this PR doesn't require the checklist to be completed.

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
