### PR TITLE
fix(DashboardSidebar): add overflow-hidden to footer slot

### DIFF
--- a/src/theme/dashboard-sidebar.ts
+++ b/src/theme/dashboard-sidebar.ts
@@ -3,7 +3,7 @@ export default {
     root: 'relative hidden lg:flex flex-col min-h-svh min-w-16 w-(--width) shrink-0',
     header: 'h-(--ui-header-height) shrink-0 flex items-center gap-1.5 px-4',
     body: 'flex flex-col gap-4 flex-1 overflow-y-auto px-4 py-2',
-    footer: 'shrink-0 flex items-center gap-1.5 px-4 py-2',
+    footer: 'shrink-0 flex items-center gap-1.5 overflow-hidden px-4 py-2',
     toggle: '',
     handle: '',
     content: 'lg:hidden',

--- a/test/components/__snapshots__/DashboardSidebar-vue.spec.ts.snap
+++ b/test/components/__snapshots__/DashboardSidebar-vue.spec.ts.snap
@@ -110,7 +110,7 @@ exports[`DashboardSidebar > renders with footer slot correctly 1`] = `
   <div id="dashboard-sidebar-v-0" data-collapsed="false" data-dragging="false" data-slot="root" class="relative hidden lg:flex flex-col min-h-svh min-w-16 w-(--width) shrink-0 border-e border-default" style="--width: 15%;">
     <!--v-if-->
     <div data-slot="body" class="flex flex-col gap-4 flex-1 overflow-y-auto px-4 py-2"></div>
-    <div data-slot="footer" class="shrink-0 flex items-center gap-1.5 px-4 py-2">Footer slot</div>
+    <div data-slot="footer" class="shrink-0 flex items-center gap-1.5 overflow-hidden px-4 py-2">Footer slot</div>
   </div>
   <!--v-if-->
   <!--v-if-->

--- a/test/components/__snapshots__/DashboardSidebar.spec.ts.snap
+++ b/test/components/__snapshots__/DashboardSidebar.spec.ts.snap
@@ -110,7 +110,7 @@ exports[`DashboardSidebar > renders with footer slot correctly 1`] = `
   <div id="dashboard-sidebar-v-0-0-0" data-collapsed="false" data-dragging="false" data-slot="root" class="relative hidden lg:flex flex-col min-h-svh min-w-16 w-(--width) shrink-0 border-e border-default" style="--width: 15%;">
     <!--v-if-->
     <div data-slot="body" class="flex flex-col gap-4 flex-1 overflow-y-auto px-4 py-2"></div>
-    <div data-slot="footer" class="shrink-0 flex items-center gap-1.5 px-4 py-2">Footer slot</div>
+    <div data-slot="footer" class="shrink-0 flex items-center gap-1.5 overflow-hidden px-4 py-2">Footer slot</div>
   </div>
   <!--v-if-->
   <!--v-if-->


### PR DESCRIPTION
Fixes #6231

The footer slot in `DashboardSidebar` was missing overflow handling. When you put a `UNavigationMenu` in the footer, it doesn't resize correctly when the sidebar is collapsed — the content bleeds out. The body slot already has `overflow-y-auto` which creates an overflow context, but footer had nothing.

Added `overflow-hidden` to the footer slot theme class.