### PR TITLE
docs(migration): update changed components

### DIFF
--- a/docs/content/docs/1.getting-started/3.migration/2.v3.md
+++ b/docs/content/docs/1.getting-started/3.migration/2.v3.md
@@ -374,6 +374,31 @@ This change affects the following components: `Modal`, `Popover`, `Slideover`, `
 This change affects the following components: `Modal`, `Slideover`.
 ::
 
+- The `prevent-close` prop in `Modal` and `Slideover` has been removed in favor of the `dismissible` prop that takes a boolean value:
+```diff
+<template>
+- <UModal prevent-close />
++ <UModal :dismissible="false" />
+</template>
+```
+
+- The `v-model` directive in `Pagination` has been renamed to `v-model:page` to control current page:
+
+```diff
+<template>
+- <UPagination v-model="page" />
++ <UPagination v-model:page="page" />
+</template>
+```
+
+- The `change` event in `Select`, `SelectMenu` and `RadioGroup` now emits the native `change` event, not the new chnage value, which is now emitted in the `update:modelValue` event:
+
+```diff
+<template></template>
+- <USelectMenu v-model="country" :items="countries" @change="console.log(newVal)" />
++ <USelectMenu v-model="country" :items="countries" @update:modelValue="console.log(newVal)" />
+```
+
 ### Changed composables
 
 - The `useToast()` composable `timeout` prop has been renamed to `duration`:


### PR DESCRIPTION
Updated the migration page by adding some of the changes that I noticed and are not documented

Note: Same is applied on v3 branch: https://github.com/nuxt/ui/pull/5655

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Documented the removal of `prevent-close` and the new `dismissible` prop for `UModal` and `USlideover`.
- Added notes about the `v-model` change in `UPagination` (`v-model:page` instead of `v-model`).
- Updated documentation for `USelect`, `USelectMenu`, and `URadioGroup` regarding the new change event behavior and the shift to using `update:model-value` for receiving the selected value.

### 📝 Checklist
- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.