### PR TITLE
feat(InputMenu/SelectMenu): don't show ComboboxEmpty when loading is true

### DIFF
--- a/docs/app/components/content/examples/input-menu/InputMenuInfiniteScrollExample.vue
+++ b/docs/app/components/content/examples/input-menu/InputMenuInfiniteScrollExample.vue
@@ -51,6 +51,7 @@ onMounted(() => {
 <template>
   <UInputMenu
     ref="inputMenu"
+    :loading="status === 'pending'"
     placeholder="Select user"
     :items="users"
   />

--- a/docs/app/components/content/examples/select-menu/SelectMenuInfiniteScrollExample.vue
+++ b/docs/app/components/content/examples/select-menu/SelectMenuInfiniteScrollExample.vue
@@ -51,6 +51,7 @@ onMounted(() => {
 <template>
   <USelectMenu
     ref="selectMenu"
+    :loading="status === 'pending'"
     placeholder="Select user"
     :items="users"
   />

--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -665,7 +665,7 @@ defineExpose({
       <ComboboxContent data-slot="content" :class="ui.content({ class: props.ui?.content })" v-bind="contentProps" @focus-outside.prevent>
         <slot name="content-top" />
 
-        <ComboboxEmpty data-slot="empty" :class="ui.empty({ class: props.ui?.empty })">
+        <ComboboxEmpty v-if="!props.loading" data-slot="empty" :class="ui.empty({ class: props.ui?.empty })">
           <slot name="empty" :search-term="searchTerm">
             {{ searchTerm ? t('inputMenu.noMatch', { searchTerm }) : t('inputMenu.noData') }}
           </slot>

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -620,7 +620,7 @@ defineExpose({
             />
           </ComboboxInput>
 
-          <ComboboxEmpty data-slot="empty" :class="ui.empty({ class: props.ui?.empty })">
+          <ComboboxEmpty v-if="!props.loading" data-slot="empty" :class="ui.empty({ class: props.ui?.empty })">
             <slot name="empty" :search-term="searchTerm">
               {{ searchTerm ? t('selectMenu.noMatch', { searchTerm }) : t('selectMenu.noData') }}
             </slot>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

https://github.com/user-attachments/assets/7238a3eb-35bc-4305-a59e-22f24c4638cd

Currently, when there is no data but being fetched and you open the InputMenu for example the ComboboxEmpty displays and then after the data is displayed.
 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
