### PR TITLE
feat(theme)!: normalize theme structure to slots-based (BREAKING)

### DIFF
--- a/src/runtime/components/Container.vue
+++ b/src/runtime/components/Container.vue
@@ -24,17 +24,18 @@ import { computed } from 'vue'
 import { Primitive } from 'reka-ui'
 import { useAppConfig } from '#imports'
 import { tv } from '../utils/tv'
+import { normalizeThemeConfig } from '../../utils/theme'
 
 const props = defineProps<ContainerProps>()
 defineSlots<ContainerSlots>()
 
 const appConfig = useAppConfig() as Container['AppConfig']
 
-const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.container || {}) }))
+const ui = computed(() => tv({ extend: tv(theme), ...normalizeThemeConfig(appConfig.ui?.container || {}) }))
 </script>
 
 <template>
-  <Primitive :as="as" :class="ui({ class: props.class })">
+  <Primitive :as="as" :class="ui.base({ class: props.class })">
     <slot />
   </Primitive>
 </template>

--- a/src/runtime/components/DashboardGroup.vue
+++ b/src/runtime/components/DashboardGroup.vue
@@ -63,7 +63,7 @@ provideDashboardContext({
 </script>
 
 <template>
-  <Primitive :as="as" :class="ui({ class: props.class })">
+  <Primitive :as="as" :class="ui.base({ class: props.class })">
     <slot />
   </Primitive>
 </template>

--- a/src/runtime/components/DashboardResizeHandle.vue
+++ b/src/runtime/components/DashboardResizeHandle.vue
@@ -37,7 +37,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.dashboardRes
   <Primitive
     :as="as"
     role="separator"
-    :class="ui({ class: props.class })"
+    :class="ui.base({ class: props.class })"
   >
     <slot />
   </Primitive>

--- a/src/runtime/components/DashboardSidebarCollapse.vue
+++ b/src/runtime/components/DashboardSidebarCollapse.vue
@@ -56,7 +56,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.dashboardSid
       'aria-label': sidebarCollapsed ? t('dashboardSidebarCollapse.expand') : t('dashboardSidebarCollapse.collapse'),
       ...$attrs
     }"
-    :class="ui({ class: props.class, side: props.side })"
+    :class="ui.base({ class: props.class, side: props.side })"
     @click="collapseSidebar?.(!sidebarCollapsed)"
   />
 </template>

--- a/src/runtime/components/DashboardSidebarToggle.vue
+++ b/src/runtime/components/DashboardSidebarToggle.vue
@@ -58,7 +58,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.dashboardSid
       'aria-label': sidebarOpen ? t('dashboardSidebarToggle.close') : t('dashboardSidebarToggle.open'),
       ...$attrs
     }"
-    :class="ui({ class: props.class, side: props.side })"
+    :class="ui.base({ class: props.class, side: props.side })"
     @click="toggleSidebar"
   />
 </template>

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -448,7 +448,7 @@ defineExpose(api)
   <component
     :is="parentBus ? 'div' : 'form'"
     :id="formId"
-    :class="ui({ class: props.class })"
+    :class="ui.base({ class: props.class })"
     @submit.prevent="onSubmitWrapper"
   >
     <slot :errors="errors" :loading="loading" />

--- a/src/runtime/components/Kbd.vue
+++ b/src/runtime/components/Kbd.vue
@@ -52,7 +52,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.kbd || {}) }
 </script>
 
 <template>
-  <Primitive :as="as" :class="ui({ class: props.class, color: props.color, variant: props.variant, size: props.size })">
+  <Primitive :as="as" :class="ui.base({ class: props.class, color: props.color, variant: props.variant, size: props.size })">
     <slot>
       {{ getKbdKey(value) }}
     </slot>

--- a/src/runtime/components/Main.vue
+++ b/src/runtime/components/Main.vue
@@ -34,7 +34,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.main || {}) 
 </script>
 
 <template>
-  <Primitive :as="as" :class="ui({ class: props.class })">
+  <Primitive :as="as" :class="ui.base({ class: props.class })">
     <slot />
   </Primitive>
 </template>

--- a/src/runtime/components/PageBody.vue
+++ b/src/runtime/components/PageBody.vue
@@ -34,7 +34,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.pageBody || 
 </script>
 
 <template>
-  <Primitive :as="as" :class="ui({ class: props.class })">
+  <Primitive :as="as" :class="ui.base({ class: props.class })">
     <slot />
   </Primitive>
 </template>

--- a/src/runtime/components/PageColumns.vue
+++ b/src/runtime/components/PageColumns.vue
@@ -34,7 +34,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.pageColumns 
 </script>
 
 <template>
-  <Primitive :as="as" :class="ui({ class: props.class })">
+  <Primitive :as="as" :class="ui.base({ class: props.class })">
     <slot />
   </Primitive>
 </template>

--- a/src/runtime/components/PageGrid.vue
+++ b/src/runtime/components/PageGrid.vue
@@ -34,7 +34,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.pageGrid || 
 </script>
 
 <template>
-  <Primitive :as="as" :class="ui({ class: props.class })">
+  <Primitive :as="as" :class="ui.base({ class: props.class })">
     <slot />
   </Primitive>
 </template>

--- a/src/runtime/components/PageList.vue
+++ b/src/runtime/components/PageList.vue
@@ -37,7 +37,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.pageList || 
 </script>
 
 <template>
-  <Primitive :as="as" role="list" :class="ui({ class: props.class, divide: props.divide })">
+  <Primitive :as="as" role="list" :class="ui.base({ class: props.class, divide: props.divide })">
     <slot />
   </Primitive>
 </template>

--- a/src/runtime/components/PricingPlans.vue
+++ b/src/runtime/components/PricingPlans.vue
@@ -83,7 +83,7 @@ function mapSlot(slot: any) {
 </script>
 
 <template>
-  <Primitive :as="as" :data-orientation="orientation" :class="ui({ class: props.class, compact, scale, orientation })" :style="{ '--count': count }">
+  <Primitive :as="as" :data-orientation="orientation" :class="ui.base({ class: props.class, compact, scale, orientation })" :style="{ '--count': count }">
     <slot>
       <UPricingPlan
         v-for="(plan, index) in plans"

--- a/src/runtime/components/Skeleton.vue
+++ b/src/runtime/components/Skeleton.vue
@@ -35,7 +35,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.skeleton || 
     aria-label="loading"
     aria-live="polite"
     role="alert"
-    :class="ui({ class: props.class })"
+    :class="ui.base({ class: props.class })"
   >
     <slot />
   </Primitive>

--- a/src/runtime/components/prose/A.vue
+++ b/src/runtime/components/prose/A.vue
@@ -31,7 +31,7 @@ defineSlots<ProseASlots>()
 </script>
 
 <template>
-  <ULink :href="href" :target="target" :class="ui({ class: props.class })" raw>
+  <ULink :href="href" :target="target" :class="ui.base({ class: props.class })" raw>
     <slot />
   </ULink>
 </template>

--- a/src/runtime/components/prose/AccordionItem.vue
+++ b/src/runtime/components/prose/AccordionItem.vue
@@ -30,7 +30,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.accor
 </script>
 
 <template>
-  <div :class="ui({ class: props.class })">
+  <div :class="ui.base({ class: props.class })">
     <slot>
       {{ description }}
     </slot>

--- a/src/runtime/components/prose/Badge.vue
+++ b/src/runtime/components/prose/Badge.vue
@@ -29,7 +29,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.badge
 </script>
 
 <template>
-  <UBadge color="primary" variant="subtle" :class="ui({ class: props.class })">
+  <UBadge color="primary" variant="subtle" :class="ui.base({ class: props.class })">
     <slot mdc-unwrap="p" />
   </UBadge>
 </template>

--- a/src/runtime/components/prose/Blockquote.vue
+++ b/src/runtime/components/prose/Blockquote.vue
@@ -28,7 +28,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.block
 </script>
 
 <template>
-  <blockquote :class="ui({ class: props.class })">
+  <blockquote :class="ui.base({ class: props.class })">
     <slot />
   </blockquote>
 </template>

--- a/src/runtime/components/prose/CardGroup.vue
+++ b/src/runtime/components/prose/CardGroup.vue
@@ -28,7 +28,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.cardG
 </script>
 
 <template>
-  <div :class="ui({ class: props.class })">
+  <div :class="ui.base({ class: props.class })">
     <slot />
   </div>
 </template>

--- a/src/runtime/components/prose/Code.vue
+++ b/src/runtime/components/prose/Code.vue
@@ -33,7 +33,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.code 
 </script>
 
 <template>
-  <code :class="ui({ class: (props.class || '').split(',').join(' '), color: props.color })">
+  <code :class="ui.base({ class: (props.class || '').split(',').join(' '), color: props.color })">
     <slot />
   </code>
 </template>

--- a/src/runtime/components/prose/Em.vue
+++ b/src/runtime/components/prose/Em.vue
@@ -28,5 +28,5 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.em ||
 </script>
 
 <template>
-  <em :class="ui({ class: props.class })"><slot /></em>
+  <em :class="ui.base({ class: props.class })"><slot /></em>
 </template>

--- a/src/runtime/components/prose/FieldGroup.vue
+++ b/src/runtime/components/prose/FieldGroup.vue
@@ -34,7 +34,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.field
 </script>
 
 <template>
-  <Primitive :as="as" :class="ui({ class: props.class })">
+  <Primitive :as="as" :class="ui.base({ class: props.class })">
     <slot />
   </Primitive>
 </template>

--- a/src/runtime/components/prose/Hr.vue
+++ b/src/runtime/components/prose/Hr.vue
@@ -23,5 +23,5 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.hr ||
 </script>
 
 <template>
-  <hr :class="ui({ class: props.class })">
+  <hr :class="ui.base({ class: props.class })">
 </template>

--- a/src/runtime/components/prose/Icon.vue
+++ b/src/runtime/components/prose/Icon.vue
@@ -25,5 +25,5 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.icon 
 </script>
 
 <template>
-  <UIcon :name="name" :class="ui({ class: props.class })" />
+  <UIcon :name="name" :class="ui.base({ class: props.class })" />
 </template>

--- a/src/runtime/components/prose/Kbd.vue
+++ b/src/runtime/components/prose/Kbd.vue
@@ -25,5 +25,5 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.kbd |
 </script>
 
 <template>
-  <UKbd :value="value" :class="ui({ class: props.class })" />
+  <UKbd :value="value" :class="ui.base({ class: props.class })" />
 </template>

--- a/src/runtime/components/prose/Li.vue
+++ b/src/runtime/components/prose/Li.vue
@@ -28,7 +28,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.li ||
 </script>
 
 <template>
-  <li :class="ui({ class: props.class })">
+  <li :class="ui.base({ class: props.class })">
     <slot />
   </li>
 </template>

--- a/src/runtime/components/prose/Ol.vue
+++ b/src/runtime/components/prose/Ol.vue
@@ -28,7 +28,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.ol ||
 </script>
 
 <template>
-  <ol :class="ui({ class: props.class })">
+  <ol :class="ui.base({ class: props.class })">
     <slot />
   </ol>
 </template>

--- a/src/runtime/components/prose/P.vue
+++ b/src/runtime/components/prose/P.vue
@@ -28,7 +28,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.p || 
 </script>
 
 <template>
-  <p :class="ui({ class: props.class })">
+  <p :class="ui.base({ class: props.class })">
     <slot />
   </p>
 </template>

--- a/src/runtime/components/prose/Steps.vue
+++ b/src/runtime/components/prose/Steps.vue
@@ -33,7 +33,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.steps
 </script>
 
 <template>
-  <div :class="ui({ class: props.class, level: props.level })">
+  <div :class="ui.base({ class: props.class, level: props.level })">
     <slot />
   </div>
 </template>

--- a/src/runtime/components/prose/Strong.vue
+++ b/src/runtime/components/prose/Strong.vue
@@ -28,7 +28,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.stron
 </script>
 
 <template>
-  <strong :class="ui({ class: props.class })">
+  <strong :class="ui.base({ class: props.class })">
     <slot />
   </strong>
 </template>

--- a/src/runtime/components/prose/TabsItem.vue
+++ b/src/runtime/components/prose/TabsItem.vue
@@ -30,7 +30,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.tabsI
 </script>
 
 <template>
-  <div :class="ui({ class: props.class })">
+  <div :class="ui.base({ class: props.class })">
     <slot>
       {{ description }}
     </slot>

--- a/src/runtime/components/prose/Tbody.vue
+++ b/src/runtime/components/prose/Tbody.vue
@@ -28,7 +28,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.tbody
 </script>
 
 <template>
-  <tbody :class="ui({ class: props.class })">
+  <tbody :class="ui.base({ class: props.class })">
     <slot />
   </tbody>
 </template>

--- a/src/runtime/components/prose/Td.vue
+++ b/src/runtime/components/prose/Td.vue
@@ -28,7 +28,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.td ||
 </script>
 
 <template>
-  <td :class="ui({ class: props.class })">
+  <td :class="ui.base({ class: props.class })">
     <slot />
   </td>
 </template>

--- a/src/runtime/components/prose/Th.vue
+++ b/src/runtime/components/prose/Th.vue
@@ -28,7 +28,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.th ||
 </script>
 
 <template>
-  <th :class="ui({ class: props.class })">
+  <th :class="ui.base({ class: props.class })">
     <slot />
   </th>
 </template>

--- a/src/runtime/components/prose/Thead.vue
+++ b/src/runtime/components/prose/Thead.vue
@@ -28,7 +28,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.thead
 </script>
 
 <template>
-  <thead :class="ui({ class: props.class })">
+  <thead :class="ui.base({ class: props.class })">
     <slot />
   </thead>
 </template>

--- a/src/runtime/components/prose/Tr.vue
+++ b/src/runtime/components/prose/Tr.vue
@@ -28,7 +28,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.tr ||
 </script>
 
 <template>
-  <tr :class="ui({ class: props.class })">
+  <tr :class="ui.base({ class: props.class })">
     <slot />
   </tr>
 </template>

--- a/src/runtime/components/prose/Ul.vue
+++ b/src/runtime/components/prose/Ul.vue
@@ -28,7 +28,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.ul ||
 </script>
 
 <template>
-  <ul :class="ui({ class: props.class })">
+  <ul :class="ui.base({ class: props.class })">
     <slot />
   </ul>
 </template>

--- a/src/theme/blog-posts.ts
+++ b/src/theme/blog-posts.ts
@@ -1,5 +1,7 @@
 export default {
-  base: 'flex flex-col gap-8 lg:gap-y-16',
+  slots: {
+    base: 'flex flex-col gap-8 lg:gap-y-16'
+  },
   variants: {
     orientation: {
       horizontal: 'sm:grid sm:grid-cols-2 lg:grid-cols-3',

--- a/src/theme/container.ts
+++ b/src/theme/container.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'w-full max-w-(--ui-container) mx-auto px-4 sm:px-6 lg:px-8'
+  slots: {
+    base: 'w-full max-w-(--ui-container) mx-auto px-4 sm:px-6 lg:px-8'
+  }
 }

--- a/src/theme/dashboard-group.ts
+++ b/src/theme/dashboard-group.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'fixed inset-0 flex overflow-hidden'
+  slots: {
+    base: 'fixed inset-0 flex overflow-hidden'
+  }
 }

--- a/src/theme/dashboard-resize-handle.ts
+++ b/src/theme/dashboard-resize-handle.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'hidden lg:block touch-none select-none cursor-ew-resize relative before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5'
+  slots: {
+    base: 'hidden lg:block touch-none select-none cursor-ew-resize relative before:absolute before:inset-y-0 before:-left-1.5 before:-right-1.5'
+  }
 }

--- a/src/theme/dashboard-sidebar-collapse.ts
+++ b/src/theme/dashboard-sidebar-collapse.ts
@@ -1,5 +1,7 @@
 export default {
-  base: 'hidden lg:flex',
+  slots: {
+    base: 'hidden lg:flex'
+  },
   variants: {
     side: {
       left: '',

--- a/src/theme/dashboard-sidebar-toggle.ts
+++ b/src/theme/dashboard-sidebar-toggle.ts
@@ -1,5 +1,7 @@
 export default {
-  base: 'lg:hidden',
+  slots: {
+    base: 'lg:hidden'
+  },
   variants: {
     side: {
       left: '',

--- a/src/theme/field-group.ts
+++ b/src/theme/field-group.ts
@@ -19,7 +19,9 @@ export const fieldGroupVariantWithRoot = {
 }
 
 export default {
-  base: 'relative',
+  slots: {
+    base: 'relative'
+  },
   variants: {
     size: {
       xs: '',

--- a/src/theme/form.ts
+++ b/src/theme/form.ts
@@ -1,3 +1,5 @@
 export default {
-  base: ''
+  slots: {
+    base: ''
+  }
 }

--- a/src/theme/kbd.ts
+++ b/src/theme/kbd.ts
@@ -1,7 +1,9 @@
 import type { ModuleOptions } from '../module'
 
 export default (options: Required<ModuleOptions>) => ({
-  base: 'inline-flex items-center justify-center px-1 rounded-sm font-medium font-sans uppercase',
+  slots: {
+    base: 'inline-flex items-center justify-center px-1 rounded-sm font-medium font-sans uppercase'
+  },
   variants: {
     color: {
       ...Object.fromEntries((options.theme.colors || []).map((color: string) => [color, ''])),

--- a/src/theme/link.ts
+++ b/src/theme/link.ts
@@ -1,7 +1,9 @@
 import type { ModuleOptions } from '../module'
 
 export default (options: Required<ModuleOptions>) => ({
-  base: 'focus-visible:outline-primary',
+  slots: {
+    base: 'focus-visible:outline-primary'
+  },
   variants: {
     active: {
       true: 'text-primary',

--- a/src/theme/main.ts
+++ b/src/theme/main.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'min-h-[calc(100vh-var(--ui-header-height))]'
+  slots: {
+    base: 'min-h-[calc(100vh-var(--ui-header-height))]'
+  }
 }

--- a/src/theme/page-body.ts
+++ b/src/theme/page-body.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'mt-8 pb-24 space-y-12'
+  slots: {
+    base: 'mt-8 pb-24 space-y-12'
+  }
 }

--- a/src/theme/page-columns.ts
+++ b/src/theme/page-columns.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'relative column-1 md:columns-2 lg:columns-3 gap-8 space-y-8 *:break-inside-avoid-column *:will-change-transform'
+  slots: {
+    base: 'relative column-1 md:columns-2 lg:columns-3 gap-8 space-y-8 *:break-inside-avoid-column *:will-change-transform'
+  }
 }

--- a/src/theme/page-grid.ts
+++ b/src/theme/page-grid.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'relative grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8'
+  slots: {
+    base: 'relative grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-8'
+  }
 }

--- a/src/theme/page-list.ts
+++ b/src/theme/page-list.ts
@@ -1,5 +1,7 @@
 export default {
-  base: 'relative flex flex-col',
+  slots: {
+    base: 'relative flex flex-col'
+  },
   variants: {
     divide: {
       true: '*:not-last:after:absolute *:not-last:after:inset-x-1 *:not-last:after:bottom-0 *:not-last:after:bg-border *:not-last:after:h-px'

--- a/src/theme/pricing-plans.ts
+++ b/src/theme/pricing-plans.ts
@@ -1,5 +1,7 @@
 export default {
-  base: 'flex flex-col gap-y-8',
+  slots: {
+    base: 'flex flex-col gap-y-8'
+  },
   variants: {
     orientation: {
       horizontal: 'lg:grid lg:grid-cols-[repeat(var(--count),minmax(0,1fr))]',

--- a/src/theme/prose/a.ts
+++ b/src/theme/prose/a.ts
@@ -1,5 +1,7 @@
 import type { NuxtOptions } from '@nuxt/schema'
 
 export default (options: Required<NuxtOptions['ui']>) => ({
-  base: ['text-primary border-b border-transparent hover:border-primary font-medium focus-visible:outline-primary focus-visible:has-[>code]:outline-0 [&>code]:border-dashed hover:[&>code]:border-primary hover:[&>code]:text-primary focus-visible:[&>code]:border-primary focus-visible:[&>code]:text-primary', options.theme.transitions && 'transition-colors [&>code]:transition-colors']
+  slots: {
+    base: ['text-primary border-b border-transparent hover:border-primary font-medium focus-visible:outline-primary focus-visible:has-[>code]:outline-0 [&>code]:border-dashed hover:[&>code]:border-primary hover:[&>code]:text-primary focus-visible:[&>code]:border-primary focus-visible:[&>code]:text-primary', options.theme.transitions && 'transition-colors [&>code]:transition-colors']
+  }
 })

--- a/src/theme/prose/accordion-item.ts
+++ b/src/theme/prose/accordion-item.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'pb-4 text-muted *:first:mt-0 *:last:mb-0 *:my-1.5'
+  slots: {
+    base: 'pb-4 text-muted *:first:mt-0 *:last:mb-0 *:my-1.5'
+  }
 }

--- a/src/theme/prose/badge.ts
+++ b/src/theme/prose/badge.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'rounded-full'
+  slots: {
+    base: 'rounded-full'
+  }
 }

--- a/src/theme/prose/blockquote.ts
+++ b/src/theme/prose/blockquote.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'border-s-4 border-accented ps-4 italic'
+  slots: {
+    base: 'border-s-4 border-accented ps-4 italic'
+  }
 }

--- a/src/theme/prose/card-group.ts
+++ b/src/theme/prose/card-group.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'grid grid-cols-1 sm:grid-cols-2 gap-5 my-5 *:my-0'
+  slots: {
+    base: 'grid grid-cols-1 sm:grid-cols-2 gap-5 my-5 *:my-0'
+  }
 }

--- a/src/theme/prose/code.ts
+++ b/src/theme/prose/code.ts
@@ -1,7 +1,8 @@
 import type { NuxtOptions } from '@nuxt/schema'
 
 export default (options: Required<NuxtOptions['ui']>) => ({
-  base: 'px-1.5 py-0.5 text-sm font-mono font-medium rounded-md inline-block',
+  slots: {
+    base: 'px-1.5 py-0.5 text-sm font-mono font-medium rounded-md inline-block',
   variants: {
     color: {
       ...Object.fromEntries((options.theme.colors || []).map((color: string) => [color, `border border-${color}/25 bg-${color}/10 text-${color}`])),
@@ -10,5 +11,6 @@ export default (options: Required<NuxtOptions['ui']>) => ({
   },
   defaultVariants: {
     color: 'neutral'
+  }
   }
 })

--- a/src/theme/prose/em.ts
+++ b/src/theme/prose/em.ts
@@ -1,3 +1,5 @@
 export default {
-  base: ''
+  slots: {
+    base: ''
+  }
 }

--- a/src/theme/prose/field-group.ts
+++ b/src/theme/prose/field-group.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'my-5 divide-y divide-default *:not-last:pb-5'
+  slots: {
+    base: 'my-5 divide-y divide-default *:not-last:pb-5'
+  }
 }

--- a/src/theme/prose/hr.ts
+++ b/src/theme/prose/hr.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'border-t border-default my-12'
+  slots: {
+    base: 'border-t border-default my-12'
+  }
 }

--- a/src/theme/prose/icon.ts
+++ b/src/theme/prose/icon.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'size-4 shrink-0 align-sub'
+  slots: {
+    base: 'size-4 shrink-0 align-sub'
+  }
 }

--- a/src/theme/prose/kbd.ts
+++ b/src/theme/prose/kbd.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'align-text-top'
+  slots: {
+    base: 'align-text-top'
+  }
 }

--- a/src/theme/prose/li.ts
+++ b/src/theme/prose/li.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'my-1.5 ps-1.5 leading-7 [&>ul]:my-0'
+  slots: {
+    base: 'my-1.5 ps-1.5 leading-7 [&>ul]:my-0'
+  }
 }

--- a/src/theme/prose/ol.ts
+++ b/src/theme/prose/ol.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'list-decimal ps-6 my-5 marker:text-muted'
+  slots: {
+    base: 'list-decimal ps-6 my-5 marker:text-muted'
+  }
 }

--- a/src/theme/prose/p.ts
+++ b/src/theme/prose/p.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'my-5 leading-7 text-pretty'
+  slots: {
+    base: 'my-5 leading-7 text-pretty'
+  }
 }

--- a/src/theme/prose/steps.ts
+++ b/src/theme/prose/steps.ts
@@ -1,5 +1,7 @@
 export default {
-  base: 'ms-4 border-s border-default ps-8 [counter-reset:step]',
+  slots: {
+    base: 'ms-4 border-s border-default ps-8 [counter-reset:step]'
+  },
   variants: {
     level: {
       2: '[&>h2]:[counter-increment:step] [&>h2]:relative [&>h2]:before:absolute [&>h2]:before:size-8 [&>h2]:before:bg-elevated [&>h2]:before:rounded-full [&>h2]:before:font-semibold [&>h2]:before:text-sm [&>h2]:before:tabular-nums [&>h2]:before:inline-flex [&>h2]:before:items-center [&>h2]:before:justify-center [&>h2]:before:ring-4 [&>h2]:before:ring-bg [&>h2]:before:-ms-[48.5px] [&>h2]:before:-mt-0 [&>h2]:before:content-[counter(step)] [&>h2>a>span.absolute]:hidden',

--- a/src/theme/prose/strong.ts
+++ b/src/theme/prose/strong.ts
@@ -1,3 +1,5 @@
 export default {
-  base: ''
+  slots: {
+    base: ''
+  }
 }

--- a/src/theme/prose/tabs-item.ts
+++ b/src/theme/prose/tabs-item.ts
@@ -1,3 +1,5 @@
 export default {
-  base: '*:first:mt-0 *:last:mb-0 *:my-1.5'
+  slots: {
+    base: '*:first:mt-0 *:last:mb-0 *:my-1.5'
+  }
 }

--- a/src/theme/prose/tbody.ts
+++ b/src/theme/prose/tbody.ts
@@ -1,3 +1,5 @@
 export default {
-  base: ''
+  slots: {
+    base: ''
+  }
 }

--- a/src/theme/prose/td.ts
+++ b/src/theme/prose/td.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'py-3 px-4 text-sm text-left align-top border-e border-b first:border-s border-muted [&_code]:text-xs/5 [&_p]:my-0 [&_p]:leading-6 [&_ul]:my-0 [&_ol]:my-0 [&_ul]:ps-4.5 [&_ol]:ps-4.5 [&_li]:leading-6 [&_li]:my-0.5'
+  slots: {
+    base: 'py-3 px-4 text-sm text-left align-top border-e border-b first:border-s border-muted [&_code]:text-xs/5 [&_p]:my-0 [&_p]:leading-6 [&_ul]:my-0 [&_ol]:my-0 [&_ul]:ps-4.5 [&_ol]:ps-4.5 [&_li]:leading-6 [&_li]:my-0.5'
+  }
 }

--- a/src/theme/prose/th.ts
+++ b/src/theme/prose/th.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'py-3 px-4 font-semibold text-sm text-left border-e border-b first:border-s border-t border-muted'
+  slots: {
+    base: 'py-3 px-4 font-semibold text-sm text-left border-e border-b first:border-s border-t border-muted'
+  }
 }

--- a/src/theme/prose/thead.ts
+++ b/src/theme/prose/thead.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'bg-muted'
+  slots: {
+    base: 'bg-muted'
+  }
 }

--- a/src/theme/prose/tr.ts
+++ b/src/theme/prose/tr.ts
@@ -1,3 +1,5 @@
 export default {
-  base: '[&:first-child>th:first-child]:rounded-tl-md [&:first-child>th:last-child]:rounded-tr-md [&:last-child>td:first-child]:rounded-bl-md [&:last-child>td:last-child]:rounded-br-md'
+  slots: {
+    base: '[&:first-child>th:first-child]:rounded-tl-md [&:first-child>th:last-child]:rounded-tr-md [&:last-child>td:first-child]:rounded-bl-md [&:last-child>td:last-child]:rounded-br-md'
+  }
 }

--- a/src/theme/prose/ul.ts
+++ b/src/theme/prose/ul.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'list-disc ps-6 my-5 marker:text-(--ui-border-accented)'
+  slots: {
+    base: 'list-disc ps-6 my-5 marker:text-(--ui-border-accented)'
+  }
 }

--- a/src/theme/skeleton.ts
+++ b/src/theme/skeleton.ts
@@ -1,3 +1,5 @@
 export default {
-  base: 'animate-pulse rounded-md bg-elevated'
+  slots: {
+    base: 'animate-pulse rounded-md bg-elevated'
+  }
 }

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -96,3 +96,42 @@ export function applyDefaultVariants(result: any, defaultVariants?: { color?: st
 
   return result
 }
+
+/**
+ * Normalize theme config to support backward compatibility with flat base structure
+ * Converts { base: '...' } to { slots: { base: '...' } } for components that were migrated
+ * @param config - The theme config from app.config
+ * @returns The normalized config with slots structure
+ */
+export function normalizeThemeConfig(config: any): any {
+  if (!config) return config
+
+  // Already has slots structure - no normalization needed
+  if (config.slots) {
+    // Handle edge case: both base and slots.base exist
+    if (config.base) {
+      const { base, ...rest } = config
+      return {
+        ...rest,
+        slots: {
+          ...config.slots,
+          base: Array.isArray(config.slots.base)
+            ? [...config.slots.base, base]
+            : [config.slots.base, base]
+        }
+      }
+    }
+    return config
+  }
+
+  // Normalize flat base to slots.base
+  if (config.base) {
+    const { base, ...rest } = config
+    return {
+      ...rest,
+      slots: { base }
+    }
+  }
+
+  return config
+}


### PR DESCRIPTION
Closes #5847

> [WARNING!]
> I know this is huge PR and it is unlikely to be merge

## Summary

Normalizes 39 theme files from flat `base:` structure to `slots: { base: ... }` for consistency with existing components (Button, Card, Input, etc.) and to enable TypeScript support for slot overrides in app.config.

Previously, these components couldn't be customized via `app.config.ts` due to TypeScript errors:
- Container, Skeleton, Form, Main, Kbd, Link
- PageBody, PageColumns, PageGrid, PageList
- DashboardGroup, DashboardResizeHandle, DashboardSidebarCollapse, DashboardSidebarToggle  
- BlogPosts, PricingPlans, FieldGroup
- 23 prose components (A, Blockquote, Code, Li, Ol, P, Strong, table elements, etc.)

## StackBlitz

| | Link | Expected |
|---|---|---|
| Bug | [nuxt-ui-5847](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-ui-5847/nuxt-ui-5847?startScript=typecheck) | ❌ TypeScript errors |
| Fix | [nuxt-ui-5847-fixed](https://stackblitz.com/github/onmax/repros/tree/repro/nuxt-ui-5847/nuxt-ui-5847-fixed?startScript=typecheck) | ✅ Passes |

## CLI Reproduction

```bash
git clone --depth 1 --filter=blob:none --sparse --branch repro/nuxt-ui-5847 https://github.com/onmax/repros.git
cd repros && git sparse-checkout set nuxt-ui-5847
cd nuxt-ui-5847 && pnpm i && pnpm typecheck
# Shows TypeScript errors
```

## Verify fix

```bash
git sparse-checkout add nuxt-ui-5847-fixed
cd ../nuxt-ui-5847-fixed && pnpm i && pnpm typecheck
# ✅ Passes
```

The `-fixed` folder uses [pnpm patch](https://pnpm.io/cli/patch) to demonstrate expected behavior.

## Changes

### Theme Files (39 files)
Converted from:
```ts
export default {
  base: 'w-full max-w-(--ui-container) mx-auto px-4 sm:px-6 lg:px-8'
}
```

To:
```ts
export default {
  slots: {
    base: 'w-full max-w-(--ui-container) mx-auto px-4 sm:px-6 lg:px-8'
  }
}
```

### Component Files (37 files)
Updated template from:
```vue
<Primitive :class="ui({ class: props.class })" />
```

To:
```vue
<Primitive :class="ui.base({ class: props.class })" />
```

### Backward Compatibility
Added `normalizeThemeConfig()` utility to support legacy flat `base:` syntax in app.config at runtime:

```ts
// src/utils/theme.ts
export function normalizeThemeConfig(config: any): any {
  // Converts { base: '...' } → { slots: { base: '...' } }
  // Handles edge cases with both base and slots.base
}
```

Applied in Container component as reference implementation (other components can adopt this pattern as needed).

## Breaking Changes

**BREAKING CHANGE**: Theme files now use `slots: { base: '...' }` instead of flat `base: '...'`.

### Migration Required

Users customizing affected components in `app.config.ts` must update:

#### Before:
```ts
export default defineAppConfig({
  ui: {
    container: { base: 'max-w-lg' },  // ❌ TypeScript error
    skeleton: { base: 'rounded-xl' }  // ❌ TypeScript error
  }
})
```

#### After:
```ts
export default defineAppConfig({
  ui: {
    container: { slots: { base: 'max-w-lg' } },  // ✅ Works
    skeleton: { slots: { base: 'rounded-xl' } }   // ✅ Works
  }
})
```

### What's Affected
- ❌ TypeScript types (build-time)
- ❌ Third-party libraries exporting flat themes
- ❌ pnpm patches relying on flat structure
- ✅ Runtime normalization for app.config (partial backward compat)

### Limitations
Normalization does NOT fix:
- Third-party theme libraries
- Build-time type checking
- Module hooks setting themes programmatically

## Related
- #4953 - "Allow replacing all UI classes" (similar pain point)