### PR TITLE
fix(ContentSurround): align next link to right on tablet without prev

### DIFF
--- a/src/runtime/components/content/ContentSurround.vue
+++ b/src/runtime/components/content/ContentSurround.vue
@@ -102,7 +102,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.contentSurro
         </p>
       </slot>
     </ULink>
-    <span v-else class="hidden lg:block">&nbsp;</span>
+    <span v-else class="hidden sm:block">&nbsp;</span>
   </DefineLinkTemplate>
 
   <Primitive v-if="surround" :as="as" v-bind="$attrs" data-slot="root" :class="ui.root({ class: [props.ui?.root, props.class] })">


### PR DESCRIPTION
### Overview

The next link was aligned to the left instead of the right on tablet-sized screens (like iPad) when prev link is missing.

<img width="624" height="924" alt="スクリーンショット 2026-01-08 19 17 03" src="https://github.com/user-attachments/assets/96b0eeeb-b7b3-416b-bad6-46e83fbcf0ed" />

### Fix

Before:

When prev link is missing, the placeholder <span> only becomes visible at lg breakpoint (hidden lg:block). However, the grid switches to 2 columns at sm breakpoint (sm:grid-cols-2). This mismatch causes the next link to be placed in the first column (left side) between sm and lg breakpoints, since the placeholder is hidden and doesn't occupy the first grid cell.

https://github.com/user-attachments/assets/da052eb4-79ae-4789-8637-7835b2f9b236

After:

https://github.com/user-attachments/assets/10ff55d7-a811-4e8d-a35e-d7377199b2f2

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

I searched for "iPad", "tablet", and "responsive breakpoint" but didn't find any related issues. It seems this issue hasn't been reported before.

- ~~[ ] I have linked an issue or discussion.~~
- ~~[ ] I have updated the documentation accordingly.~~
