### PR TITLE
docs(components): properly escape markdown in prop type rendering

### DIFF
--- a/docs/app/components/content/HighlightInlineType.vue
+++ b/docs/app/components/content/HighlightInlineType.vue
@@ -24,7 +24,7 @@ const type = computed(() => {
 const ast = ref<any>(null)
 
 onMounted(async () => {
-  ast.value = await parseMarkdown(`\`${type.value}\`{lang="ts-type"}`)
+  ast.value = await parseMarkdown(`\`\` ${type.value} \`\`{lang="ts-type"}`)
 })
 </script>
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/ui/issues/5813

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Fix the problematic Markdown rendering by proper escaping backticks with the double backticks syntax.
    - https://www.markdownguide.org/basic-syntax/#escaping-backticks
- I've also checked all occurrences of `parseMarkdown` to make sure that only `<HighlightInlineType />` needs to fix.
- I didn't check all component pages, but I don't think that this markdown change will break rendering.

#### Screenshot

| Before | After |
| -- | -- |
| <img width="388" height="414" alt="image" src="https://github.com/user-attachments/assets/e9a38422-69f4-465b-9fa1-cd68058bd62d" /> | <img width="387" height="407" alt="image" src="https://github.com/user-attachments/assets/2fdb6280-2054-4d25-aac7-c0be57f53699" /> |

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
