### PR TITLE
docs(mcp): add setup instructions for claude desktop

### DIFF
--- a/docs/content/docs/1.getting-started/7.ai/1.mcp.md
+++ b/docs/content/docs/1.getting-started/7.ai/1.mcp.md
@@ -102,6 +102,30 @@ Add the server using the CLI command:
 claude mcp add --transport http nuxt-ui-remote https://ui.nuxt.com/mcp
 ```
 
+### Claude Desktop
+
+#### Setup Instructions:
+
+1. Open Claude Desktop and navigate to "Settings" > "Developer".
+2. Click on "Edit Config". This will open the local Claude directory.
+3. Modify the `claude_desktop_config.json` file with your custom MCP server configuration.
+
+```json [claude_desktop_config.json]
+{
+  "mcpServers": {
+    "nuxt-ui": {
+      "command": "npx",
+      "args": [
+        "mcp-remote",
+        "https://ui.nuxt.com/mcp"
+      ]
+    }
+  }
+}
+```
+
+4. Restart Claude Desktop app. The Nuxt UI MCP server should now be registered.
+
 ### Cursor
 
 #### Quick Install


### PR DESCRIPTION
### 🔗 Linked issue

This PR doesn't resolve any particular issue. It's a small documentation improvement.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The Nuxt UI MCP server configuration guides don't currently include instructions for Claude Desktop. This PR adds setup instructions for it.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
