### PR TITLE
fix(Table): improve perfs with `shallowRef` when watch deep is disabled

### DIFF
--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -137,12 +137,6 @@ export interface TableProps<T extends TableData = TableData> extends TableOption
    */
   loadingAnimation?: Table['variants']['loadingAnimation']
   /**
-   * Whether to use shallow data for the table.
-   * @see [API](https://vueuse.org/shared/createRef/#usage)
-   * @defaultValue false
-   */
-  shallowData?: boolean
-  /**
    * Use the `watchOptions` prop to customize reactivity (for ex: disable deep watching for changes in your data or limiting the max traversal depth). This can improve performance by reducing unnecessary re-renders, but it should be used with caution as it may lead to unexpected behavior if not managed properly.
    * @see [API](https://vuejs.org/api/options-state.html#watch)
    * @see [Guide](https://vuejs.org/guide/essentials/watchers.html)
@@ -256,7 +250,7 @@ const slots = defineSlots<TableSlots<T>>()
 const { t } = useLocale()
 const appConfig = useAppConfig() as Table['AppConfig']
 
-const data = createRef(props.data ?? [], !props.shallowData)
+const data = createRef(props.data ?? [], props.watchOptions?.deep !== false)
 const meta = computed(() => props.meta ?? {})
 const columns = computed<TableColumn<T>[]>(() => processColumns(props.columns ?? Object.keys(data.value[0] ?? {}).map((accessorKey: string) => ({ accessorKey, header: upperFirst(accessorKey) }))))
 

--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -256,7 +256,7 @@ const slots = defineSlots<TableSlots<T>>()
 const { t } = useLocale()
 const appConfig = useAppConfig() as Table['AppConfig']
 
-const data = createRef(props.data ?? [], props.shallowData)
+const data = createRef(props.data ?? [], !props.shallowData)
 const meta = computed(() => props.meta ?? {})
 const columns = computed<TableColumn<T>[]>(() => processColumns(props.columns ?? Object.keys(data.value[0] ?? {}).map((accessorKey: string) => ({ accessorKey, header: upperFirst(accessorKey) }))))
 

--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -226,7 +226,7 @@ export type TableSlots<T extends TableData = TableData> = {
 </script>
 
 <script setup lang="ts" generic="T extends TableData">
-import { ref, computed, useTemplateRef, watch, toRef } from 'vue'
+import { shallowRef, computed, useTemplateRef, watch, toRef } from 'vue'
 import { Primitive, useForwardProps } from 'reka-ui'
 import { upperFirst } from 'scule'
 import { defu } from 'defu'
@@ -250,7 +250,7 @@ const slots = defineSlots<TableSlots<T>>()
 const { t } = useLocale()
 const appConfig = useAppConfig() as Table['AppConfig']
 
-const data = ref(props.data ?? []) as Ref<T[]>
+const data = shallowRef(props.data ?? [])
 const meta = computed(() => props.meta ?? {})
 const columns = computed<TableColumn<T>[]>(() => processColumns(props.columns ?? Object.keys(data.value[0] ?? {}).map((accessorKey: string) => ({ accessorKey, header: upperFirst(accessorKey) }))))
 

--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -137,6 +137,12 @@ export interface TableProps<T extends TableData = TableData> extends TableOption
    */
   loadingAnimation?: Table['variants']['loadingAnimation']
   /**
+   * Whether to use shallow data for the table.
+   * @see [API](https://vueuse.org/shared/createRef/#usage)
+   * @defaultValue false
+   */
+  shallowData?: boolean
+  /**
    * Use the `watchOptions` prop to customize reactivity (for ex: disable deep watching for changes in your data or limiting the max traversal depth). This can improve performance by reducing unnecessary re-renders, but it should be used with caution as it may lead to unexpected behavior if not managed properly.
    * @see [API](https://vuejs.org/api/options-state.html#watch)
    * @see [Guide](https://vuejs.org/guide/essentials/watchers.html)
@@ -226,13 +232,13 @@ export type TableSlots<T extends TableData = TableData> = {
 </script>
 
 <script setup lang="ts" generic="T extends TableData">
-import { shallowRef, computed, useTemplateRef, watch, toRef } from 'vue'
+import { computed, useTemplateRef, watch, toRef } from 'vue'
 import { Primitive, useForwardProps } from 'reka-ui'
 import { upperFirst } from 'scule'
 import { defu } from 'defu'
 import { FlexRender, getCoreRowModel, getFilteredRowModel, getSortedRowModel, getExpandedRowModel, useVueTable } from '@tanstack/vue-table'
 import { useVirtualizer } from '@tanstack/vue-virtual'
-import { reactivePick, createReusableTemplate } from '@vueuse/core'
+import { reactivePick, createReusableTemplate, createRef } from '@vueuse/core'
 import { useAppConfig } from '#imports'
 import { useLocale } from '../composables/useLocale'
 import { tv } from '../utils/tv'
@@ -250,7 +256,7 @@ const slots = defineSlots<TableSlots<T>>()
 const { t } = useLocale()
 const appConfig = useAppConfig() as Table['AppConfig']
 
-const data = shallowRef(props.data ?? [])
+const data = createRef(props.data ?? [], props.shallowData)
 const meta = computed(() => props.meta ?? {})
 const columns = computed<TableColumn<T>[]>(() => processColumns(props.columns ?? Object.keys(data.value[0] ?? {}).map((accessorKey: string) => ({ accessorKey, header: upperFirst(accessorKey) }))))
 


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

We have to work with large tables, where we cannot use virtualize, so we often search the page using ctrl+f. Therefore, we are looking for places where we can optimize the code.

In this case, there is no need to use `ref`, `shallowRef` will suffice.

We testing on dev playground:

- Data items `100 000`
- Per page `50`
- Watch options deep `false`
- Client pagination
- SSR `false`
- Mode `prod`

<table>
<tr>
 <td>ref
 <td>shallowRef
<tr>
 <td>
<img width="793" height="644" alt="image" src="https://github.com/user-attachments/assets/2b488693-6c76-4619-a721-35cd1d9faa79" />

 <td>
<img width="793" height="644" alt="image" src="https://github.com/user-attachments/assets/c4d8e401-aa39-48ff-91c1-276755d64cca" />

</table>

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
