### PR TITLE
fix(ChatMessages): allow message props to override role defaults

### DIFF
--- a/src/runtime/components/ChatMessages.vue
+++ b/src/runtime/components/ChatMessages.vue
@@ -296,7 +296,7 @@ onMounted(() => {
       <UChatMessage
         v-for="message in messages"
         :key="message.id"
-        v-bind="{ ...message, ...(message.role === 'user' ? userProps : assistantProps) }"
+        v-bind="{ ...(message.role === 'user' ? userProps : assistantProps), ...message }"
         :ref="(el) => registerMessageRef(message.id, el as ComponentPublicInstance)"
         :compact="compact"
       >


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Hello! When I was using the `ChatMessages` component, I found that the `message.variant` passed in could not be correctly modified. I discovered that this was caused by the fact that `user` and `assistant` have default values and have a higher priority (which would override the value of `message`). I understand that the coverage of user and assistant can, to some extent, unify the style. However, in actual usage, I think allowing the value of `message` to override `user` and `assistant` would be a better choice, as it enables us to further customize the styles of different `ChatMessage` based on the `message`.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
