### PR TITLE
fix(Toast): improve animation smoothness

### DIFF
--- a/src/runtime/components/Toast.vue
+++ b/src/runtime/components/Toast.vue
@@ -71,7 +71,7 @@ export interface ToastSlots {
 </script>
 
 <script setup lang="ts">
-import { ref, computed, onMounted, nextTick, useTemplateRef } from 'vue'
+import { ref, computed, onMounted, useTemplateRef } from 'vue'
 import { ToastRoot, ToastTitle, ToastDescription, ToastAction, ToastClose, useForwardPropsEmits } from 'reka-ui'
 import { reactivePick } from '@vueuse/core'
 import { useAppConfig } from '#imports'
@@ -107,13 +107,11 @@ const rootRef = useTemplateRef('rootRef')
 const height = ref(0)
 
 onMounted(() => {
-  if (!rootRef.value) {
+  if (!rootRef.value?.$el?.getBoundingClientRect) {
     return
   }
 
-  nextTick(() => {
-    height.value = rootRef.value?.$el?.getBoundingClientRect()?.height
-  })
+  height.value = rootRef.value.$el.getBoundingClientRect().height
 })
 
 defineExpose({

--- a/src/runtime/keyframes.css
+++ b/src/runtime/keyframes.css
@@ -38,6 +38,46 @@
   }
 }
 
+@keyframes toast-slide-in-from-top {
+  from {
+    transform: translateY(-100%);
+  }
+
+  to {
+    transform: var(--transform);
+  }
+}
+
+@keyframes toast-slide-in-from-bottom {
+  from {
+    transform: translateY(100%);
+  }
+
+  to {
+    transform: var(--transform);
+  }
+}
+
+@keyframes toast-slide-up {
+  from {
+    transform: translateX(0) translateY(var(--translate));
+  }
+
+  to {
+    transform: translateX(0) translateY(calc(var(--translate) - 100%));
+  }
+}
+
+@keyframes toast-slide-down {
+  from {
+    transform: translateX(0) translateY(var(--translate));
+  }
+
+  to {
+    transform: translateX(0) translateY(calc(var(--translate) + 100%));
+  }
+}
+
 @keyframes toast-pulse-a {
   0%,
   100% {

--- a/src/theme/toaster.ts
+++ b/src/theme/toaster.ts
@@ -35,13 +35,13 @@ export default {
     position: ['top-left', 'top-center', 'top-right'],
     class: {
       viewport: 'top-4',
-      base: 'top-0 data-[state=open]:animate-[slide-in-from-top_200ms_ease-in-out]'
+      base: 'top-0 data-[state=open]:animate-[toast-slide-in-from-top_200ms_ease-in-out]'
     }
   }, {
     position: ['bottom-left', 'bottom-center', 'bottom-right'],
     class: {
       viewport: 'bottom-4',
-      base: 'bottom-0 data-[state=open]:animate-[slide-in-from-bottom_200ms_ease-in-out]'
+      base: 'bottom-0 data-[state=open]:animate-[toast-slide-in-from-bottom_200ms_ease-in-out]'
     }
   }, {
     swipeDirection: ['left', 'right'],


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- Toast slide-in animations were snapping because the generic `slide-in-from-top`/`slide-in-from-bottom` keyframes animate to `translateY(0)` instead of the toast's actual stacked position (`var(--transform)`). Added toast-specific keyframes that animate to the correct transform.
- Added missing `toast-slide-up` / `toast-slide-down` keyframes that were referenced in the theme but never defined (swipe dismiss up/down was broken).
- Removed unnecessary `nextTick` in height measurement — `onMounted` already guarantees the DOM is ready.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.