### PR TITLE
docs(typography): fix code preview syntax in field group

### DIFF
--- a/docs/content/docs/4.typography/field-group.md
+++ b/docs/content/docs/4.typography/field-group.md
@@ -13,7 +13,7 @@ links:
 
 Group fields together in a list.
 
-::code-preview
+:::code-preview
 
 ::field-group{class="my-0"}
 
@@ -57,7 +57,7 @@ Group fields together in a list.
 ::
 ```
 
-::
+:::
 
 ## API
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Documentation page for [FieldGroup (Typography)](https://ui.nuxt.com/docs/typography/field-group) seems to be broken:

<img width="1828" height="2344" alt="Cursor 2026-01-11 13 33 50" src="https://github.com/user-attachments/assets/e49f531d-745a-4e51-8a08-50cbf14eee41" />


This PR fixes that by adding a colon on the outer tag `code-preview`:

<img width="1800" height="2112" alt="Arc 2026-01-11 13 33 56" src="https://github.com/user-attachments/assets/0ad6eb25-fdc5-4151-b4cd-b1a5df61ed25" />


### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
