### PR TITLE
fix(Tree): use path-based keys to avoid label collisions

### DIFF
--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -142,7 +142,7 @@ export type TreeSlots<
 </script>
 
 <script setup lang="ts" generic="T extends TreeItem[], M extends boolean = false">
-import { computed, toRef, useTemplateRef } from 'vue'
+import { computed, toRaw, toRef, useTemplateRef } from 'vue'
 import { TreeRoot, TreeItem, TreeVirtualizer, useForwardPropsEmits } from 'reka-ui'
 import { reactivePick, createReusableTemplate } from '@vueuse/core'
 import { defu } from 'defu'
@@ -228,10 +228,22 @@ function getItemLabel<Item extends T[number]>(item: Item): string {
   return get(item, props.labelKey as string)
 }
 
+const itemPathMap = computed(() => {
+  const map = new WeakMap<object, string>()
+  function walk(items: T[number][], prefix: string) {
+    items?.forEach((item, i) => {
+      const path = prefix ? `${prefix}-${i}` : `${i}`
+      map.set(toRaw(item) as object, path)
+      if (item.children) walk(item.children, path)
+    })
+  }
+  walk(props.items as T[number][], '')
+  return map
+})
+
 function getItemKey<Item extends T[number]>(item: Item): string {
-  return props.getKey
-    ? props.getKey(item) || getItemLabel(item)
-    : getItemLabel(item)
+  if (props.getKey) return props.getKey(item) || getItemLabel(item)
+  return itemPathMap.value.get(toRaw(item) as object) ?? getItemLabel(item)
 }
 
 function getDefaultOpenedItems(item: T[number]): string[] {

--- a/test/components/Tree.spec.ts
+++ b/test/components/Tree.spec.ts
@@ -84,6 +84,32 @@ describe('Tree', () => {
     expect(await axe(wrapper.element)).toHaveNoViolations()
   })
 
+  it('items with duplicate labels at different levels have independent expand state', async () => {
+    const duplicateItems: TreeItem[] = [
+      { label: 'references', defaultExpanded: true, children: [{ label: 'nuxt.md' }] },
+      { label: 'module', defaultExpanded: true, children: [
+        { label: 'references', defaultExpanded: true, children: [{ label: 'querying.md' }] }
+      ] }
+    ]
+
+    const wrapper = await mountSuspended(Tree, { props: { items: duplicateItems } })
+
+    // All 5 items should be visible (both "references" expanded + "module" expanded)
+    const links = wrapper.findAll('[data-slot="link"]')
+    expect(links.length).toBe(5)
+
+    // Click the nested "references" (3rd link with children: references, module, references)
+    const nestedReferences = links[3]!
+    expect(nestedReferences.find('[data-slot="linkLabel"]').text()).toBe('references')
+    await nestedReferences.trigger('click')
+    await wrapper.vm.$nextTick()
+
+    // Root "references" children should still be visible
+    const updatedLinks = wrapper.findAll('[data-slot="link"]')
+    const labels = updatedLinks.map(l => l.find('[data-slot="linkLabel"]').text())
+    expect(labels).toContain('nuxt.md')
+  })
+
   test('should have the correct types', () => {
     expectEmitPayloadType('update:modelValue', () => Tree({
       items: [{ label: 'foo' }, { label: 'baz' }]


### PR DESCRIPTION
Without a custom `getKey` prop, `getItemKey()` defaults to the item's label. Items with the same label at different nesting levels (e.g. two folders named "references") share expansion/selection state.

The fix I implemented is a to build a `WeakMap` mapping each item to a unique index-based path (e.g. `0`, `1-0`, `1-0-0`). Uses `toRaw()` to handle Vue reactive proxies. Backward-compatible: users with `getKey` prop are unaffected.