### PR TITLE
fix(locale): improve `cs` and `sk` terminology for correct inflection

### DIFF
--- a/src/runtime/locale/cs.ts
+++ b/src/runtime/locale/cs.ts
@@ -50,7 +50,7 @@ export default defineLocale<Messages>({
     },
     contentSearch: {
       links: 'Odkazy',
-      theme: 'Téma'
+      theme: 'Barevný režim'
     },
     contentSearchButton: {
       label: 'Hledat…'
@@ -59,7 +59,7 @@ export default defineLocale<Messages>({
       title: 'Na této stránce'
     },
     dashboardSearch: {
-      theme: 'Téma'
+      theme: 'Barevný režim'
     },
     dashboardSearchButton: {
       label: 'Hledat…'

--- a/src/runtime/locale/sk.ts
+++ b/src/runtime/locale/sk.ts
@@ -50,7 +50,7 @@ export default defineLocale<Messages>({
     },
     contentSearch: {
       links: 'Odkazy',
-      theme: 'Téma'
+      theme: 'Farebný režim'
     },
     contentSearchButton: {
       label: 'Hľadať…'
@@ -59,7 +59,7 @@ export default defineLocale<Messages>({
       title: 'Na tejto stránke'
     },
     dashboardSearch: {
-      theme: 'Téma'
+      theme: 'Farebný režim'
     },
     dashboardSearchButton: {
       label: 'Hľadať…'


### PR DESCRIPTION
### 🔗 Linked issue
Resolves #5788

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Slovak and Czech languages are inflected languages meaning, that suffixes of the different words, including adjectives change in response to cases and grammatic genders. Aditionally, they both follow the rule, where the gender of the adjective needs to follow the gender of the noun, adjective describes. [https://www.juls.savba.sk/ediela/msj/msj-lq.pdf](https://www.juls.savba.sk/ediela/msj/msj-lq.pdf) (Page 195 | Official codification handbook of the Slovak language)

The current problem with the CZ and SK locale of Nuxt UI is that there is a mismatch between gender of the noun and adjective. In DashboardSearch and ContentSearch with `colorMode` prop set to true and `colorMode` config set to true, color theme selection options show title "Téma" (Theme), which is feminine noun and options "Svetlý" (Light), "Tmavý" (Dark), which are masculine adjectives. The correct feminine adjectives would be "Svetlá" and "Tmavá" as it is "Svetlá téma" (Light theme) and "Tmavá téma" (Dark theme).

I considered changing those to the masculine gender, yet the problem with such change would be that in context, where these adjectives are used without any noun (in ColorModeSelect component), it is much more natural to use masculine gender for standalone adjectives, and such change would lead to language inconsistencies.

Therefore, I propose to switch from wording "Téma" (theme) to "Farebný/Barevný režim" (Color mode). Even tough, the content of the locale doesn't match the key word-to-word-wise, it leads to much cleaner and frictionless UX when viewing Nuxt UI powered site and the meaning is practically the same. Another inspiration for me was that we use "farebný/barevný režim" accross multiple spaces in existing locale and hence, it seams clean

As native Slovak and Czech speaker, with interest in these languages, I feel qualified to propose such change.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly. (N/A)
