### PR TITLE
fix(Modal/Slideover): suppress aria-describedby warning when no description

### DIFF
--- a/src/runtime/components/Modal.vue
+++ b/src/runtime/components/Modal.vue
@@ -144,6 +144,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.modal || {})
       <DialogContent
         data-slot="content"
         :class="ui.content({ class: [!slots.default && props.class, uiProp?.content] })"
+        :aria-describedby="(!description && !slots.description) ? 'undefined' : undefined"
         v-bind="contentProps"
         @after-enter="emits('after:enter')"
         @after-leave="emits('after:leave')"

--- a/src/runtime/components/Slideover.vue
+++ b/src/runtime/components/Slideover.vue
@@ -149,6 +149,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.slideover ||
         :data-side="side"
         data-slot="content"
         :class="ui.content({ class: [!slots.default && props.class, uiProp?.content] })"
+        :aria-describedby="(!description && !slots.description) ? 'undefined' : undefined"
         v-bind="contentProps"
         @after-enter="emits('after:enter')"
         @after-leave="emits('after:leave')"


### PR DESCRIPTION
Fixes #6240

Reka UI warns `Missing 'Description' or 'aria-describedby="undefined"'` when `DialogContent` has no `DialogDescription` child. The fix is to pass `aria-describedby="undefined"` to suppress it when no description is intentionally provided.

Added the conditional binding to both `Modal.vue` and `Slideover.vue` — when description prop and slot are both absent, set it; otherwise leave it unset so reka-ui can wire it to the `DialogDescription` id normally.