### PR TITLE
feat(Tooltip): support global content configuration via App tooltip prop

### DIFF
--- a/docs/content/docs/2.components/tooltip.md
+++ b/docs/content/docs/2.components/tooltip.md
@@ -113,6 +113,10 @@ This can be configured globally through the `tooltip.delayDuration` option in th
 
 Use the `content` prop to control how the Tooltip content is rendered, like its `align` or `side` for example.
 
+::tip
+This can be configured globally through the `tooltip.content` option in the [`App`](/docs/components/app) component.
+::
+
 ::component-code
 ---
 prettier: true

--- a/src/runtime/components/Tooltip.vue
+++ b/src/runtime/components/Tooltip.vue
@@ -16,6 +16,8 @@ export interface TooltipProps extends TooltipRootProps {
   kbds?: KbdProps['value'][] | KbdProps[]
   /**
    * The content of the tooltip.
+   *
+   * Inherits from the `tooltip.content` of the {@link AppProps} component when not provided.
    * @defaultValue { side: 'bottom', sideOffset: 8, collisionPadding: 8 }
    */
   content?: Omit<TooltipContentProps, 'as' | 'asChild'> & Partial<EmitsToProps<TooltipContentEmits>>
@@ -51,7 +53,7 @@ export interface TooltipSlots {
 <script setup lang="ts">
 import { computed, toRef } from 'vue'
 import { defu } from 'defu'
-import { TooltipRoot, TooltipTrigger, TooltipPortal, TooltipContent, TooltipArrow, useForwardPropsEmits } from 'reka-ui'
+import { TooltipRoot, TooltipTrigger, TooltipPortal, TooltipContent, TooltipArrow, useForwardPropsEmits, injectTooltipProviderContext } from 'reka-ui'
 import { reactivePick } from '@vueuse/core'
 import { useAppConfig } from '#imports'
 import { useComponentUI } from '../composables/useComponentUI'
@@ -68,9 +70,11 @@ const slots = defineSlots<TooltipSlots>()
 const appConfig = useAppConfig() as Tooltip['AppConfig']
 const uiProp = useComponentUI('tooltip', props)
 
+const providerContext = injectTooltipProviderContext()
+
 const rootProps = useForwardPropsEmits(reactivePick(props, 'defaultOpen', 'open', 'delayDuration', 'disableHoverableContent', 'disableClosingTrigger', 'ignoreNonKeyboardFocus'), emits)
 const portalProps = usePortal(toRef(() => props.portal))
-const contentProps = toRef(() => defu(props.content, { side: 'bottom', sideOffset: 8, collisionPadding: 8 }) as TooltipContentProps)
+const contentProps = toRef(() => defu(props.content, providerContext.content.value, { side: 'bottom', sideOffset: 8, collisionPadding: 8 }) as TooltipContentProps)
 const arrowProps = toRef(() => defu(props.arrow, { rounded: true }) as TooltipArrowProps)
 
 // eslint-disable-next-line vue/no-dupe-keys

--- a/test/components/Tooltip.spec.ts
+++ b/test/components/Tooltip.spec.ts
@@ -21,6 +21,21 @@ const TooltipWrapper = defineComponent({
 </TooltipProvider>`
 })
 
+const TooltipProviderContentWrapper = defineComponent({
+  components: {
+    TooltipProvider,
+    UTooltip: Tooltip
+  },
+  inheritAttrs: false,
+  template: `<TooltipProvider :content="{ side: 'right', sideOffset: 12 }">
+  <UTooltip v-bind="$attrs">
+    <template v-for="(_, name) in $slots" #[name]="slotData">
+      <slot :name="name" v-bind="slotData" />
+    </template>
+  </UTooltip>
+</TooltipProvider>`
+})
+
 describe('Tooltip', () => {
   const props = { text: 'Tooltip', open: true, portal: false }
 
@@ -35,6 +50,24 @@ describe('Tooltip', () => {
     ['with default slot', { props, slots: { default: () => 'Default slot' } }],
     ['with content slot', { props, slots: { content: () => 'Content slot' } }]
   ])
+
+  it('respects provider content defaults', async () => {
+    const wrapper = await mountSuspended(TooltipProviderContentWrapper, {
+      props: { text: 'Tooltip', open: true, portal: false }
+    })
+
+    const content = wrapper.find('[data-slot="content"]')
+    expect(content.attributes('data-side')).toBe('right')
+  })
+
+  it('allows per-tooltip content to override provider defaults', async () => {
+    const wrapper = await mountSuspended(TooltipProviderContentWrapper, {
+      props: { text: 'Tooltip', open: true, portal: false, content: { side: 'top' } }
+    })
+
+    const content = wrapper.find('[data-slot="content"]')
+    expect(content.attributes('data-side')).toBe('top')
+  })
 
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(TooltipWrapper, {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
Follows-up https://github.com/nuxt/ui/pull/6147

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
Inject TooltipProvider context so that `tooltip.content` set on the App component is respected as default for all tooltips. The merge priority is: per-tooltip `content` > provider `content` > Nuxt UI defaults.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
