### PR TITLE
fix(Modal/Slideover/Popover/Drawer): prevent double `close:prevent` emit

### DIFF
--- a/src/runtime/components/Drawer.vue
+++ b/src/runtime/components/Drawer.vue
@@ -93,7 +93,7 @@ const portalProps = usePortal(toRef(() => props.portal))
 const contentProps = toRef(() => props.content)
 const contentEvents = computed(() => {
   if (!props.dismissible) {
-    const events = ['pointerDownOutside', 'interactOutside', 'escapeKeyDown']
+    const events = ['interactOutside', 'escapeKeyDown']
 
     return events.reduce((acc, curr) => {
       acc[curr] = (e: Event) => {

--- a/src/runtime/components/Modal.vue
+++ b/src/runtime/components/Modal.vue
@@ -111,7 +111,7 @@ const portalProps = usePortal(toRef(() => props.portal))
 const contentProps = toRef(() => props.content)
 const contentEvents = computed(() => {
   if (!props.dismissible) {
-    const events = ['pointerDownOutside', 'interactOutside', 'escapeKeyDown']
+    const events = ['interactOutside', 'escapeKeyDown']
 
     return events.reduce((acc, curr) => {
       acc[curr] = (e: Event) => {

--- a/src/runtime/components/Popover.vue
+++ b/src/runtime/components/Popover.vue
@@ -90,7 +90,7 @@ const portalProps = usePortal(toRef(() => props.portal))
 const contentProps = toRef(() => defu(props.content, { side: 'bottom', sideOffset: 8, collisionPadding: 8 }) as PopoverContentProps)
 const contentEvents = computed(() => {
   if (!props.dismissible) {
-    const events = ['pointerDownOutside', 'interactOutside', 'escapeKeyDown']
+    const events = ['interactOutside', 'escapeKeyDown']
 
     return events.reduce((acc, curr) => {
       acc[curr] = (e: Event) => {

--- a/src/runtime/components/Slideover.vue
+++ b/src/runtime/components/Slideover.vue
@@ -112,7 +112,7 @@ const portalProps = usePortal(toRef(() => props.portal))
 const contentProps = toRef(() => props.content)
 const contentEvents = computed(() => {
   if (!props.dismissible) {
-    const events = ['pointerDownOutside', 'interactOutside', 'escapeKeyDown']
+    const events = ['interactOutside', 'escapeKeyDown']
 
     return events.reduce((acc, curr) => {
       acc[curr] = (e: Event) => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6224

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When `dismissible` is `false`, clicking the overlay triggers `@close:prevent` twice. This happens because the non-dismissible code path registers handlers for both `pointerDownOutside` and `interactOutside`, but Reka UI fires both events on an overlay click — `interactOutside` is a superset that includes pointer-down-outside interactions.

The fix removes `pointerDownOutside` from the event list, keeping only `interactOutside` and `escapeKeyDown`. This ensures `close:prevent` fires exactly once per interaction. The same pattern existed in Modal, Slideover, Popover, and Drawer, so all four are fixed.

Note: the `dismissible: true` path still uses its own `pointerDownOutside` handler for scrollbar-click prevention — that is unaffected.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.