### PR TITLE
docs(code-group): update example with new icon syntax

### DIFF
--- a/docs/content/docs/4.typography/code-group.md
+++ b/docs/content/docs/4.typography/code-group.md
@@ -1,6 +1,6 @@
 ---
 title: CodeGroup
-description: 'Group multiple code examples in tabbed interfaces for easy comparison.'
+description: "Group multiple code examples in tabbed interfaces for easy comparison."
 framework: nuxt
 category: components
 links:
@@ -13,7 +13,7 @@ links:
 
 Wrap your code blocks around a `code-group` component to group them together in tabs.
 
-::code-preview{class="[&>div]:*:my-0 [&>div]:*:w-full"}
+::code-preview{class="[&>div]:_:my-0 [&>div]:_:w-full"}
 
 :::code-group
 
@@ -63,6 +63,46 @@ bun add @nuxt/ui
 
 ::note{to="/docs/typography/code#code-blocks"}
 Like the `ProsePre` component, the `CodeGroup` handles filenames, icons and copy button.
+::
+
+## Icon Position
+
+Use the `iconPosition` attribute to position the icon on the right side of the label.
+
+::code-preview{class="[&>div]:_:my-0 [&>div]:_:w-full"}
+
+:::code-group
+
+```ts [Script|logos:typescript|right]
+console.log("Hello World");
+```
+
+```vue [Component|logos:vue]
+<template>
+  <h1>Hello World</h1>
+</template>
+```
+
+:::
+
+#code
+
+````mdc
+::code-group
+
+```ts [Script|logos:typescript|right]
+console.log('Hello World')
+```
+
+```vue [Component|logos:vue]
+<template>
+  <h1>Hello World</h1>
+</template>
+```
+
+::
+````
+
 ::
 
 ## API

--- a/src/runtime/components/prose/CodeGroup.vue
+++ b/src/runtime/components/prose/CodeGroup.vue
@@ -49,6 +49,7 @@ const items = computed<{
   index: number
   label: string
   icon: string
+  iconPosition: string
   component: any
 }[]>(() => {
   // eslint-disable-next-line @typescript-eslint/no-unused-expressions
@@ -64,6 +65,7 @@ function transformSlot(slot: any, index: number) {
   return {
     label: slot.props?.filename || slot.props?.label || `${index}`,
     icon: slot.props?.icon,
+    iconPosition: slot.props?.iconPosition,
     component: slot
   }
 }
@@ -97,9 +99,11 @@ onBeforeUpdate(() => rerenderCount.value++)
       <TabsIndicator :class="ui.indicator({ class: props.ui?.indicator })" />
 
       <TabsTrigger v-for="(item, index) of items" :key="index" :value="String(index)" :class="ui.trigger({ class: props.ui?.trigger })">
-        <UCodeIcon :icon="item.icon" :filename="item.label" :class="ui.triggerIcon({ class: props.ui?.triggerIcon })" />
+        <UCodeIcon v-if="item.iconPosition !== 'right'" :icon="item.icon" :filename="item.label" :class="ui.triggerIcon({ class: props.ui?.triggerIcon })" />
 
         <span :class="ui.triggerLabel({ class: props.ui?.triggerLabel })">{{ item.label }}</span>
+
+        <UCodeIcon v-if="item.iconPosition === 'right'" :icon="item.icon" :filename="item.label" :class="ui.triggerIcon({ class: props.ui?.triggerIcon })" />
       </TabsTrigger>
     </TabsList>
 


### PR DESCRIPTION
📚 Description
This PR adds support for displaying icons in 
CodeGroup
 tabs using the new metadata syntax [filename|icon|position].

⚠️ Dependency: This feature relies on parser changes introduced in [nuxt-content/mdc#462](https://github.com/nuxt-content/mdc/pull/462). The functionality will fully work once that PR is merged and @nuxtjs/mdc is updated.

Changes:


- Updated 
CodeGroup.vue
 to handle icon and iconPosition props.

- Updated documentation with examples demonstrating the new icon syntax using TypeScript and Vue code blocks.