### PR TITLE
docs(installation): resolve missing theme prop types in vue

### DIFF
--- a/docs/content/docs/1.getting-started/2.installation/2.vue.md
+++ b/docs/content/docs/1.getting-started/2.installation/2.vue.md
@@ -133,13 +133,22 @@ components.d.ts
 ::tip
 Internally, Nuxt UI relies on custom alias to resolve the theme types. If you're using TypeScript, you should add an alias to your `tsconfig` to enable auto-completion in your `vite.config.ts`.
 
-```json [tsconfig.app.json]
+```json [tsconfig.node.json]
 {
   "compilerOptions": {
     "paths": {
       "#build/ui": [
         "./node_modules/.nuxt-ui/ui"
-      ],
+      ]
+    }
+  }
+}
+```
+
+```json [tsconfig.app.json]
+{
+  "compilerOptions": {
+    "paths": {
       "#build/ui/*": [
         "./node_modules/.nuxt-ui/ui/*"
       ]

--- a/docs/content/docs/1.getting-started/2.installation/2.vue.md
+++ b/docs/content/docs/1.getting-started/2.installation/2.vue.md
@@ -133,7 +133,7 @@ components.d.ts
 ::tip
 Internally, Nuxt UI relies on custom alias to resolve the theme types. If you're using TypeScript, you should add an alias to your `tsconfig` to enable auto-completion in your `vite.config.ts`.
 
-```json [tsconfig.node.json]
+```json [tsconfig.app.json]
 {
   "compilerOptions": {
     "paths": {

--- a/docs/content/docs/1.getting-started/2.installation/2.vue.md
+++ b/docs/content/docs/1.getting-started/2.installation/2.vue.md
@@ -139,6 +139,9 @@ Internally, Nuxt UI relies on custom alias to resolve the theme types. If you're
     "paths": {
       "#build/ui": [
         "./node_modules/.nuxt-ui/ui"
+      ],
+      "#build/ui/*": [
+        "./node_modules/.nuxt-ui/ui/*"
       ]
     }
   }


### PR DESCRIPTION
### 🔗 Linked issue

This PR does not modify any program content; it mainly addresses the TypeScript suggestions issue.

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

[Minimal Reproduction](https://github.com/Codfisher/Nuxt-UI-theme-props-issue)

In Vite + Vue projects, type definitions for theme-related props are currently missing. Following the official documentation setup results in incomplete type hints (specifically missing theme content).

<img width="716" height="185" alt="image" src="https://github.com/user-attachments/assets/f8624a4f-8f25-4ec0-80eb-8ab3a3a740f4" />

After investigation, I identified that this is caused by missing paths in the `tsconfig.json`.

By adding `#build/ui/*` to the `compilerOptions.paths`, the issue is resolved and types are correctly inferred.

```json
{
  "compilerOptions": {
    "paths": {
      "#build/ui": [
        "./node_modules/.nuxt-ui/ui"
      ],
      "#build/ui/*": [
        "./node_modules/.nuxt-ui/ui/*"
      ]
    }
  }
}
```
<img width="983" height="310" alt="image" src="https://github.com/user-attachments/assets/979c406d-6652-4738-ba2d-69d2a047fa30" />

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
