### PR TITLE
feat(module): add support for taupe / mauve / mist / olive neutral colors

### DIFF
--- a/docs/app/composables/useTheme.ts
+++ b/docs/app/composables/useTheme.ts
@@ -7,7 +7,7 @@ export function useTheme() {
   const colorMode = useColorMode()
   const { track } = useAnalytics()
 
-  const neutralColors = ['slate', 'gray', 'zinc', 'neutral', 'stone']
+  const neutralColors = ['slate', 'gray', 'zinc', 'neutral', 'stone', 'taupe', 'mauve', 'mist', 'olive']
   const neutral = computed({
     get() {
       return appConfig.ui.colors.neutral

--- a/playgrounds/nuxt/app/components/ThemeDropdown.vue
+++ b/playgrounds/nuxt/app/components/ThemeDropdown.vue
@@ -4,7 +4,7 @@ import type { DropdownMenuItem } from '@nuxt/ui'
 const appConfig = useAppConfig()
 
 const colors = ['red', 'orange', 'amber', 'yellow', 'lime', 'green', 'emerald', 'teal', 'cyan', 'sky', 'blue', 'indigo', 'violet', 'purple', 'fuchsia', 'pink', 'rose']
-const neutrals = ['slate', 'gray', 'zinc', 'neutral', 'stone']
+const neutrals = ['slate', 'gray', 'zinc', 'neutral', 'stone', 'taupe', 'mauve', 'mist', 'olive']
 
 const items = computed<DropdownMenuItem[]>(() => [{
   label: 'Primary',

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -293,7 +293,7 @@ import colors from 'tailwindcss/colors'
 
 type IconsConfig = Record<${iconUnion} | (string & {}), string>
 
-type NeutralColor = 'slate' | 'gray' | 'zinc' | 'neutral' | 'stone'
+type NeutralColor = 'slate' | 'gray' | 'zinc' | 'neutral' | 'stone' | 'taupe' | 'mauve' | 'mist' | 'olive'
 type Color = Exclude<keyof typeof colors, 'inherit' | 'current' | 'transparent' | 'black' | 'white' | NeutralColor> | (string & {})
 
 type AppConfigUI = {

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -24,7 +24,7 @@ import AutoImportPlugin from './plugins/auto-import'
 
 import type { TVConfig } from './runtime/types/tv'
 
-type NeutralColor = 'slate' | 'gray' | 'zinc' | 'neutral' | 'stone'
+type NeutralColor = 'slate' | 'gray' | 'zinc' | 'neutral' | 'stone' | 'taupe' | 'mauve' | 'mist' | 'olive'
 type Color = Exclude<keyof typeof colors, 'inherit' | 'current' | 'transparent' | 'black' | 'white' | NeutralColor> | (string & {})
 
 type AppConfigUI = {


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Following the release of Tailwind CSS `v4.2.0`, I have added the new color options to the neutral palette. This change includes:
- Adding `taupe`, `mauve`, `mist`, and `olive` to the `neutralColors` constant in `useTheme`.
- Updating the `ThemeDropdown` component in the playground to support these new options.
- Updating `NeutralColor` TypeScript types in `src/templates.ts` and `src/unplugin.ts`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.