### PR TITLE
feat(skills): add table of contents to all skill files

### DIFF
--- a/skills/nuxt-ui/SKILL.md
+++ b/skills/nuxt-ui/SKILL.md
@@ -7,6 +7,18 @@ description: Build UIs with @nuxt/ui v4 — 125+ accessible Vue components with 
 
 Vue component library built on [Reka UI](https://reka-ui.com/) + [Tailwind CSS](https://tailwindcss.com/) + [Tailwind Variants](https://www.tailwind-variants.org/). Works with Nuxt, Vue (Vite), Laravel (Inertia), and AdonisJS (Inertia).
 
+## Table of contents
+
+- [Installation](#installation)
+- [Icons](#icons)
+- [Theming & Branding](#theming--branding)
+- [Composables](#composables)
+- [Form validation](#form-validation)
+- [Overlays](#overlays)
+- [Layouts](#layouts)
+- [Templates](#templates)
+- [Additional references](#additional-references)
+
 ## Installation
 
 ### Nuxt

--- a/skills/nuxt-ui/references/components.md
+++ b/skills/nuxt-ui/references/components.md
@@ -2,6 +2,21 @@
 
 125+ Vue components powered by Tailwind CSS and Reka UI. For any component's theme slots, read the generated theme file (Nuxt: `.nuxt/ui/<component>.ts`, Vue: `node_modules/.nuxt-ui/ui/<component>.ts`).
 
+## Table of contents
+
+- [Layout](#layout)
+- [Element](#element)
+- [Form](#form)
+- [Data](#data)
+- [Navigation](#navigation)
+- [Overlay](#overlay)
+- [Page](#page)
+- [Dashboard](#dashboard)
+- [Chat](#chat)
+- [Editor](#editor)
+- [Content](#content)
+- [Color Mode](#color-mode)
+
 ## Layout
 
 Core structural components for organizing your application's layout.

--- a/skills/nuxt-ui/references/composables.md
+++ b/skills/nuxt-ui/references/composables.md
@@ -1,5 +1,14 @@
 # Composables
 
+## Table of contents
+
+- [useToast](#usetoast)
+- [useOverlay](#useoverlay)
+- [defineShortcuts](#defineshortcuts)
+- [defineLocale / extendLocale](#definelocale--extendlocale)
+- [extractShortcuts](#extractshortcuts)
+- [Quick reference](#quick-reference)
+
 ## useToast
 
 Show notifications. Requires `<UApp>` wrapper.

--- a/skills/nuxt-ui/references/layouts/chat.md
+++ b/skills/nuxt-ui/references/layouts/chat.md
@@ -2,6 +2,16 @@
 
 Build AI chat interfaces with message streams, reasoning, tool calling, and Vercel AI SDK integration.
 
+## Table of contents
+
+- [Component tree](#component-tree)
+- [Setup](#setup)
+- [Full page chat](#full-page-chat)
+- [Key components](#key-components)
+- [Chat in a modal](#chat-in-a-modal)
+- [With model selector](#with-model-selector)
+- [Conversation sidebar](#conversation-sidebar)
+
 ## Component tree
 
 ```

--- a/skills/nuxt-ui/references/layouts/dashboard.md
+++ b/skills/nuxt-ui/references/layouts/dashboard.md
@@ -2,6 +2,17 @@
 
 Build admin interfaces with resizable sidebars, multi-panel layouts, and toolbars.
 
+## Table of contents
+
+- [Component tree](#component-tree)
+- [Layout](#layout)
+- [Page](#page)
+- [Key components](#key-components)
+- [Multi-panel (list-detail)](#multi-panel-list-detail)
+- [With toolbar](#with-toolbar)
+- [With search](#with-search)
+- [Right sidebar](#right-sidebar)
+
 ## Component tree
 
 ```

--- a/skills/nuxt-ui/references/layouts/docs.md
+++ b/skills/nuxt-ui/references/layouts/docs.md
@@ -4,6 +4,14 @@ Build documentation sites with sidebar navigation, table of contents, and surrou
 
 > Requires `@nuxt/content` module for navigation, search, and TOC.
 
+## Table of contents
+
+- [Component tree](#component-tree)
+- [App shell](#app-shell)
+- [Layout](#layout)
+- [Page](#page)
+- [Key components](#key-components)
+
 ## Component tree
 
 ```

--- a/skills/nuxt-ui/references/layouts/editor.md
+++ b/skills/nuxt-ui/references/layouts/editor.md
@@ -2,6 +2,15 @@
 
 Build a rich text editor with toolbars, slash commands, mentions, and drag-and-drop.
 
+## Table of contents
+
+- [Component tree](#component-tree)
+- [Page](#page)
+- [Key components](#key-components)
+- [Toolbar modes](#toolbar-modes)
+- [Content types](#content-types)
+- [With document sidebar](#with-document-sidebar)
+
 ## Component tree
 
 ```

--- a/skills/nuxt-ui/references/layouts/page.md
+++ b/skills/nuxt-ui/references/layouts/page.md
@@ -2,6 +2,16 @@
 
 Build public-facing pages — landing, blog, changelog, pricing — using the Header + Main + Footer shell with Page components.
 
+## Table of contents
+
+- [App shell](#app-shell)
+- [Landing page](#landing-page)
+- [Blog listing](#blog-listing)
+- [Blog article](#blog-article)
+- [Changelog](#changelog)
+- [Key components](#key-components)
+- [Variations](#variations)
+
 ## App shell
 
 ```vue [app.vue]

--- a/skills/nuxt-ui/references/theming.md
+++ b/skills/nuxt-ui/references/theming.md
@@ -1,5 +1,16 @@
 # Theming
 
+## Table of contents
+
+- [Semantic colors](#semantic-colors)
+- [Configuring colors](#configuring-colors)
+- [Adding custom colors](#adding-custom-colors)
+- [CSS utilities](#css-utilities)
+- [Component theme customization](#component-theme-customization)
+- [Dark mode](#dark-mode)
+- [Fonts](#fonts)
+- [Brand customization playbook](#brand-customization-playbook)
+
 ## Semantic colors
 
 | Color | Default | Purpose |


### PR DESCRIPTION
## Summary

- Add table of contents sections to `SKILL.md` and all 8 reference files in the `nuxt-ui` skill
- Helps AI agents navigate long documents more efficiently by providing an upfront overview of sections

## Files updated

| File | Lines |
|------|-------|
| `skills/nuxt-ui/SKILL.md` | 330+ |
| `skills/nuxt-ui/references/components.md` | 370+ |
| `skills/nuxt-ui/references/theming.md` | 420+ |
| `skills/nuxt-ui/references/composables.md` | 120+ |
| `skills/nuxt-ui/references/layouts/dashboard.md` | 220+ |
| `skills/nuxt-ui/references/layouts/chat.md` | 260+ |
| `skills/nuxt-ui/references/layouts/editor.md` | 160+ |
| `skills/nuxt-ui/references/layouts/page.md` | 260+ |
| `skills/nuxt-ui/references/layouts/docs.md` | 140+ |

## Why

Skill review tools recommend adding a TOC to files exceeding 100 lines. All 9 files in this skill exceed that threshold. A TOC at the top helps AI agents quickly locate the relevant section instead of scanning the entire document, improving context efficiency.

## Test plan

- [ ] Verify TOC links resolve correctly (all use standard markdown anchor format)
- [ ] Confirm no content was modified — only TOC sections were inserted