### PR TITLE
fix(defineShortcuts): improve chained shortcuts and add test coverage

### DIFF
--- a/src/runtime/composables/defineShortcuts.ts
+++ b/src/runtime/composables/defineShortcuts.ts
@@ -125,7 +125,7 @@ export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: Shor
 
     // push either code or key depending on layoutIndependent flag
     chainedInputs.value.push(layoutIndependent ? e.code : e.key)
-    
+
     // try matching a chained shortcut
     if (chainedInputs.value.length >= 2) {
       chainedKey = chainedInputs.value.slice(-2).join('-')

--- a/src/runtime/composables/defineShortcuts.ts
+++ b/src/runtime/composables/defineShortcuts.ts
@@ -95,6 +95,9 @@ export function extractShortcuts(items: any[] | any[][], separator: '_' | '-' = 
 
 export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: ShortcutsOptions = {}) {
   const chainedInputs = ref<string[]>([])
+  const pendingShortcut = ref<Shortcut | null>(null)
+  let pendingTimer: ReturnType<typeof setTimeout> | null = null
+
   const clearChainedInput = () => {
     chainedInputs.value.splice(0, chainedInputs.value.length)
   }
@@ -113,23 +116,31 @@ export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: Shor
       return
     }
 
+    const keyValue = layoutIndependent ? e.code : e.key.toLowerCase()
+
     const alphabetKey = layoutIndependent ? /^Key[A-Z]$/i.test(e.code) : /^[a-z]{1}$/i.test(e.key)
     const shiftableKey = layoutIndependent ? shiftableCodes.includes(e.code) : shiftableKeys.includes(e.key.toLowerCase())
 
     let chainedKey
+
     // push either code or key depending on layoutIndependent flag
     chainedInputs.value.push(layoutIndependent ? e.code : e.key)
+    
     // try matching a chained shortcut
     if (chainedInputs.value.length >= 2) {
       chainedKey = chainedInputs.value.slice(-2).join('-')
 
       for (const shortcut of shortcuts.value.filter(s => s.chained)) {
-        if (shortcut.key !== chainedKey) {
-          continue
-        }
+        if (shortcut.key !== chainedKey) continue
 
         if (shortcut.enabled) {
           e.preventDefault()
+          // Cancel any pending single-key shortcut
+          if (pendingTimer) {
+            clearTimeout(pendingTimer)
+            pendingTimer = null
+            pendingShortcut.value = null
+          }
           shortcut.handler(e)
         }
         clearChainedInput()
@@ -139,34 +150,34 @@ export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: Shor
 
     // try matching a standard shortcut
     for (const shortcut of shortcuts.value.filter(s => !s.chained)) {
-      if (layoutIndependent) {
-        // compare by code
-        if (e.code !== shortcut.key) {
-          continue
-        }
-      } else {
-        if (e.key.toLowerCase() !== shortcut.key) {
-          continue
-        }
+      if (layoutIndependent ? e.code !== shortcut.key : e.key.toLowerCase() !== shortcut.key) continue
+      if (e.metaKey !== shortcut.metaKey) continue
+      if (e.ctrlKey !== shortcut.ctrlKey) continue
+      if ((alphabetKey || shiftableKey) && e.shiftKey !== shortcut.shiftKey) continue
+      if (!shortcut.enabled) {
+        chainedInputs.value = []
+        return
       }
 
-      if (e.metaKey !== shortcut.metaKey) {
-        continue
-      }
-      if (e.ctrlKey !== shortcut.ctrlKey) {
-        continue
-      }
-      // shift modifier is only checked in combination with alphabet keys and some extra keys
-      // (shift with special characters would change the key)
-      if ((alphabetKey || shiftableKey) && e.shiftKey !== shortcut.shiftKey) {
-        continue
-      }
-
-      if (shortcut.enabled) {
+      // Delay if this key is a chain prefix
+      if (isChainPrefix(keyValue)) {
         e.preventDefault()
-        shortcut.handler(e)
+        pendingShortcut.value = shortcut
+
+        if (pendingTimer) clearTimeout(pendingTimer)
+        pendingTimer = setTimeout(() => {
+          pendingShortcut.value?.handler(e)
+          pendingShortcut.value = null
+          chainedInputs.value = []
+        }, options.chainDelay ?? 800)
+
+        return
       }
-      clearChainedInput()
+
+      // Otherwise, fire immediately
+      e.preventDefault()
+      shortcut.handler(e)
+      chainedInputs.value = []
       return
     }
 
@@ -270,6 +281,12 @@ export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: Shor
       return shortcut
     }).filter(Boolean) as Shortcut[]
   })
+
+  function isChainPrefix(key: string) {
+    return shortcuts.value.some(s =>
+      s.chained && s.key.split('-')[0] === key
+    )
+  }
 
   return useEventListener('keydown', onKeyDown)
 }

--- a/test/composables/defineShortcuts.spec.ts
+++ b/test/composables/defineShortcuts.spec.ts
@@ -1,0 +1,88 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { defineShortcuts } from '../../src/runtime/composables/defineShortcuts'
+
+describe('defineShortcuts', () => {
+  let handlers: Record<string, ReturnType<typeof vi.fn>>
+
+  beforeEach(() => {
+    handlers = {
+      'f': vi.fn(),
+      'h': vi.fn(),
+      'f-h': vi.fn(),
+      'z-x': vi.fn(),
+      'meta_k': vi.fn()
+    }
+  })
+
+  function createShortcuts(options: any = {}) {
+    defineShortcuts(
+      {
+        'f': handlers.f,
+        'h': handlers.h,
+        'f-h': handlers['f-h'],
+        'z-x': handlers['z-x'],
+        'meta_k': handlers['meta_k']
+      },
+      options
+    )
+  }
+
+  function dispatchKey(key: string, code?: string) {
+    const e = new KeyboardEvent('keydown', {
+      key,
+      code: code || `Key${key.toUpperCase()}`,
+      bubbles: true
+    })
+    window.dispatchEvent(e)
+  }
+
+  it('fires single key shortcuts', async () => {
+    createShortcuts({ chainDelay: 50 })
+
+    dispatchKey('f')
+    await new Promise(r => setTimeout(r, 60))
+
+    expect(handlers.f).toHaveBeenCalled()
+    expect(handlers['f-h']).not.toHaveBeenCalled()
+  })
+
+  it('fires chain shortcuts if second key pressed', async () => {
+    createShortcuts({ chainDelay: 50 })
+
+    dispatchKey('f')
+    dispatchKey('h')
+    await new Promise(r => setTimeout(r, 60))
+
+    expect(handlers['f-h']).toHaveBeenCalled()
+    expect(handlers.f).not.toHaveBeenCalled()
+  })
+
+  it('fires z-x chain independently', async () => {
+    createShortcuts({ chainDelay: 50 })
+
+    dispatchKey('z')
+    dispatchKey('x')
+    await new Promise(r => setTimeout(r, 60))
+
+    expect(handlers['z-x']).toHaveBeenCalled()
+  })
+
+  it('fires h alone if pressed independently', async () => {
+    createShortcuts({ chainDelay: 50 })
+
+    dispatchKey('h')
+    await new Promise(r => setTimeout(r, 60))
+
+    expect(handlers.h).toHaveBeenCalled()
+  })
+
+  it('works across different keyboard layouts when layoutIndependent is enabled', async () => {
+    createShortcuts({ chainDelay: 50, layoutIndependent: true })
+
+    // Press a different key character on the same physical key
+    dispatchKey('ب', 'KeyF') // 'ب' is what Arabic layout produces on the F key
+    await new Promise(r => setTimeout(r, 60))
+
+    expect(handlers.f).toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue
Resolves https://github.com/nuxt/ui/issues/5654

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
This PR introduces two improvements to the `defineShortcuts` composable:

1. **Chained shortcut handling:**  
   - Chained shortcuts (e.g., 'f-h') now properly override single key shortcuts when the same keys are used both individually and in a sequence.  
   - This ensures that pressing 'f' followed quickly by 'h' triggers 'f-h', while pressing 'f' alone still triggers the single key handler.

2. **Test coverage:**  
   - Adds a comprehensive test suite covering single keys, key chains, and layout-independent mode.  
   - Ensures correct behavior across different keyboard layouts and prevents regressions in chained key handling.

Future work may include tests for modifier keys (Ctrl, Shift, Meta) and more complex combinations.

### 📝 Checklist
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
