### PR TITLE
fix(types): resolve GetItemKeys / GetItemValue with branded and complex types

### DIFF
--- a/src/runtime/types/utils.ts
+++ b/src/runtime/types/utils.ts
@@ -64,22 +64,32 @@ type DotPathValue<T, P extends DotPathKeys<T> | (string & {})>
       ? T[P]
       : never
 
-export type GetItemKeys<I> = keyof Extract<NestedItem<I>, object> | DotPathKeys<Extract<NestedItem<I>, object>>
+// Non-recursive 2-level unwrap used as a fast-path so TypeScript can eagerly resolve branded/complex types.
+type _FlatItem<I> = I extends readonly (infer Item)[]
+  ? Item extends readonly (infer SubItem)[] ? SubItem : Item
+  : I
+
+export type GetItemKeys<I>
+  = | keyof Extract<_FlatItem<I>, object>
+    | keyof Extract<NestedItem<I>, object>
+    | DotPathKeys<Extract<NestedItem<I>, object>>
 
 export type GetItemValue<
   I,
   VK extends GetItemKeys<I> | undefined,
   O extends object | undefined = undefined,
-  T extends NestedItem<I> = NestedItem<I>
+  T extends _FlatItem<I> = _FlatItem<I>
 >
   = T extends object
     ? VK extends undefined
       ? T extends O
         ? never
         : T
-      : VK extends DotPathKeys<T>
-        ? DotPathValue<T, VK>
-        : never
+      : VK extends keyof T
+        ? T[VK]
+        : VK extends DotPathKeys<T>
+          ? DotPathValue<T, VK>
+          : never
     : T
 
 export type GetModelValue<


### PR DESCRIPTION
## Description

Fixes #6072

`GetItemKeys<I>` and `GetItemValue` rely on `NestedItem<T>`, a recursive conditional type. When item types contain branded types, complex intersections, or readonly symbol properties, TypeScript defers evaluation of `NestedItem<T>` — the resulting type becomes opaque and concrete string keys like `"id"` or `"name"` are no longer assignable to `GetItemKeys<I>`. This also breaks `v-model` inference through `GetModelValue`.

## Changes

Added a non-recursive `_FlatItem<I>` helper that performs a simple 2-level array unwrap. Since it's non-recursive, TypeScript can always eagerly resolve it.

- **`GetItemKeys`**: added `keyof Extract<_FlatItem<I>, object>` as the first union member (fast-path). `NestedItem` and `DotPathKeys` are kept as fallbacks so deeply nested arrays continue to work.
- **`GetItemValue`**: changed the default type parameter from `NestedItem<I>` to `_FlatItem<I>`, and added a `keyof T` fast-path before the `DotPathKeys` branch.

## Why a new type instead of fixing `NestedItem`?

`NestedItem` is recursive by design — it handles arbitrarily nested arrays (`T[][][]...`). TypeScript's deferred evaluation of recursive conditional types is expected behavior and cannot be avoided. `_FlatItem` provides an eagerly-resolvable alternative for the common case (1-2 levels of array nesting) while keeping `NestedItem` for the general case.

## Testing

Verified that:
- Branded types (`T & { readonly [symbol]: B }`) now work with `value-key`, `label-key`, and `v-model` on `USelect`, `USelectMenu`, and `UInputMenu`
- Standard (non-branded) types continue to work as before
- Deeply nested arrays (`T[][]`) still resolve correctly through the `NestedItem` fallback