### PR TITLE
fix(InputMenu/Select/SelectMenu): exclude cosmetic items from model value type

### DIFF
--- a/src/runtime/components/Input.vue
+++ b/src/runtime/components/Input.vue
@@ -122,11 +122,11 @@ function updateInput(value: string | null | undefined) {
   }
 
   if (props.modelModifiers?.nullable) {
-    value ||= null
+    value ??= null
   }
 
   if (props.modelModifiers?.optional) {
-    value ||= undefined
+    value ??= undefined
   }
 
   modelValue.value = value as T

--- a/src/runtime/components/Input.vue
+++ b/src/runtime/components/Input.vue
@@ -122,11 +122,11 @@ function updateInput(value: string | null | undefined) {
   }
 
   if (props.modelModifiers?.nullable) {
-    value ??= null
+    value ||= null
   }
 
-  if (props.modelModifiers?.optional) {
-    value ??= undefined
+  if (props.modelModifiers?.optional && !props.modelModifiers?.nullable && value !== null) {
+    value ||= undefined
   }
 
   modelValue.value = value as T

--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -34,7 +34,7 @@ export type InputMenuItem = InputMenuValue | {
   [key: string]: any
 }
 
-type ExcludeMenuItem = { type: 'label' | 'separator' }
+type ExcludeItem = { type: 'label' | 'separator' }
 
 export interface InputMenuProps<T extends ArrayOrNested<InputMenuItem> = ArrayOrNested<InputMenuItem>, VK extends GetItemKeys<T> | undefined = undefined, M extends boolean = false> extends Pick<ComboboxRootProps<T>, 'open' | 'defaultOpen' | 'disabled' | 'name' | 'resetSearchTermOnBlur' | 'resetSearchTermOnSelect' | 'resetModelValueOnClear' | 'highlightOnHover' | 'openOnClick' | 'openOnFocus' | 'by'>, UseComponentIconsProps, /** @vue-ignore */ Omit<InputHTMLAttributes, 'disabled' | 'name' | 'type' | 'placeholder' | 'autofocus' | 'maxlength' | 'minlength' | 'pattern' | 'size' | 'min' | 'max' | 'step'> {
   /**
@@ -141,10 +141,10 @@ export interface InputMenuProps<T extends ArrayOrNested<InputMenuItem> = ArrayOr
   descriptionKey?: GetItemKeys<T>
   items?: T
   /** The value of the InputMenu when initially rendered. Use when you do not need to control the state of the InputMenu. */
-  defaultValue?: GetModelValue<T, VK, M, ExcludeMenuItem>
+  defaultValue?: GetModelValue<T, VK, M, ExcludeItem>
   /** The controlled value of the InputMenu. Can be binded-with with `v-model`. */
-  modelValue?: GetModelValue<T, VK, M, ExcludeMenuItem>
-  modelModifiers?: Omit<ModelModifiers<GetModelValue<T, VK, M, ExcludeMenuItem>>, 'lazy'>
+  modelValue?: GetModelValue<T, VK, M, ExcludeItem>
+  modelModifiers?: Omit<ModelModifiers<GetModelValue<T, VK, M, ExcludeItem>>, 'lazy'>
   /** Whether multiple options can be selected or not. */
   multiple?: M & boolean
   /** Highlight the ring color like a focus state. */
@@ -177,10 +177,10 @@ export type InputMenuEmits<A extends ArrayOrNested<InputMenuItem>, VK extends Ge
   /** Event handler when highlighted element changes. */
   'highlight': [payload: {
     ref: HTMLElement
-    value: GetModelValue<A, VK, M, ExcludeMenuItem>
+    value: GetModelValue<A, VK, M, ExcludeItem>
   } | undefined]
-  'remove-tag': [item: GetModelValue<A, VK, M, ExcludeMenuItem>]
-} & GetModelValueEmits<A, VK, M, ExcludeMenuItem>
+  'remove-tag': [item: GetModelValue<A, VK, M, ExcludeItem>]
+} & GetModelValueEmits<A, VK, M, ExcludeItem>
 
 type SlotProps<T extends InputMenuItem> = (props: { item: T, index: number, ui: InputMenu['ui'] }) => any
 
@@ -190,8 +190,8 @@ export interface InputMenuSlots<
   M extends boolean = false,
   T extends NestedItem<A> = NestedItem<A>
 > {
-  'leading'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeMenuItem>, open: boolean, ui: InputMenu['ui'] }): any
-  'trailing'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeMenuItem>, open: boolean, ui: InputMenu['ui'] }): any
+  'leading'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeItem>, open: boolean, ui: InputMenu['ui'] }): any
+  'trailing'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeItem>, open: boolean, ui: InputMenu['ui'] }): any
   'empty'(props: { searchTerm?: string }): any
   'item': SlotProps<T>
   'item-leading': SlotProps<T>
@@ -299,8 +299,8 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.inputMenu ||
 // eslint-disable-next-line vue/no-dupe-keys
 const items = computed(() => groups.value.flatMap(group => group) as T[])
 
-function displayValue(value: GetItemValue<T, VK, ExcludeMenuItem>): string {
-  return getDisplayValue<T[], GetItemValue<T, VK, ExcludeMenuItem>>(items.value, value, {
+function displayValue(value: GetItemValue<T, VK, ExcludeItem>): string {
+  return getDisplayValue<T[], GetItemValue<T, VK, ExcludeItem>>(items.value, value, {
     labelKey: props.labelKey,
     valueKey: props.valueKey,
     by: props.by
@@ -446,10 +446,10 @@ function onUpdateOpen(value: boolean) {
   }
 }
 
-function onRemoveTag(event: any, modelValue: GetModelValue<T, VK, true, ExcludeMenuItem>) {
+function onRemoveTag(event: any, modelValue: GetModelValue<T, VK, true, ExcludeItem>) {
   if (props.multiple) {
     const filteredValue = modelValue.filter(value => !isEqual(value, event))
-    emits('update:modelValue', filteredValue as GetModelValue<T, VK, M, ExcludeMenuItem>)
+    emits('update:modelValue', filteredValue as GetModelValue<T, VK, M, ExcludeItem>)
     emits('remove-tag', event)
     onUpdate(filteredValue)
   }
@@ -479,7 +479,7 @@ function isInputItem(item: InputMenuItem): item is Exclude<InputMenuItem, InputM
   return typeof item === 'object' && item !== null
 }
 
-function isModelValueEmpty(modelValue: GetModelValue<T, VK, M, ExcludeMenuItem>): boolean {
+function isModelValueEmpty(modelValue: GetModelValue<T, VK, M, ExcludeItem>): boolean {
   if (props.multiple && Array.isArray(modelValue)) {
     return modelValue.length === 0
   }
@@ -593,12 +593,12 @@ defineExpose({
         as-child
         @blur="onBlur"
         @focus="onFocus"
-        @remove-tag="onRemoveTag($event, modelValue as GetModelValue<T, VK, true, ExcludeMenuItem>)"
+        @remove-tag="onRemoveTag($event, modelValue as GetModelValue<T, VK, true, ExcludeItem>)"
       >
         <TagsInputItem v-for="(item, index) in tags" :key="index" :value="item" data-slot="tagsItem" :class="ui.tagsItem({ class: [uiProp?.tagsItem, isInputItem(item) && item.ui?.tagsItem] })">
           <TagsInputItemText data-slot="tagsItemText" :class="ui.tagsItemText({ class: [uiProp?.tagsItemText, isInputItem(item) && item.ui?.tagsItemText] })">
             <slot name="tags-item-text" :item="(item as NestedItem<T>)" :index="index">
-              {{ displayValue(item as GetItemValue<T, VK, ExcludeMenuItem>) }}
+              {{ displayValue(item as GetItemValue<T, VK, ExcludeItem>) }}
             </slot>
           </TagsInputItemText>
 
@@ -638,15 +638,15 @@ defineExpose({
       />
 
       <span v-if="isLeading || !!avatar || !!slots.leading" data-slot="leading" :class="ui.leading({ class: uiProp?.leading })">
-        <slot name="leading" :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)" :open="open" :ui="ui">
+        <slot name="leading" :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeItem>)" :open="open" :ui="ui">
           <UIcon v-if="isLeading && leadingIconName" :name="leadingIconName" data-slot="leadingIcon" :class="ui.leadingIcon({ class: uiProp?.leadingIcon })" />
           <UAvatar v-else-if="!!avatar" :size="((uiProp?.itemLeadingAvatarSize || ui.itemLeadingAvatarSize()) as AvatarProps['size'])" v-bind="avatar" data-slot="itemLeadingAvatar" :class="ui.itemLeadingAvatar({ class: uiProp?.itemLeadingAvatar })" />
         </slot>
       </span>
 
       <ComboboxTrigger v-if="isTrailing || !!slots.trailing || !!clear" data-slot="trailing" :class="ui.trailing({ class: uiProp?.trailing })">
-        <slot name="trailing" :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)" :open="open" :ui="ui">
-          <ComboboxCancel v-if="!!clear && !isModelValueEmpty(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)" as-child>
+        <slot name="trailing" :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeItem>)" :open="open" :ui="ui">
+          <ComboboxCancel v-if="!!clear && !isModelValueEmpty(modelValue as GetModelValue<T, VK, M, ExcludeItem>)" as-child>
             <UButton
               as="span"
               :icon="clearIcon || appConfig.ui.icons.close"

--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -34,6 +34,8 @@ export type InputMenuItem = InputMenuValue | {
   [key: string]: any
 }
 
+type ExcludeMenuItem = { type: 'label' | 'separator' }
+
 export interface InputMenuProps<T extends ArrayOrNested<InputMenuItem> = ArrayOrNested<InputMenuItem>, VK extends GetItemKeys<T> | undefined = undefined, M extends boolean = false> extends Pick<ComboboxRootProps<T>, 'open' | 'defaultOpen' | 'disabled' | 'name' | 'resetSearchTermOnBlur' | 'resetSearchTermOnSelect' | 'resetModelValueOnClear' | 'highlightOnHover' | 'openOnClick' | 'openOnFocus' | 'by'>, UseComponentIconsProps, /** @vue-ignore */ Omit<InputHTMLAttributes, 'disabled' | 'name' | 'type' | 'placeholder' | 'autofocus' | 'maxlength' | 'minlength' | 'pattern' | 'size' | 'min' | 'max' | 'step'> {
   /**
    * The element or component this component should render as.
@@ -139,10 +141,10 @@ export interface InputMenuProps<T extends ArrayOrNested<InputMenuItem> = ArrayOr
   descriptionKey?: GetItemKeys<T>
   items?: T
   /** The value of the InputMenu when initially rendered. Use when you do not need to control the state of the InputMenu. */
-  defaultValue?: GetModelValue<T, VK, M>
+  defaultValue?: GetModelValue<T, VK, M, ExcludeMenuItem>
   /** The controlled value of the InputMenu. Can be binded-with with `v-model`. */
-  modelValue?: GetModelValue<T, VK, M>
-  modelModifiers?: Omit<ModelModifiers<GetModelValue<T, VK, M>>, 'lazy'>
+  modelValue?: GetModelValue<T, VK, M, ExcludeMenuItem>
+  modelModifiers?: Omit<ModelModifiers<GetModelValue<T, VK, M, ExcludeMenuItem>>, 'lazy'>
   /** Whether multiple options can be selected or not. */
   multiple?: M & boolean
   /** Highlight the ring color like a focus state. */
@@ -175,10 +177,10 @@ export type InputMenuEmits<A extends ArrayOrNested<InputMenuItem>, VK extends Ge
   /** Event handler when highlighted element changes. */
   'highlight': [payload: {
     ref: HTMLElement
-    value: GetModelValue<A, VK, M>
+    value: GetModelValue<A, VK, M, ExcludeMenuItem>
   } | undefined]
-  'remove-tag': [item: GetModelValue<A, VK, M>]
-} & GetModelValueEmits<A, VK, M>
+  'remove-tag': [item: GetModelValue<A, VK, M, ExcludeMenuItem>]
+} & GetModelValueEmits<A, VK, M, ExcludeMenuItem>
 
 type SlotProps<T extends InputMenuItem> = (props: { item: T, index: number, ui: InputMenu['ui'] }) => any
 
@@ -188,8 +190,8 @@ export interface InputMenuSlots<
   M extends boolean = false,
   T extends NestedItem<A> = NestedItem<A>
 > {
-  'leading'(props: { modelValue?: GetModelValue<A, VK, M>, open: boolean, ui: InputMenu['ui'] }): any
-  'trailing'(props: { modelValue?: GetModelValue<A, VK, M>, open: boolean, ui: InputMenu['ui'] }): any
+  'leading'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeMenuItem>, open: boolean, ui: InputMenu['ui'] }): any
+  'trailing'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeMenuItem>, open: boolean, ui: InputMenu['ui'] }): any
   'empty'(props: { searchTerm?: string }): any
   'item': SlotProps<T>
   'item-leading': SlotProps<T>
@@ -297,8 +299,8 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.inputMenu ||
 // eslint-disable-next-line vue/no-dupe-keys
 const items = computed(() => groups.value.flatMap(group => group) as T[])
 
-function displayValue(value: GetItemValue<T, VK>): string {
-  return getDisplayValue<T[], GetItemValue<T, VK>>(items.value, value, {
+function displayValue(value: GetItemValue<T, VK, ExcludeMenuItem>): string {
+  return getDisplayValue<T[], GetItemValue<T, VK, ExcludeMenuItem>>(items.value, value, {
     labelKey: props.labelKey,
     valueKey: props.valueKey,
     by: props.by
@@ -444,10 +446,10 @@ function onUpdateOpen(value: boolean) {
   }
 }
 
-function onRemoveTag(event: any, modelValue: GetModelValue<T, VK, true>) {
+function onRemoveTag(event: any, modelValue: GetModelValue<T, VK, true, ExcludeMenuItem>) {
   if (props.multiple) {
     const filteredValue = modelValue.filter(value => !isEqual(value, event))
-    emits('update:modelValue', filteredValue as GetModelValue<T, VK, M>)
+    emits('update:modelValue', filteredValue as GetModelValue<T, VK, M, ExcludeMenuItem>)
     emits('remove-tag', event)
     onUpdate(filteredValue)
   }
@@ -477,7 +479,7 @@ function isInputItem(item: InputMenuItem): item is Exclude<InputMenuItem, InputM
   return typeof item === 'object' && item !== null
 }
 
-function isModelValueEmpty(modelValue: GetModelValue<T, VK, M>): boolean {
+function isModelValueEmpty(modelValue: GetModelValue<T, VK, M, ExcludeMenuItem>): boolean {
   if (props.multiple && Array.isArray(modelValue)) {
     return modelValue.length === 0
   }
@@ -591,12 +593,12 @@ defineExpose({
         as-child
         @blur="onBlur"
         @focus="onFocus"
-        @remove-tag="onRemoveTag($event, modelValue as GetModelValue<T, VK, true>)"
+        @remove-tag="onRemoveTag($event, modelValue as GetModelValue<T, VK, true, ExcludeMenuItem>)"
       >
         <TagsInputItem v-for="(item, index) in tags" :key="index" :value="item" data-slot="tagsItem" :class="ui.tagsItem({ class: [uiProp?.tagsItem, isInputItem(item) && item.ui?.tagsItem] })">
           <TagsInputItemText data-slot="tagsItemText" :class="ui.tagsItemText({ class: [uiProp?.tagsItemText, isInputItem(item) && item.ui?.tagsItemText] })">
             <slot name="tags-item-text" :item="(item as NestedItem<T>)" :index="index">
-              {{ displayValue(item as GetItemValue<T, VK>) }}
+              {{ displayValue(item as GetItemValue<T, VK, ExcludeMenuItem>) }}
             </slot>
           </TagsInputItemText>
 
@@ -636,15 +638,15 @@ defineExpose({
       />
 
       <span v-if="isLeading || !!avatar || !!slots.leading" data-slot="leading" :class="ui.leading({ class: uiProp?.leading })">
-        <slot name="leading" :model-value="(modelValue as GetModelValue<T, VK, M>)" :open="open" :ui="ui">
+        <slot name="leading" :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)" :open="open" :ui="ui">
           <UIcon v-if="isLeading && leadingIconName" :name="leadingIconName" data-slot="leadingIcon" :class="ui.leadingIcon({ class: uiProp?.leadingIcon })" />
           <UAvatar v-else-if="!!avatar" :size="((uiProp?.itemLeadingAvatarSize || ui.itemLeadingAvatarSize()) as AvatarProps['size'])" v-bind="avatar" data-slot="itemLeadingAvatar" :class="ui.itemLeadingAvatar({ class: uiProp?.itemLeadingAvatar })" />
         </slot>
       </span>
 
       <ComboboxTrigger v-if="isTrailing || !!slots.trailing || !!clear" data-slot="trailing" :class="ui.trailing({ class: uiProp?.trailing })">
-        <slot name="trailing" :model-value="(modelValue as GetModelValue<T, VK, M>)" :open="open" :ui="ui">
-          <ComboboxCancel v-if="!!clear && !isModelValueEmpty(modelValue as GetModelValue<T, VK, M>)" as-child>
+        <slot name="trailing" :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)" :open="open" :ui="ui">
+          <ComboboxCancel v-if="!!clear && !isModelValueEmpty(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)" as-child>
             <UButton
               as="span"
               :icon="clearIcon || appConfig.ui.icons.close"

--- a/src/runtime/components/Select.vue
+++ b/src/runtime/components/Select.vue
@@ -35,6 +35,8 @@ export type SelectItem = SelectValue | {
   [key: string]: any
 }
 
+type ExcludeItem = { type: 'label' | 'separator' }
+
 export interface SelectProps<T extends ArrayOrNested<SelectItem> = ArrayOrNested<SelectItem>, VK extends GetItemKeys<T> = 'value', M extends boolean = false> extends Omit<SelectRootProps<T>, 'dir' | 'multiple' | 'modelValue' | 'defaultValue' | 'by'>, UseComponentIconsProps, /** @vue-ignore */ Omit<ButtonHTMLAttributes, 'type' | 'disabled' | 'name'> {
   id?: string
   /** The placeholder text when the select is empty. */
@@ -95,10 +97,10 @@ export interface SelectProps<T extends ArrayOrNested<SelectItem> = ArrayOrNested
   descriptionKey?: GetItemKeys<T>
   items?: T
   /** The value of the Select when initially rendered. Use when you do not need to control the state of the Select. */
-  defaultValue?: GetModelValue<T, VK, M>
+  defaultValue?: GetModelValue<T, VK, M, ExcludeItem>
   /** The controlled value of the Select. Can be bind as `v-model`. */
-  modelValue?: GetModelValue<T, VK, M>
-  modelModifiers?: Omit<ModelModifiers<GetModelValue<T, VK, M>>, 'lazy'>
+  modelValue?: GetModelValue<T, VK, M, ExcludeItem>
+  modelModifiers?: Omit<ModelModifiers<GetModelValue<T, VK, M, ExcludeItem>>, 'lazy'>
   /** Whether multiple options can be selected or not. */
   multiple?: M & boolean
   /** Highlight the ring color like a focus state. */
@@ -113,7 +115,7 @@ export type SelectEmits<A extends ArrayOrNested<SelectItem>, VK extends GetItemK
   change: [event: Event]
   blur: [event: FocusEvent]
   focus: [event: FocusEvent]
-} & GetModelValueEmits<A, VK, M>
+} & GetModelValueEmits<A, VK, M, ExcludeItem>
 
 type SlotProps<T extends SelectItem> = (props: { item: T, index: number, ui: Select['ui'] }) => any
 
@@ -123,9 +125,9 @@ export interface SelectSlots<
   M extends boolean = false,
   T extends NestedItem<A> = NestedItem<A>
 > {
-  'leading'(props: { modelValue?: GetModelValue<A, VK, M>, open: boolean, ui: Select['ui'] }): any
-  'default'(props: { modelValue?: GetModelValue<A, VK, M>, open: boolean, ui: Select['ui'] }): any
-  'trailing'(props: { modelValue?: GetModelValue<A, VK, M>, open: boolean, ui: Select['ui'] }): any
+  'leading'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeItem>, open: boolean, ui: Select['ui'] }): any
+  'default'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeItem>, open: boolean, ui: Select['ui'] }): any
+  'trailing'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeItem>, open: boolean, ui: Select['ui'] }): any
   'item': SlotProps<T>
   'item-leading': SlotProps<T>
   'item-label'(props: { item: T, index: number }): any
@@ -200,10 +202,10 @@ const groups = computed<SelectItem[][]>(() =>
 // eslint-disable-next-line vue/no-dupe-keys
 const items = computed(() => groups.value.flatMap(group => group) as T[])
 
-function displayValue(value: GetItemValue<T, VK> | GetItemValue<T, VK>[]): string | undefined {
+function displayValue(value: GetItemValue<T, VK, ExcludeItem> | GetItemValue<T, VK, ExcludeItem>[]): string | undefined {
   if (props.multiple && Array.isArray(value)) {
     const displayedValues = value
-      .map(item => getDisplayValue<T[], GetItemValue<T, VK>>(items.value, item, {
+      .map(item => getDisplayValue<T[], GetItemValue<T, VK, ExcludeItem>>(items.value, item, {
         labelKey: props.labelKey,
         valueKey: props.valueKey
       }))
@@ -212,7 +214,7 @@ function displayValue(value: GetItemValue<T, VK> | GetItemValue<T, VK>[]): strin
     return displayedValues.length > 0 ? displayedValues.join(', ') : undefined
   }
 
-  return getDisplayValue<T[], GetItemValue<T, VK>>(items.value, value as GetItemValue<T, VK>, {
+  return getDisplayValue<T[], GetItemValue<T, VK, ExcludeItem>>(items.value, value as GetItemValue<T, VK, ExcludeItem>, {
     labelKey: props.labelKey,
     valueKey: props.valueKey
   })
@@ -303,14 +305,14 @@ defineExpose({
       v-bind="{ ...$attrs, ...ariaAttrs }"
     >
       <span v-if="isLeading || !!avatar || !!slots.leading" data-slot="leading" :class="ui.leading({ class: uiProp?.leading })">
-        <slot name="leading" :model-value="(modelValue as GetModelValue<T, VK, M>)" :open="open" :ui="ui">
+        <slot name="leading" :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeItem>)" :open="open" :ui="ui">
           <UIcon v-if="isLeading && leadingIconName" :name="leadingIconName" data-slot="leadingIcon" :class="ui.leadingIcon({ class: uiProp?.leadingIcon })" />
           <UAvatar v-else-if="!!avatar" :size="((uiProp?.itemLeadingAvatarSize || ui.itemLeadingAvatarSize()) as AvatarProps['size'])" v-bind="avatar" data-slot="itemLeadingAvatar" :class="ui.itemLeadingAvatar({ class: uiProp?.itemLeadingAvatar })" />
         </slot>
       </span>
 
-      <slot :model-value="(modelValue as GetModelValue<T, VK, M>)" :open="open" :ui="ui">
-        <template v-for="displayedModelValue in [displayValue(modelValue as GetModelValue<T, VK, M>)]" :key="displayedModelValue">
+      <slot :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeItem>)" :open="open" :ui="ui">
+        <template v-for="displayedModelValue in [displayValue(modelValue as GetModelValue<T, VK, M, ExcludeItem>)]" :key="displayedModelValue">
           <span v-if="displayedModelValue !== undefined && displayedModelValue !== null" data-slot="value" :class="ui.value({ class: uiProp?.value })">
             {{ displayedModelValue }}
           </span>
@@ -321,7 +323,7 @@ defineExpose({
       </slot>
 
       <span v-if="isTrailing || !!slots.trailing" data-slot="trailing" :class="ui.trailing({ class: uiProp?.trailing })">
-        <slot name="trailing" :model-value="(modelValue as GetModelValue<T, VK, M>)" :open="open" :ui="ui">
+        <slot name="trailing" :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeItem>)" :open="open" :ui="ui">
           <UIcon v-if="trailingIconName" :name="trailingIconName" data-slot="trailingIcon" :class="ui.trailingIcon({ class: uiProp?.trailingIcon })" />
         </slot>
       </span>

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -34,6 +34,8 @@ export type SelectMenuItem = SelectMenuValue | {
   [key: string]: any
 }
 
+type ExcludeMenuItem = { type: 'label' | 'separator' }
+
 export interface SelectMenuProps<T extends ArrayOrNested<SelectMenuItem> = ArrayOrNested<SelectMenuItem>, VK extends GetItemKeys<T> | undefined = undefined, M extends boolean = false> extends Pick<ComboboxRootProps<T>, 'open' | 'defaultOpen' | 'disabled' | 'name' | 'resetSearchTermOnBlur' | 'resetSearchTermOnSelect' | 'resetModelValueOnClear' | 'highlightOnHover' | 'by'>, UseComponentIconsProps, /** @vue-ignore */ Omit<ButtonHTMLAttributes, 'type' | 'disabled' | 'name'> {
   id?: string
   /** The placeholder text when the select is empty. */
@@ -132,10 +134,10 @@ export interface SelectMenuProps<T extends ArrayOrNested<SelectMenuItem> = Array
   descriptionKey?: GetItemKeys<T>
   items?: T
   /** The value of the SelectMenu when initially rendered. Use when you do not need to control the state of the SelectMenu. */
-  defaultValue?: GetModelValue<T, VK, M>
+  defaultValue?: GetModelValue<T, VK, M, ExcludeMenuItem>
   /** The controlled value of the SelectMenu. Can be binded-with with `v-model`. */
-  modelValue?: GetModelValue<T, VK, M>
-  modelModifiers?: Omit<ModelModifiers<GetModelValue<T, VK, M>>, 'lazy'>
+  modelValue?: GetModelValue<T, VK, M, ExcludeMenuItem>
+  modelModifiers?: Omit<ModelModifiers<GetModelValue<T, VK, M, ExcludeMenuItem>>, 'lazy'>
   /** Whether multiple options can be selected or not. */
   multiple?: M & boolean
   /** Highlight the ring color like a focus state. */
@@ -170,9 +172,9 @@ export type SelectMenuEmits<A extends ArrayOrNested<SelectMenuItem>, VK extends 
   /** Event handler when highlighted element changes. */
   highlight: [payload: {
     ref: HTMLElement
-    value: GetModelValue<A, VK, M>
+    value: GetModelValue<A, VK, M, ExcludeMenuItem>
   } | undefined]
-} & GetModelValueEmits<A, VK, M>
+} & GetModelValueEmits<A, VK, M, ExcludeMenuItem>
 
 type SlotProps<T extends SelectMenuItem> = (props: { item: T, index: number, ui: SelectMenu['ui'] }) => any
 
@@ -182,9 +184,9 @@ export interface SelectMenuSlots<
   M extends boolean = false,
   T extends NestedItem<A> = NestedItem<A>
 > {
-  'leading'(props: { modelValue?: GetModelValue<A, VK, M>, open: boolean, ui: SelectMenu['ui'] }): any
-  'default'(props: { modelValue?: GetModelValue<A, VK, M>, open: boolean, ui: SelectMenu['ui'] }): any
-  'trailing'(props: { modelValue?: GetModelValue<A, VK, M>, open: boolean, ui: SelectMenu['ui'] }): any
+  'leading'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeMenuItem>, open: boolean, ui: SelectMenu['ui'] }): any
+  'default'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeMenuItem>, open: boolean, ui: SelectMenu['ui'] }): any
+  'trailing'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeMenuItem>, open: boolean, ui: SelectMenu['ui'] }): any
   'empty'(props: { searchTerm?: string }): any
   'item': SlotProps<T>
   'item-leading': SlotProps<T>
@@ -288,10 +290,10 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.selectMenu |
   virtualize: !!props.virtualize
 }))
 
-function displayValue(value: GetItemValue<T, VK> | GetItemValue<T, VK>[]): string | undefined {
+function displayValue(value: GetItemValue<T, VK, ExcludeMenuItem> | GetItemValue<T, VK, ExcludeMenuItem>[]): string | undefined {
   if (props.multiple && Array.isArray(value)) {
     const displayedValues = value
-      .map(item => getDisplayValue<T[], GetItemValue<T, VK>>(items.value, item, {
+      .map(item => getDisplayValue<T[], GetItemValue<T, VK, ExcludeMenuItem>>(items.value, item, {
         labelKey: props.labelKey,
         valueKey: props.valueKey,
         by: props.by
@@ -301,7 +303,7 @@ function displayValue(value: GetItemValue<T, VK> | GetItemValue<T, VK>[]): strin
     return displayedValues.length > 0 ? displayedValues.join(', ') : undefined
   }
 
-  return getDisplayValue<T[], GetItemValue<T, VK>>(items.value, value as GetItemValue<T, VK>, {
+  return getDisplayValue<T[], GetItemValue<T, VK, ExcludeMenuItem>>(items.value, value as GetItemValue<T, VK, ExcludeMenuItem>, {
     labelKey: props.labelKey,
     valueKey: props.valueKey,
     by: props.by
@@ -461,7 +463,7 @@ function isSelectItem(item: SelectMenuItem): item is Exclude<SelectMenuItem, Sel
   return typeof item === 'object' && item !== null
 }
 
-function isModelValueEmpty(modelValue: GetModelValue<T, VK, M>): boolean {
+function isModelValueEmpty(modelValue: GetModelValue<T, VK, M, ExcludeMenuItem>): boolean {
   if (props.multiple && Array.isArray(modelValue)) {
     return modelValue.length === 0
   }
@@ -566,14 +568,14 @@ defineExpose({
     <ComboboxAnchor as-child>
       <ComboboxTrigger ref="triggerRef" data-slot="base" :class="ui.base({ class: [uiProp?.base, props.class] })" tabindex="0">
         <span v-if="isLeading || !!avatar || !!slots.leading" data-slot="leading" :class="ui.leading({ class: uiProp?.leading })">
-          <slot name="leading" :model-value="(modelValue as GetModelValue<T, VK, M>)" :open="open" :ui="ui">
+          <slot name="leading" :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)" :open="open" :ui="ui">
             <UIcon v-if="isLeading && leadingIconName" :name="leadingIconName" data-slot="leadingIcon" :class="ui.leadingIcon({ class: uiProp?.leadingIcon })" />
             <UAvatar v-else-if="!!avatar" :size="((uiProp?.itemLeadingAvatarSize || ui.itemLeadingAvatarSize()) as AvatarProps['size'])" v-bind="avatar" data-slot="itemLeadingAvatar" :class="ui.itemLeadingAvatar({ class: uiProp?.itemLeadingAvatar })" />
           </slot>
         </span>
 
-        <slot :model-value="(modelValue as GetModelValue<T, VK, M>)" :open="open" :ui="ui">
-          <template v-for="displayedModelValue in [displayValue(modelValue as GetModelValue<T, VK, M>)]" :key="displayedModelValue">
+        <slot :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)" :open="open" :ui="ui">
+          <template v-for="displayedModelValue in [displayValue(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)]" :key="displayedModelValue">
             <span v-if="displayedModelValue !== undefined && displayedModelValue !== null" data-slot="value" :class="ui.value({ class: uiProp?.value })">
               {{ displayedModelValue }}
             </span>
@@ -584,8 +586,8 @@ defineExpose({
         </slot>
 
         <span v-if="isTrailing || !!slots.trailing || !!clear" data-slot="trailing" :class="ui.trailing({ class: uiProp?.trailing })">
-          <slot name="trailing" :model-value="(modelValue as GetModelValue<T, VK, M>)" :open="open" :ui="ui">
-            <ComboboxCancel v-if="!!clear && !isModelValueEmpty(modelValue as GetModelValue<T, VK, M>)" as-child>
+          <slot name="trailing" :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)" :open="open" :ui="ui">
+            <ComboboxCancel v-if="!!clear && !isModelValueEmpty(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)" as-child>
               <UButton
                 as="span"
                 :icon="clearIcon || appConfig.ui.icons.close"

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -34,7 +34,7 @@ export type SelectMenuItem = SelectMenuValue | {
   [key: string]: any
 }
 
-type ExcludeMenuItem = { type: 'label' | 'separator' }
+type ExcludeItem = { type: 'label' | 'separator' }
 
 export interface SelectMenuProps<T extends ArrayOrNested<SelectMenuItem> = ArrayOrNested<SelectMenuItem>, VK extends GetItemKeys<T> | undefined = undefined, M extends boolean = false> extends Pick<ComboboxRootProps<T>, 'open' | 'defaultOpen' | 'disabled' | 'name' | 'resetSearchTermOnBlur' | 'resetSearchTermOnSelect' | 'resetModelValueOnClear' | 'highlightOnHover' | 'by'>, UseComponentIconsProps, /** @vue-ignore */ Omit<ButtonHTMLAttributes, 'type' | 'disabled' | 'name'> {
   id?: string
@@ -134,10 +134,10 @@ export interface SelectMenuProps<T extends ArrayOrNested<SelectMenuItem> = Array
   descriptionKey?: GetItemKeys<T>
   items?: T
   /** The value of the SelectMenu when initially rendered. Use when you do not need to control the state of the SelectMenu. */
-  defaultValue?: GetModelValue<T, VK, M, ExcludeMenuItem>
+  defaultValue?: GetModelValue<T, VK, M, ExcludeItem>
   /** The controlled value of the SelectMenu. Can be binded-with with `v-model`. */
-  modelValue?: GetModelValue<T, VK, M, ExcludeMenuItem>
-  modelModifiers?: Omit<ModelModifiers<GetModelValue<T, VK, M, ExcludeMenuItem>>, 'lazy'>
+  modelValue?: GetModelValue<T, VK, M, ExcludeItem>
+  modelModifiers?: Omit<ModelModifiers<GetModelValue<T, VK, M, ExcludeItem>>, 'lazy'>
   /** Whether multiple options can be selected or not. */
   multiple?: M & boolean
   /** Highlight the ring color like a focus state. */
@@ -172,9 +172,9 @@ export type SelectMenuEmits<A extends ArrayOrNested<SelectMenuItem>, VK extends 
   /** Event handler when highlighted element changes. */
   highlight: [payload: {
     ref: HTMLElement
-    value: GetModelValue<A, VK, M, ExcludeMenuItem>
+    value: GetModelValue<A, VK, M, ExcludeItem>
   } | undefined]
-} & GetModelValueEmits<A, VK, M, ExcludeMenuItem>
+} & GetModelValueEmits<A, VK, M, ExcludeItem>
 
 type SlotProps<T extends SelectMenuItem> = (props: { item: T, index: number, ui: SelectMenu['ui'] }) => any
 
@@ -184,9 +184,9 @@ export interface SelectMenuSlots<
   M extends boolean = false,
   T extends NestedItem<A> = NestedItem<A>
 > {
-  'leading'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeMenuItem>, open: boolean, ui: SelectMenu['ui'] }): any
-  'default'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeMenuItem>, open: boolean, ui: SelectMenu['ui'] }): any
-  'trailing'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeMenuItem>, open: boolean, ui: SelectMenu['ui'] }): any
+  'leading'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeItem>, open: boolean, ui: SelectMenu['ui'] }): any
+  'default'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeItem>, open: boolean, ui: SelectMenu['ui'] }): any
+  'trailing'(props: { modelValue?: GetModelValue<A, VK, M, ExcludeItem>, open: boolean, ui: SelectMenu['ui'] }): any
   'empty'(props: { searchTerm?: string }): any
   'item': SlotProps<T>
   'item-leading': SlotProps<T>
@@ -290,10 +290,10 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.selectMenu |
   virtualize: !!props.virtualize
 }))
 
-function displayValue(value: GetItemValue<T, VK, ExcludeMenuItem> | GetItemValue<T, VK, ExcludeMenuItem>[]): string | undefined {
+function displayValue(value: GetItemValue<T, VK, ExcludeItem> | GetItemValue<T, VK, ExcludeItem>[]): string | undefined {
   if (props.multiple && Array.isArray(value)) {
     const displayedValues = value
-      .map(item => getDisplayValue<T[], GetItemValue<T, VK, ExcludeMenuItem>>(items.value, item, {
+      .map(item => getDisplayValue<T[], GetItemValue<T, VK, ExcludeItem>>(items.value, item, {
         labelKey: props.labelKey,
         valueKey: props.valueKey,
         by: props.by
@@ -303,7 +303,7 @@ function displayValue(value: GetItemValue<T, VK, ExcludeMenuItem> | GetItemValue
     return displayedValues.length > 0 ? displayedValues.join(', ') : undefined
   }
 
-  return getDisplayValue<T[], GetItemValue<T, VK, ExcludeMenuItem>>(items.value, value as GetItemValue<T, VK, ExcludeMenuItem>, {
+  return getDisplayValue<T[], GetItemValue<T, VK, ExcludeItem>>(items.value, value as GetItemValue<T, VK, ExcludeItem>, {
     labelKey: props.labelKey,
     valueKey: props.valueKey,
     by: props.by
@@ -463,7 +463,7 @@ function isSelectItem(item: SelectMenuItem): item is Exclude<SelectMenuItem, Sel
   return typeof item === 'object' && item !== null
 }
 
-function isModelValueEmpty(modelValue: GetModelValue<T, VK, M, ExcludeMenuItem>): boolean {
+function isModelValueEmpty(modelValue: GetModelValue<T, VK, M, ExcludeItem>): boolean {
   if (props.multiple && Array.isArray(modelValue)) {
     return modelValue.length === 0
   }
@@ -568,14 +568,14 @@ defineExpose({
     <ComboboxAnchor as-child>
       <ComboboxTrigger ref="triggerRef" data-slot="base" :class="ui.base({ class: [uiProp?.base, props.class] })" tabindex="0">
         <span v-if="isLeading || !!avatar || !!slots.leading" data-slot="leading" :class="ui.leading({ class: uiProp?.leading })">
-          <slot name="leading" :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)" :open="open" :ui="ui">
+          <slot name="leading" :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeItem>)" :open="open" :ui="ui">
             <UIcon v-if="isLeading && leadingIconName" :name="leadingIconName" data-slot="leadingIcon" :class="ui.leadingIcon({ class: uiProp?.leadingIcon })" />
             <UAvatar v-else-if="!!avatar" :size="((uiProp?.itemLeadingAvatarSize || ui.itemLeadingAvatarSize()) as AvatarProps['size'])" v-bind="avatar" data-slot="itemLeadingAvatar" :class="ui.itemLeadingAvatar({ class: uiProp?.itemLeadingAvatar })" />
           </slot>
         </span>
 
-        <slot :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)" :open="open" :ui="ui">
-          <template v-for="displayedModelValue in [displayValue(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)]" :key="displayedModelValue">
+        <slot :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeItem>)" :open="open" :ui="ui">
+          <template v-for="displayedModelValue in [displayValue(modelValue as GetModelValue<T, VK, M, ExcludeItem>)]" :key="displayedModelValue">
             <span v-if="displayedModelValue !== undefined && displayedModelValue !== null" data-slot="value" :class="ui.value({ class: uiProp?.value })">
               {{ displayedModelValue }}
             </span>
@@ -586,8 +586,8 @@ defineExpose({
         </slot>
 
         <span v-if="isTrailing || !!slots.trailing || !!clear" data-slot="trailing" :class="ui.trailing({ class: uiProp?.trailing })">
-          <slot name="trailing" :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)" :open="open" :ui="ui">
-            <ComboboxCancel v-if="!!clear && !isModelValueEmpty(modelValue as GetModelValue<T, VK, M, ExcludeMenuItem>)" as-child>
+          <slot name="trailing" :model-value="(modelValue as GetModelValue<T, VK, M, ExcludeItem>)" :open="open" :ui="ui">
+            <ComboboxCancel v-if="!!clear && !isModelValueEmpty(modelValue as GetModelValue<T, VK, M, ExcludeItem>)" as-child>
               <UButton
                 as="span"
                 :icon="clearIcon || appConfig.ui.icons.close"

--- a/src/runtime/components/Textarea.vue
+++ b/src/runtime/components/Textarea.vue
@@ -119,11 +119,11 @@ function updateInput(value: string | null | undefined) {
   }
 
   if (props.modelModifiers?.nullable) {
-    value ??= null
+    value ||= null
   }
 
-  if (props.modelModifiers?.optional) {
-    value ??= undefined
+  if (props.modelModifiers?.optional && !props.modelModifiers?.nullable && value !== null) {
+    value ||= undefined
   }
 
   modelValue.value = value as T

--- a/src/runtime/components/Textarea.vue
+++ b/src/runtime/components/Textarea.vue
@@ -119,11 +119,11 @@ function updateInput(value: string | null | undefined) {
   }
 
   if (props.modelModifiers?.nullable) {
-    value ||= null
+    value ??= null
   }
 
   if (props.modelModifiers?.optional) {
-    value ||= undefined
+    value ??= undefined
   }
 
   modelValue.value = value as T

--- a/src/runtime/types/input.ts
+++ b/src/runtime/types/input.ts
@@ -1,8 +1,9 @@
 export interface ModelModifiers<T = any> {
-  string?: string extends T ? boolean : never
-  number?: number extends T ? boolean : never
-  trim?: string extends T ? boolean : never
-  lazy?: boolean
-  nullable?: null extends T ? boolean : never
+  nullable?: null extends T ? boolean : false
+  number?: number extends T ? boolean : false
+  string?: string extends T ? boolean : false
+  trim?: string extends T ? boolean : false
+
   optional?: boolean
+  lazy?: boolean
 }

--- a/src/runtime/types/utils.ts
+++ b/src/runtime/types/utils.ts
@@ -66,30 +66,39 @@ type DotPathValue<T, P extends DotPathKeys<T> | (string & {})>
 
 export type GetItemKeys<I> = keyof Extract<NestedItem<I>, object> | DotPathKeys<Extract<NestedItem<I>, object>>
 
-export type GetItemValue<I, VK extends GetItemKeys<I> | undefined, T extends NestedItem<I> = NestedItem<I>>
+export type GetItemValue<
+  I,
+  VK extends GetItemKeys<I> | undefined,
+  O extends object | undefined = undefined,
+  T extends NestedItem<I> = NestedItem<I>
+>
   = T extends object
     ? VK extends undefined
-      ? T
+      ? T extends O
+        ? never
+        : T
       : VK extends DotPathKeys<T>
         ? DotPathValue<T, VK>
         : never
     : T
 
 export type GetModelValue<
-  T,
-  VK extends GetItemKeys<T> | undefined,
-  M extends boolean
+  I,
+  VK extends GetItemKeys<I> | undefined,
+  M extends boolean,
+  O extends object | undefined = undefined
 > = M extends true
-  ? GetItemValue<T, VK>[]
-  : GetItemValue<T, VK>
+  ? GetItemValue<I, VK, O>[]
+  : GetItemValue<I, VK, O>
 
 export type GetModelValueEmits<
-  T,
-  VK extends GetItemKeys<T> | undefined,
-  M extends boolean
+  I,
+  VK extends GetItemKeys<I> | undefined,
+  M extends boolean,
+  O extends object | undefined = undefined
 > = {
   /** Event handler called when the value changes. */
-  'update:modelValue': [value: GetModelValue<T, VK, M>]
+  'update:modelValue': [value: GetModelValue<I, VK, M, O>]
 }
 
 export type StringOrVNode


### PR DESCRIPTION
Some components like `InputMenu`, `SelectMenu` and `Select` support for items that are purely cosmetic like `type: 'label'` and `type: 'separator'`.

This causes a waterfall of type issues