### PR TITLE
feat: Use new `useTimeAgoIntl()` for i18n support in example

### DIFF
--- a/docs/app/components/content/examples/timeline/TimelineSlotsExample.vue
+++ b/docs/app/components/content/examples/timeline/TimelineSlotsExample.vue
@@ -54,7 +54,7 @@ const items = [{
     </template>
 
     <template #date="{ item }">
-      {{ useTimeAgoIntl(new Date(item.date)) }}
+      {{ useTimeAgoIntl(new Date(item.date), { locale: 'fr' }) }}
     </template>
   </UTimeline>
 </template>

--- a/docs/app/components/content/examples/timeline/TimelineSlotsExample.vue
+++ b/docs/app/components/content/examples/timeline/TimelineSlotsExample.vue
@@ -1,6 +1,6 @@
 <script lang="ts" setup>
 import type { TimelineItem } from '@nuxt/ui'
-import { useTimeAgo } from '@vueuse/core'
+import { useTimeAgoIntl } from '@vueuse/core'
 
 const items = [{
   username: 'J-Michalek',
@@ -54,7 +54,7 @@ const items = [{
     </template>
 
     <template #date="{ item }">
-      {{ useTimeAgo(new Date(item.date)) }}
+      {{ useTimeAgoIntl(new Date(item.date)) }}
     </template>
   </UTimeline>
 </template>


### PR DESCRIPTION
### ❓ Type of change

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

[useTimeAgoIntl](https://vueuse.org/core/useTimeAgoIntl/) has been introduced to have the text be translated, this could be showcased in this example

