### PR TITLE
feat(Slideover): add size and fullscreen props

### DIFF
--- a/docs/content/docs/2.components/slideover.md
+++ b/docs/content/docs/2.components/slideover.md
@@ -197,6 +197,67 @@ slots:
 :placeholder{class="h-full min-h-48"}
 ::
 
+### Size
+
+Use the `size` prop to change the size of the Slideover. Defaults to `md`.
+
+::component-code
+---
+prettier: true
+ignore:
+  - title
+props:
+  size: 'lg'
+  title: 'Slideover with size'
+slots:
+  default: |
+
+    <UButton label="Open" color="neutral" variant="subtle" />
+
+  body: |
+
+    <Placeholder class="h-full" />
+---
+
+:u-button{label="Open" color="neutral" variant="subtle"}
+
+#body
+:placeholder{class="h-full"}
+::
+
+::note
+For `left` and `right` sides, the size controls the `max-width`. For `top` and `bottom` sides, it controls the `max-height`.
+::
+
+### Fullscreen
+
+Use the `fullscreen` prop to make the Slideover take the full width or height of the screen.
+
+::component-code
+---
+prettier: true
+ignore:
+  - title
+  - fullscreen
+props:
+  fullscreen: true
+  title: 'Slideover fullscreen'
+slots:
+  default: |
+
+    <UButton label="Open" color="neutral" variant="subtle" />
+
+  body: |
+
+    <Placeholder class="h-full" />
+---
+
+:u-button{label="Open" color="neutral" variant="subtle"}
+
+#body
+:placeholder{class="h-full"}
+::
+
 ### Inset :badge{label="4.3+" class="align-text-top"}
 
 Use the `inset` prop to inset the Slideover from the edges.

--- a/src/runtime/components/Slideover.vue
+++ b/src/runtime/components/Slideover.vue
@@ -29,6 +29,16 @@ export interface SlideoverProps extends DialogRootProps {
    */
   side?: Slideover['variants']['side']
   /**
+   * The size of the slideover.
+   * @defaultValue 'md'
+   */
+  size?: Slideover['variants']['size']
+  /**
+   * Render the slideover fullscreen.
+   * @defaultValue false
+   */
+  fullscreen?: boolean
+  /**
    * Whether to inset the slideover from the edges.
    * @defaultValue false
    */
@@ -95,7 +105,9 @@ const props = withDefaults(defineProps<SlideoverProps>(), {
   transition: true,
   modal: true,
   dismissible: true,
-  side: 'right'
+  side: 'right',
+  size: 'md',
+  fullscreen: false
 })
 const emits = defineEmits<SlideoverEmits>()
 const slots = defineSlots<SlideoverSlots>()
@@ -125,6 +137,8 @@ const contentEvents = computed(() => {
 const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.slideover || {}) })({
   transition: props.transition,
   side: props.side,
+  size: props.size,
+  fullscreen: props.fullscreen,
   inset: props.inset
 }))
 </script>

--- a/src/theme/slideover.ts
+++ b/src/theme/slideover.ts
@@ -16,14 +16,25 @@ export default {
         content: ''
       },
       right: {
-        content: 'max-w-md'
+        content: ''
       },
       bottom: {
         content: ''
       },
       left: {
-        content: 'max-w-md'
+        content: ''
       }
+    },
+    size: {
+      xs: '',
+      sm: '',
+      md: '',
+      lg: '',
+      xl: ''
+    },
+    fullscreen: {
+      true: '',
+      false: ''
     },
     inset: {
       true: {
@@ -108,5 +119,160 @@ export default {
     class: {
       content: 'data-[state=open]:animate-[slide-in-from-left_200ms_ease-in-out] data-[state=closed]:animate-[slide-out-to-left_200ms_ease-in-out]'
     }
-  }]
+  },
+  // Size variants for left/right sides (width)
+  {
+    side: 'left',
+    size: 'xs',
+    class: {
+      content: 'max-w-xs'
+    }
+  }, {
+    side: 'left',
+    size: 'sm',
+    class: {
+      content: 'max-w-sm'
+    }
+  }, {
+    side: 'left',
+    size: 'md',
+    class: {
+      content: 'max-w-md'
+    }
+  }, {
+    side: 'left',
+    size: 'lg',
+    class: {
+      content: 'max-w-1/2'
+    }
+  }, {
+    side: 'left',
+    size: 'xl',
+    class: {
+      content: 'max-w-3/4'
+    }
+  }, {
+    side: 'right',
+    size: 'xs',
+    class: {
+      content: 'max-w-xs'
+    }
+  }, {
+    side: 'right',
+    size: 'sm',
+    class: {
+      content: 'max-w-sm'
+    }
+  }, {
+    side: 'right',
+    size: 'md',
+    class: {
+      content: 'max-w-md'
+    }
+  }, {
+    side: 'right',
+    size: 'lg',
+    class: {
+      content: 'max-w-1/2'
+    }
+  }, {
+    side: 'right',
+    size: 'xl',
+    class: {
+      content: 'max-w-3/4'
+    }
+  },
+  // Size variants for top/bottom sides (height)
+  {
+    side: 'top',
+    size: 'xs',
+    class: {
+      content: 'max-h-48'
+    }
+  }, {
+    side: 'top',
+    size: 'sm',
+    class: {
+      content: 'max-h-64'
+    }
+  }, {
+    side: 'top',
+    size: 'md',
+    class: {
+      content: 'max-h-96'
+    }
+  }, {
+    side: 'top',
+    size: 'lg',
+    class: {
+      content: 'max-h-1/2'
+    }
+  }, {
+    side: 'top',
+    size: 'xl',
+    class: {
+      content: 'max-h-3/4'
+    }
+  }, {
+    side: 'bottom',
+    size: 'xs',
+    class: {
+      content: 'max-h-48'
+    }
+  }, {
+    side: 'bottom',
+    size: 'sm',
+    class: {
+      content: 'max-h-64'
+    }
+  }, {
+    side: 'bottom',
+    size: 'md',
+    class: {
+      content: 'max-h-96'
+    }
+  }, {
+    side: 'bottom',
+    size: 'lg',
+    class: {
+      content: 'max-h-1/2'
+    }
+  }, {
+    side: 'bottom',
+    size: 'xl',
+    class: {
+      content: 'max-h-3/4'
+    }
+  },
+  // Fullscreen variants (override size)
+  {
+    side: 'left',
+    fullscreen: true,
+    class: {
+      content: 'max-w-full'
+    }
+  }, {
+    side: 'right',
+    fullscreen: true,
+    class: {
+      content: 'max-w-full'
+    }
+  }, {
+    side: 'top',
+    fullscreen: true,
+    class: {
+      content: 'max-h-full'
+    }
+  }, {
+    side: 'bottom',
+    fullscreen: true,
+    class: {
+      content: 'max-h-full'
+    }
+  }],
+  defaultVariants: {
+    side: 'right',
+    size: 'md',
+    fullscreen: false
+  }
 }


### PR DESCRIPTION
### ❓ Type of change

Add `fullscreen` and `size` props to slideover

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I added a new prop similar to Modal and Button, which adds support for different sizes and a fullscreen variant of the slideover.
It could be overwritten individually, but I work on a project that requires different "standard" sizes of slideovers based on context. With this feature, users can create an always fullscreen slideover, similar to fullscreen Modal, or set different sizes easily.
It follows standard definition so you can use variants/compound variants or just do not specify these new props at all for standard look.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
