### PR TITLE
fix(BlogPost/ChangelogVersion): use `ImgHTMLAttributes` type for image prop

### DIFF
--- a/src/runtime/components/BlogPost.vue
+++ b/src/runtime/components/BlogPost.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
 import type { AppConfig } from '@nuxt/schema'
-import type { ImgHTMLAttributes } from '../types/html'
 import theme from '#build/ui/blog-post'
 import type { BadgeProps, LinkProps, UserProps } from '../types'
+import type { ImgHTMLAttributes } from '../types/html'
 import type { ComponentConfig } from '../types/tv'
 
 type BlogPost = ComponentConfig<typeof theme, AppConfig, 'blogPost'>

--- a/src/runtime/components/BlogPost.vue
+++ b/src/runtime/components/BlogPost.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { AppConfig } from '@nuxt/schema'
-import type { ImgHTMLAttributes as VueImgHTMLAttributes } from 'vue'
+import type { ImgHTMLAttributes } from '../types/html'
 import theme from '#build/ui/blog-post'
 import type { BadgeProps, LinkProps, UserProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
@@ -26,7 +26,7 @@ export interface BlogPostProps {
   /** The authors of the blog post. */
   authors?: UserProps[]
   /** The image of the blog post. Can be a string or an object. */
-  image?: string | (Partial<VueImgHTMLAttributes> & { [key: string]: any })
+  image?: string | (Partial<ImgHTMLAttributes> & { [key: string]: any })
   /**
    * The orientation of the blog post.
    * @defaultValue 'vertical'

--- a/src/runtime/components/BlogPost.vue
+++ b/src/runtime/components/BlogPost.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { AppConfig } from '@nuxt/schema'
+import type { ImgHTMLAttributes as VueImgHTMLAttributes } from 'vue'
 import theme from '#build/ui/blog-post'
 import type { BadgeProps, LinkProps, UserProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
@@ -25,7 +26,7 @@ export interface BlogPostProps {
   /** The authors of the blog post. */
   authors?: UserProps[]
   /** The image of the blog post. Can be a string or an object. */
-  image?: string | (Partial<HTMLImageElement> & { [key: string]: any })
+  image?: string | (Partial<VueImgHTMLAttributes> & { [key: string]: any })
   /**
    * The orientation of the blog post.
    * @defaultValue 'vertical'

--- a/src/runtime/components/ChangelogVersion.vue
+++ b/src/runtime/components/ChangelogVersion.vue
@@ -1,8 +1,8 @@
 <script lang="ts">
 import type { AppConfig } from '@nuxt/schema'
-import type { ImgHTMLAttributes } from '../types/html'
 import theme from '#build/ui/changelog-version'
 import type { BadgeProps, LinkProps, UserProps } from '../types'
+import type { ImgHTMLAttributes } from '../types/html'
 import type { ComponentConfig } from '../types/tv'
 
 type ChangelogVersion = ComponentConfig<typeof theme, AppConfig, 'changelogVersion'>

--- a/src/runtime/components/ChangelogVersion.vue
+++ b/src/runtime/components/ChangelogVersion.vue
@@ -1,6 +1,6 @@
 <script lang="ts">
 import type { AppConfig } from '@nuxt/schema'
-import type { ImgHTMLAttributes as VueImgHTMLAttributes } from 'vue'
+import type { ImgHTMLAttributes } from '../types/html'
 import theme from '#build/ui/changelog-version'
 import type { BadgeProps, LinkProps, UserProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
@@ -26,7 +26,7 @@ export interface ChangelogVersionProps {
   /** The authors of the changelog version. */
   authors?: UserProps[]
   /** The image of the changelog version. Can be a string or an object. */
-  image?: string | (Partial<VueImgHTMLAttributes> & { [key: string]: any })
+  image?: string | (Partial<ImgHTMLAttributes> & { [key: string]: any })
   /**
    * Display an indicator dot on the left.
    * @defaultValue true

--- a/src/runtime/components/ChangelogVersion.vue
+++ b/src/runtime/components/ChangelogVersion.vue
@@ -1,5 +1,6 @@
 <script lang="ts">
 import type { AppConfig } from '@nuxt/schema'
+import type { ImgHTMLAttributes as VueImgHTMLAttributes } from 'vue'
 import theme from '#build/ui/changelog-version'
 import type { BadgeProps, LinkProps, UserProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
@@ -25,7 +26,7 @@ export interface ChangelogVersionProps {
   /** The authors of the changelog version. */
   authors?: UserProps[]
   /** The image of the changelog version. Can be a string or an object. */
-  image?: string | (Partial<HTMLImageElement> & { [key: string]: any })
+  image?: string | (Partial<VueImgHTMLAttributes> & { [key: string]: any })
   /**
    * Display an indicator dot on the left.
    * @defaultValue true


### PR DESCRIPTION
## Summary
- Fixes #5993
- Changes image prop type from `Partial<HTMLImageElement>` to `Partial<VueImgHTMLAttributes>` in BlogPost and ChangelogVersion components

## Changes
Replaced `Partial<HTMLImageElement>` with `Partial<VueImgHTMLAttributes>` (from Vue) for the image property type. This fixes TypeScript errors when using Vue's `StyleValue` type for the style property.

The DOM's `HTMLImageElement.style` type is `CSSStyleDeclaration`, which doesn't match Vue's template expectations. Vue's `ImgHTMLAttributes` properly types the style property as `StyleValue` (string | object | array).

## Before
```typescript
image?: string | (Partial<HTMLImageElement> & { [key: string]: any })
```

Users had to cast:
```typescript
style: {
  '--objectPosition': '50% 50%'
} as unknown as HTMLImageElement['style']
```

## After
```typescript
image?: string | (Partial<VueImgHTMLAttributes> & { [key: string]: any })
```

Now works without casting:
```typescript
style: {
  '--objectPosition': '50% 50%'
}
```

## Testing
TypeScript compilation:
1. Verify the example from issue #5993 no longer requires type casting
2. Verify other image attributes (src, alt, etc.) still work correctly
3. Verify both BlogPost and ChangelogVersion components accept the corrected types