### PR TITLE
docs(mcp): add Gemini CLI setup instructions

### DIFF
--- a/docs/content/docs/1.getting-started/7.ai/1.mcp.md
+++ b/docs/content/docs/1.getting-started/7.ai/1.mcp.md
@@ -184,24 +184,20 @@ Or manually create/update `.cursor/mcp.json` in your project root:
 
 #### Setup Instructions:
 
-1. Locate your Gemini CLI configuration file (usually ~/.gemini/config.json or as specified in your environment).
+1. Locate your Gemini CLI configuration file (usually ~/.gemini/settings.json or as specified in your environment).
 2. Add the following configuration to your mcpServers object:
 
 ```json
 {
   "mcpServers": {
     "nuxt-ui": {
-        "command": "npx",
-        "args": [
-            "mcp-remote",
-            "https://ui.nuxt.com/mcp"
-        ]
+        "url": "https://ui.nuxt.com/mcp"
     }
   }
 }
 ```
 
-5. Restart your terminal session or reload the CLI. The Nuxt UI MCP server tools will now be available for use.
+3. Restart your terminal session or reload the CLI. The Nuxt UI MCP server tools will now be available for use.
 
 ### Le Chat Mistral
 

--- a/docs/content/docs/1.getting-started/7.ai/1.mcp.md
+++ b/docs/content/docs/1.getting-started/7.ai/1.mcp.md
@@ -71,17 +71,17 @@ The Nuxt UI MCP server uses HTTP transport and can be configured in different AI
 ### ChatGPT
 
 ::note{icon="i-lucide-info"}
-**Custom connectors using MCP are available on ChatGPT for Pro and Plus accounts** on the web.
+**Custom connectors using MCP are available on ChatGPT for Pro and Plus accounts.** Accessible on the web.
 ::
 
 Follow these steps to set up Nuxt UI as a connector within ChatGPT:
 
 1. **Enable Developer mode:**
-   - Go to Settings → Connectors → Advanced settings → Developer mode
+   - Go to "Settings" > "Connectors" > "Advanced settings" > "Developer mode"
 
 2. **Open ChatGPT settings**
 
-3. **In the Connectors tab, Create a new connector:**
+3. **In the Connectors tab, create a new connector:**
    - Give it a name: `Nuxt UI`
    - MCP server URL: `https://ui.nuxt.com/mcp`
    - Authentication: `None`
@@ -93,7 +93,7 @@ The Nuxt UI connector will appear in the composer's "Developer mode" tool later 
 ### Claude Code
 
 ::note{icon="i-lucide-info"}
-**Ensure Claude Code is installed** - Visit [Anthropic's documentation](https://docs.anthropic.com/en/docs/claude-code/quickstart) for installation instructions.
+**Ensure Claude Code is installed.** Visit [Anthropic's documentation](https://docs.anthropic.com/en/docs/claude-code/quickstart) for installation instructions.
 ::
 
 Add the server using the CLI command:
@@ -191,7 +191,7 @@ Or manually create/update `.cursor/mcp.json` in your project root:
 {
   "mcpServers": {
     "nuxt-ui": {
-        "url": "https://ui.nuxt.com/mcp"
+      "url": "https://ui.nuxt.com/mcp"
     }
   }
 }
@@ -206,13 +206,13 @@ Or manually create/update `.cursor/mcp.json` in your project root:
 1. Navigate to "Intelligence" > "Connectors"
 2. Click on "Add Connector" button, then select "Custom MCP Connector"
 3. Create your Custom MCP Connector:
-    - Connector Name : `NuxtUI`
-    - Connector Server : `https://ui.nuxt.com/mcp`
+    - Connector Name: `NuxtUI`
+    - Connector Server: `https://ui.nuxt.com/mcp`
 
 ### Visual Studio Code
 
 ::note{icon="i-lucide-info"}
-**Install required extensions** - Ensure you have [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) and [GitHub Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) extensions installed.
+**Install required extensions.** Ensure you have [GitHub Copilot](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot) and [GitHub Copilot Chat](https://marketplace.visualstudio.com/items?itemName=GitHub.copilot-chat) extensions installed.
 ::
 
 #### Setup Instructions:
@@ -288,7 +288,7 @@ Or manually create/update `.cursor/mcp.json` in your project root:
       "type": "remote",
       "url": "https://ui.nuxt.com/mcp",
       "enabled": true
-    },
+    }
   }
 }
 ```
@@ -296,7 +296,7 @@ Or manually create/update `.cursor/mcp.json` in your project root:
 ### GitHub Copilot Agent
 
 ::note{icon="i-lucide-info"}
-**Repository administrator access required** to configure MCP servers for GitHub Copilot coding agent.
+**Repository administrator access required.** This is needed to configure MCP servers for GitHub Copilot coding agent.
 ::
 
 If you have already configured MCP servers in VS Code (replace the `servers` key with `mcpServers` for GitHub Copilot Agent), you can leverage a similar configuration for GitHub Copilot coding agent. You will need to add a `tools` key specifying which tools are available to Copilot.

--- a/docs/content/docs/1.getting-started/7.ai/1.mcp.md
+++ b/docs/content/docs/1.getting-started/7.ai/1.mcp.md
@@ -180,6 +180,29 @@ Or manually create/update `.cursor/mcp.json` in your project root:
 
 5. Return to the "Manage MCP Servers" tab and click "Refresh". The Nuxt UI MCP server should now appear.
 
+### Gemini CLI
+
+#### Setup Instructions:
+
+1. Locate your Gemini CLI configuration file (usually ~/.gemini/config.json or as specified in your environment).
+2. Add the following configuration to your mcpServers object:
+
+```json
+{
+  "mcpServers": {
+    "nuxt-ui": {
+        "command": "npx",
+        "args": [
+            "mcp-remote",
+            "https://ui.nuxt.com/mcp"
+        ]
+    }
+  }
+}
+```
+
+5. Restart your terminal session or reload the CLI. The Nuxt UI MCP server tools will now be available for use.
+
 ### Le Chat Mistral
 
 #### Setup Instructions:


### PR DESCRIPTION
Added setup instructions for Gemini CLI and Nuxt UI MCP server.
