### PR TITLE
fix(types): resolve `isArrayOfArray` type return

### DIFF
--- a/src/runtime/components/EditorToolbar.vue
+++ b/src/runtime/components/EditorToolbar.vue
@@ -145,11 +145,11 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.editorToolba
   layout: props.layout
 }))
 
-const groups = computed<EditorToolbarItem[][]>(() =>
+const groups = computed(() =>
   props.items?.length
     ? isArrayOfArray(props.items)
       ? props.items
-      : [props.items]
+      : [props.items as NestedItem<T>[]]
     : []
 )
 

--- a/src/runtime/utils/index.ts
+++ b/src/runtime/utils/index.ts
@@ -160,7 +160,13 @@ export function getDisplayValue<T extends Array<any>, V>(
   return String(source)
 }
 
-export function isArrayOfArray<A>(item: A[] | A[][]): item is A[][] {
+export function isArrayOfArray<
+  A extends any[] | any[][]
+>(item: A): item is A extends Array<infer T>
+  ? T extends any[]
+    ? T[]
+    : never
+  : never {
   return Array.isArray(item[0])
 }
 


### PR DESCRIPTION
Discussed privately, minor type issue that is not picked up by `vue-tsc`.