### PR TITLE
docs(toast): add HTML content example

### DIFF
--- a/docs/app/components/content/examples/toast/ToastHtmlExample.vue
+++ b/docs/app/components/content/examples/toast/ToastHtmlExample.vue
@@ -3,13 +3,17 @@ const toast = useToast()
 
 function showToast() {
   toast.add({
-    title: 'Item Deleted',
-    description: h('span', {}, [
-      'You have successfully deleted the item ',
+    title: h('span', {}, [
+      'Item ',
       h('span', { class: 'text-primary font-bold' }, '#15'),
-      ' from your account.'
+      ' deleted'
     ]),
-    icon: 'i-lucide-delete'
+    description: h('span', {}, [
+      'You have successfully deleted the item from your ',
+      h('span', { class: 'font-bold' }, 'account'),
+      '.'
+    ]),
+    icon: 'i-lucide-trash-2'
   })
 }
 </script>

--- a/docs/app/components/content/examples/toast/ToastHtmlExample.vue
+++ b/docs/app/components/content/examples/toast/ToastHtmlExample.vue
@@ -1,0 +1,19 @@
+<script setup lang="ts">
+const toast = useToast()
+
+function showToast() {
+  toast.add({
+    title: 'Item Deleted',
+    description: h('span', {}, [
+      'You have successfully deleted the item ',
+      h('span', { class: 'text-primary font-bold' }, '#15'),
+      ' from your account.'
+    ]),
+    icon: 'i-lucide-delete'
+  })
+}
+</script>
+
+<template>
+  <UButton label="Show toast" color="neutral" variant="outline" @click="showToast" />
+</template>

--- a/docs/content/docs/2.components/toast.md
+++ b/docs/content/docs/2.components/toast.md
@@ -338,7 +338,7 @@ name: 'toast-callback-example'
 
 ### With HTML content
 
-Define the toast description using the [h() Vue.js render function](https://vuejs.org/api/render-function.html#h). Use custom HTML elements or Vue components, and set custom props such as classes or component props.
+Use the [`h()` render function](https://vuejs.org/api/render-function.html#h) in the `title` or `description` fields to render HTML elements or Vue components with custom styling.
 
 ::component-example
 ---

--- a/docs/content/docs/2.components/toast.md
+++ b/docs/content/docs/2.components/toast.md
@@ -336,6 +336,17 @@ name: 'toast-callback-example'
 ---
 ::
 
+### With HTML content
+
+Define the toast description using the [h() Vue.js render function](https://vuejs.org/api/render-function.html#h). Use custom HTML elements or Vue components, and set custom props such as classes or component props.
+
+::component-example
+---
+collapse: true
+name: 'toast-html-example'
+---
+::
+
 ## API
 
 ### Props


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I had some time searching how to use HTML with toasts, and I ended up finding the issue https://github.com/nuxt/ui/issues/3226. As suggested there, this PR adds an example in the docs of using HTML on toasts content.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
