### PR TITLE
playground: prevent component cutoff on small screen heights

### DIFF
--- a/playgrounds/nuxt/app/app.vue
+++ b/playgrounds/nuxt/app/app.vue
@@ -54,14 +54,15 @@ provide('components', components)
       <UDashboardPanel
         :ui="{
           body: [
-            'justify-center items-center',
             route.path.startsWith('/components') && 'mt-16',
             route.path.startsWith('/components/scroll-area') && 'p-0!'
           ]
         }"
       >
         <template #body>
-          <NuxtPage />
+          <div class="flex flex-col items-center justify-center min-h-full shrink-0">
+            <NuxtPage />
+          </div>
         </template>
       </UDashboardPanel>
 

--- a/playgrounds/vue/src/app.vue
+++ b/playgrounds/vue/src/app.vue
@@ -64,16 +64,17 @@ provide('components', components)
       <UDashboardPanel
         :ui="{
           body: [
-            'justify-center items-center',
             route.path.startsWith('/components') && 'mt-16',
             route.path.startsWith('/components/scroll-area') && 'p-0!'
           ]
         }"
       >
         <template #body>
-          <Suspense>
-            <RouterView />
-          </Suspense>
+          <div class="flex flex-col items-center justify-center min-h-full shrink-0">
+            <Suspense>
+              <RouterView />
+            </Suspense>
+          </div>
         </template>
       </UDashboardPanel>
 


### PR DESCRIPTION
his fixes the playground so components (like the PricingTable) don't get cut off at the top when the screen height is too small.

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
