### PR TITLE
fix(FileUpload): emit null when clearing file

### DIFF
--- a/src/runtime/components/FileUpload.vue
+++ b/src/runtime/components/FileUpload.vue
@@ -228,7 +228,7 @@ function onUpdate(files: File[], reset = false) {
       modelValue.value = [...existingFiles, ...(files || [])] as (M extends true ? File[] : File) | null
     }
   } else {
-    modelValue.value = files?.[0] as (M extends true ? File[] : File) | null
+    modelValue.value = (files?.[0] ?? null) as (M extends true ? File[] : File) | null
   }
 
   // @ts-expect-error - 'target' does not exist in type 'EventInit'

--- a/test/components/FileUpload.spec.ts
+++ b/test/components/FileUpload.spec.ts
@@ -118,6 +118,12 @@ describe('FileUpload', () => {
       expect(wrapper.emitted('update:modelValue')).toBeTruthy()
     })
 
+    test('update:modelValue emits null when removing a single file', async () => {
+      const wrapper = mount(FileUpload, { props })
+      await wrapper.find('button').trigger('click')
+      expect(wrapper.emitted('update:modelValue')?.at(-1)?.[0]).toBeNull()
+    })
+
     test('change event', async () => {
       const wrapper = mount(FileUpload)
       const input = wrapper.find('input')


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #5202.

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When a file is cleared from FileUpload, it now emits `null` model value as documented (it used to emit `undefined`).

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
