### PR TITLE
feat(Form): add HTML5 validation to programmatic submit

### DIFF
--- a/docs/app/components/content/examples/form/FormExampleHtml5Validation.vue
+++ b/docs/app/components/content/examples/form/FormExampleHtml5Validation.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import type { FormSubmitEvent } from '@nuxt/ui'
+
+const state = reactive({
+  email: undefined,
+  age: undefined
+})
+
+type Schema = typeof state
+
+const form = useTemplateRef('form')
+
+const toast = useToast()
+async function onSubmit(event: FormSubmitEvent<Schema>) {
+  toast.add({ title: 'Success', description: 'The form has been submitted.', color: 'success' })
+  console.log(event.data)
+}
+</script>
+
+<template>
+  <div class="space-y-4">
+    <UForm ref="form" :state="state" class="space-y-4" @submit="onSubmit">
+      <UFormField label="Email" name="email">
+        <UInput v-model="state.email" type="email" required />
+      </UFormField>
+
+      <UFormField label="Age" name="age">
+        <UInput v-model="state.age" type="number" min="18" max="100" required />
+      </UFormField>
+    </UForm>
+
+    <UButton @click="form?.submit()">
+      Submit
+    </UButton>
+  </div>
+</template>

--- a/docs/content/docs/2.components/form.md
+++ b/docs/content/docs/2.components/form.md
@@ -159,8 +159,16 @@ props:
 
 When calling `form.submit()` programmatically, the Form component automatically triggers native HTML5 validation before submission.
 
-::tip
+::note
 This is particularly useful when the submit button is outside the form element, such as in a modal footer.
+::
+
+::component-example
+---
+name: 'form-example-html5-validation'
+props:
+  class: 'w-60'
+---
 ::
 
 ### Nesting forms

--- a/docs/content/docs/2.components/form.md
+++ b/docs/content/docs/2.components/form.md
@@ -155,6 +155,14 @@ props:
 ---
 ::
 
+### HTML5 validation
+
+When calling `form.submit()` programmatically, the Form component automatically triggers native HTML5 validation before submission.
+
+::tip
+This is particularly useful when the submit button is outside the form element, such as in a modal footer.
+::
+
 ### Nesting forms
 
 Use the `nested` prop to nest multiple Form components and link their validation functions. In this case, validating the parent form will automatically validate all the other forms inside it.
@@ -215,11 +223,11 @@ This will give you access to the following:
 
 | Name | Type |
 | ---- | ---- |
-| `submit()`{lang="ts-type"} | `Promise<void>`{lang="ts-type"} <br> <div class="text-toned mt-1"><p>Triggers form submission.</p> |
-| `validate(opts: { name?: keyof T \| (keyof T)[], silent?: boolean, nested?: boolean, transform?: boolean })`{lang="ts-type"} | `Promise<T>`{lang="ts-type"} <br> <div class="text-toned mt-1"><p>Triggers form validation. Will raise any errors unless `opts.silent` is set to true.</p> |
+| `submit()`{lang="ts-type"} | `Promise<void>`{lang="ts-type"} <br> <div class="text-toned mt-1"><p>Triggers form submission with HTML5 validation.</p></div> |
+| `validate(opts: { name?: keyof T \| (keyof T)[], silent?: boolean, nested?: boolean, transform?: boolean })`{lang="ts-type"} | `Promise<T>`{lang="ts-type"} <br> <div class="text-toned mt-1"><p>Triggers form validation. Will raise any errors unless `opts.silent` is set to true.</p></div> |
 | `clear(path?: keyof T \| RegExp)`{lang="ts-type"} | `void` <br> <div class="text-toned mt-1"><p>Clears form errors associated with a specific path. If no path is provided, clears all form errors.</p></div> |
-| `getErrors(path?: keyof T RegExp)`{lang="ts-type"} | `FormError[]`{lang="ts-type"} <br> <div class="text-toned mt-1"><p>Retrieves form errors associated with a specific path. If no path is provided, returns all form errors.</p></div> |
-| `setErrors(errors: FormError[], name?: keyof T RegExp)`{lang="ts-type"} | `void` <br> <div class="text-toned mt-1"><p>Sets form errors for a given path. If no path is provided, overrides all errors.</p></div> |
+| `getErrors(path?: keyof T \| RegExp)`{lang="ts-type"} | `FormError[]`{lang="ts-type"} <br> <div class="text-toned mt-1"><p>Retrieves form errors associated with a specific path. If no path is provided, returns all form errors.</p></div> |
+| `setErrors(errors: FormError[], name?: keyof T \| RegExp)`{lang="ts-type"} | `void` <br> <div class="text-toned mt-1"><p>Sets form errors for a given path. If no path is provided, overrides all errors.</p></div> |
 | `errors`{lang="ts-type"} | `Ref<FormError[]>`{lang="ts-type"} <br> <div class="text-toned mt-1"><p>A reference to the array containing validation errors. Use this to access or manipulate the error information.</p></div> |
 | `disabled`{lang="ts-type"} | `Ref<boolean>`{lang="ts-type"} |
 | `dirty`{lang="ts-type"} | `Ref<boolean>`{lang="ts-type"} `true` if at least one form field has been updated by the user. |

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -106,6 +106,7 @@ const uiProp = useComponentUI('form', props)
 const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.form || {}) }))
 
 const formId = props.id ?? useId() as string
+const formEl = ref<HTMLElement>()
 
 const bus = useEventBus<FormEvent<I>>(`form-${formId}`)
 
@@ -403,6 +404,9 @@ const api = {
   },
 
   async submit() {
+    if (formEl.value instanceof HTMLFormElement && formEl.value.reportValidity() === false) {
+      return
+    }
     await onSubmitWrapper(new Event('submit'))
   },
 
@@ -452,6 +456,7 @@ defineExpose(api)
   <component
     :is="parentBus ? 'div' : 'form'"
     :id="formId"
+    ref="formEl"
     :class="ui({ class: [uiProp?.base, props.class] })"
     @submit.prevent="onSubmitWrapper"
   >

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -75,7 +75,7 @@ export interface FormSlots {
 </script>
 
 <script lang="ts" setup generic="S extends FormSchema, T extends boolean = true, N extends boolean = false">
-import { provide, inject, nextTick, ref, onUnmounted, onMounted, computed, useId, readonly, reactive } from 'vue'
+import { provide, inject, nextTick, ref, onUnmounted, onMounted, computed, useId, readonly, reactive, useTemplateRef } from 'vue'
 import { useEventBus } from '@vueuse/core'
 import { useAppConfig } from '#imports'
 import { formOptionsInjectionKey, formInputsInjectionKey, formBusInjectionKey, formLoadingInjectionKey, formErrorsInjectionKey, formStateInjectionKey } from '../composables/useFormField'
@@ -106,7 +106,7 @@ const uiProp = useComponentUI('form', props)
 const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.form || {}) }))
 
 const formId = props.id ?? useId() as string
-const formEl = ref<HTMLElement>()
+const formRef = useTemplateRef('formRef')
 
 const bus = useEventBus<FormEvent<I>>(`form-${formId}`)
 
@@ -404,9 +404,10 @@ const api = {
   },
 
   async submit() {
-    if (formEl.value instanceof HTMLFormElement && formEl.value.reportValidity() === false) {
+    if (formRef.value instanceof HTMLFormElement && formRef.value.reportValidity() === false) {
       return
     }
+
     await onSubmitWrapper(new Event('submit'))
   },
 
@@ -456,7 +457,7 @@ defineExpose(api)
   <component
     :is="parentBus ? 'div' : 'form'"
     :id="formId"
-    ref="formEl"
+    ref="formRef"
     :class="ui({ class: [uiProp?.base, props.class] })"
     @submit.prevent="onSubmitWrapper"
   >

--- a/test/components/Form.spec.ts
+++ b/test/components/Form.spec.ts
@@ -644,11 +644,10 @@ describe('Form', () => {
   describe('HTML5 validation', () => {
     it('programmatic submit() triggers HTML5 validation and prevents submission when invalid', async () => {
       const onSubmit = vi.fn()
-      const onInvalid = vi.fn()
 
       const wrapper = await renderForm({
         fixture: 'FormHtml5Validation',
-        props: { onSubmit, onInvalid }
+        props: { onSubmit }
       })
 
       const form = wrapper.setupState.form.value
@@ -657,20 +656,16 @@ describe('Form', () => {
       await form.submit()
       await flushPromises()
 
-      // Verify native HTML5 invalid event was emitted
-      expect(onInvalid).toHaveBeenCalled()
-
-      // Verify form submission was prevented
+      // Verify form submission was prevented by HTML5 validation
       expect(onSubmit).not.toHaveBeenCalled()
     })
 
     it('programmatic submit() proceeds when HTML5 validation passes', async () => {
       const onSubmit = vi.fn()
-      const onInvalid = vi.fn()
 
       const wrapper = await renderForm({
         fixture: 'FormHtml5Validation',
-        props: { onSubmit, onInvalid }
+        props: { onSubmit }
       })
 
       const form = wrapper.setupState.form.value
@@ -685,9 +680,6 @@ describe('Form', () => {
       // Call submit() programmatically
       await form.submit()
       await flushPromises()
-
-      // Verify no native invalid event was emitted
-      expect(onInvalid).not.toHaveBeenCalled()
 
       // Verify form submission proceeded
       expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({

--- a/test/components/Form.spec.ts
+++ b/test/components/Form.spec.ts
@@ -640,4 +640,94 @@ describe('Form', () => {
     expect(wrapper.html()).toContain('Error on field2')
     expect(wrapper.html()).toContain('General error')
   })
+
+  describe('HTML5 validation', () => {
+    it('programmatic submit() triggers HTML5 validation and prevents submission when invalid', async () => {
+      const onSubmit = vi.fn()
+      const onInvalid = vi.fn()
+
+      const wrapper = await renderForm({
+        fixture: 'FormHtml5Validation',
+        props: { onSubmit, onInvalid }
+      })
+
+      const form = wrapper.setupState.form.value
+
+      // Call submit() programmatically (simulates usage in modals with footer buttons)
+      await form.submit()
+      await flushPromises()
+
+      // Verify native HTML5 invalid event was emitted
+      expect(onInvalid).toHaveBeenCalled()
+
+      // Verify form submission was prevented
+      expect(onSubmit).not.toHaveBeenCalled()
+    })
+
+    it('programmatic submit() proceeds when HTML5 validation passes', async () => {
+      const onSubmit = vi.fn()
+      const onInvalid = vi.fn()
+
+      const wrapper = await renderForm({
+        fixture: 'FormHtml5Validation',
+        props: { onSubmit, onInvalid }
+      })
+
+      const form = wrapper.setupState.form.value
+      const state = wrapper.setupState.state
+
+      // Set valid values
+      state.email = 'test@example.com'
+      state.age = '25'
+      state.username = 'validuser'
+      await nextTick()
+
+      // Call submit() programmatically
+      await form.submit()
+      await flushPromises()
+
+      // Verify no native invalid event was emitted
+      expect(onInvalid).not.toHaveBeenCalled()
+
+      // Verify form submission proceeded
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        data: {
+          email: 'test@example.com',
+          age: '25',
+          username: 'validuser'
+        }
+      }))
+    })
+
+    it('handles nested forms gracefully (renders as div, no HTML5 validation)', async () => {
+      const onSubmit = vi.fn()
+      // Create a nested form scenario
+      const wrapper = await renderForm({
+        fixture: 'FormNested',
+        props: { onSubmit }
+      })
+
+      const form = wrapper.setupState.form.value
+      const state = wrapper.setupState.state
+
+      // Set valid values for all fields
+      state.email = 'test@example.com'
+      state.password = 'strongpassword'
+      state.nested = { field: 'value' }
+
+      // Nested forms render as divs, so reportValidity should not be called
+      // and submit should work normally
+      await form.submit()
+      await flushPromises()
+
+      // Verify form submission proceeded (no HTML5 validation on div elements)
+      expect(onSubmit).toHaveBeenCalledWith(expect.objectContaining({
+        data: {
+          email: 'test@example.com',
+          password: 'strongpassword',
+          nested: { field: 'value' }
+        }
+      }))
+    })
+  })
 })

--- a/test/components/fixtures/FormHtml5Validation.vue
+++ b/test/components/fixtures/FormHtml5Validation.vue
@@ -1,0 +1,34 @@
+<script setup lang="ts">
+import { reactive, useTemplateRef } from 'vue'
+import { UFormField, UInput, UForm } from '#components'
+
+interface FormState {
+  email?: string
+  age?: string
+  username?: string
+}
+
+const state = reactive<FormState>({})
+const form = useTemplateRef('form')
+</script>
+
+<template>
+  <UForm ref="form" :state="state" v-bind="$attrs">
+    <UFormField id="emailField" name="email">
+      <UInput id="email" v-model="state.email" type="email" required />
+    </UFormField>
+    <UFormField id="ageField" name="age">
+      <UInput
+        id="age"
+        v-model="state.age"
+        type="number"
+        min="18"
+        max="100"
+        required
+      />
+    </UFormField>
+    <UFormField id="usernameField" name="username">
+      <UInput id="username" v-model="state.username" minlength="3" maxlength="20" required />
+    </UFormField>
+  </UForm>
+</template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #5139

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When calling `form.submit()` programmatically, the form now triggers native HTML5 validation (required, type, min, max, etc.) before submission. If validation fails, submission is prevented and browser validation messages are displayed.

This is particularly useful when the submit button is outside the form element, such as in modal footers.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

### 💡 Notes

This adds an inner template ref within the `UForm` component. I could instead use `document.getElementById()`, but then the tests wouldn't work because the fixture mount helper doesn't actually insert the mounted component into `document.body`. I could rework the helper to address that, but the template ref approach seemed cleaner as it introduced less coupling overall.

EDIT: As suggested by coderabbit, this also fixes nearby documentation formatting errors (not directly affected by the PR).