### PR TITLE
docs: strip u prefix from component search

### DIFF
--- a/docs/app/layouts/docs.vue
+++ b/docs/app/layouts/docs.vue
@@ -9,19 +9,24 @@ const { contains } = useFilter({ sensitivity: 'base' })
 const { navigationByCategory } = useNavigation(navigation!)
 
 const filteredNavigation = computed(() => {
-  if (!searchTerm.value) {
+  if (!cleanedSearchTerm.value) {
     return navigationByCategory.value
   }
 
   return navigationByCategory.value.map(item => ({
     ...item,
-    children: item.children?.filter(child => contains(child.title as string, searchTerm.value) || contains(child.description as string, searchTerm.value))
+    children: item.children?.filter(child => contains(child.title as string, cleanedSearchTerm.value) || contains(child.description as string, cleanedSearchTerm.value))
   })).filter(item => item.children && item.children.length > 0)
 })
 
 const searchTerm = ref('')
 const isSearchActive = computed(() => route.path.startsWith('/docs/components'))
 const navigationKey = computed(() => `${route.path}-${searchTerm.value ? 'filtered' : 'unfiltered'}`)
+const cleanedSearchTerm = computed(() => {
+  return searchTerm.value
+    .replace(/^U(?=[A-Z])/, '')
+    .replace(/^u-/, '')
+})
 
 watch(() => route.path, () => {
   if (!isSearchActive.value) {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

_I didn't want to create an issue for this to prevent spam, when I should create one nevertheless, please let me know._

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This changes a small behavior in the search, where when I e.g. search for "UApp" or "u-app" I get no results. 
This by itself is not that big of a deal, but it prevents one from copying the component name from the source code and pasting it into the search. 
Not sure if that's just me, but I stumbled over this multiple times in the past 😉

Now whenever there is a "U", "U-", "u" or "u-" prefixing a search term it gets trimmed so e.G. "UApp" is treated the same as "App".  
This applies only when it prefixes anything, so I still can search for "U/u" or "U-/u-" is one prefers to do so. 

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
