### PR TITLE
fix(ChatMessages): reset scroll icon when messages are cleared

### DIFF
--- a/src/runtime/components/ChatMessages.vue
+++ b/src/runtime/components/ChatMessages.vue
@@ -143,6 +143,14 @@ function scrollToBottom(smooth: boolean = true) {
 }
 
 watchThrottled([() => props.messages, () => props.status], ([_, status]) => {
+  if (!props.messages?.length) {
+    showAutoScroll.value = false
+    userScrolledUp.value = false
+    lastScrollTop.value = 0
+    messagesRefs.value.clear()
+    return
+  }
+
   if (status !== 'streaming') {
     return
   }


### PR DESCRIPTION
Fixes #6235

The scroll-to-bottom icon stays visible after you clear messages because the `watchThrottled` handler returns early when `status !== 'streaming'`, so the reset never fires.

When `messages` goes empty, reset `showAutoScroll`, `userScrolledUp`, `lastScrollTop`, and `messagesRefs` before the status check.