### PR TITLE
fix(NavigationMenu): correct `item-content` and `item-trailing` slot behavior

### DIFF
--- a/docs/content/docs/2.components/navigation-menu.md
+++ b/docs/content/docs/2.components/navigation-menu.md
@@ -1340,6 +1340,10 @@ You can also use the `#item`, `#item-leading`, `#item-label`, `#item-trailing` a
 
 Use the `#item-trailing` slot or the `slot` property (`#{{ item.slot }}-trailing`) to add a [DropdownMenu](/docs/components/dropdown-menu) that appears on hover, similar to Notion or Linear.
 
+::note
+When you pass `#item-trailing` (or `#{{ item.slot }}-trailing`), it replaces the default trailing UI for every item (badge and chevron). Use the slot props (`item`, `active`, etc.) to render different content per row.
+::
+
 ::component-example
 ---
 collapse: true
@@ -1350,6 +1354,10 @@ name: 'navigation-menu-trailing-slot-example'
 ### With content slot
 
 Use the `#item-content` slot or the `slot` property (`#{{ item.slot }}-content`) to customize the content of a specific item.
+
+::note
+In **horizontal** orientation, the menu trigger and panel are only rendered for items that define a `children` array. The `#item-content` slot customizes what appears inside that panel, it does not create a dropdown for items without `children`.
+::
 
 ::component-example
 ---

--- a/src/runtime/components/NavigationMenu.vue
+++ b/src/runtime/components/NavigationMenu.vue
@@ -369,13 +369,16 @@ function onLinkTrailingClick(e: Event, item: NavigationMenuItem) {
 
       <component
         :is="props.orientation === 'vertical' && item.children?.length && !props.collapsed ? AccordionTrigger : 'span'"
-        v-if="(item.badge || item.badge === 0) || (props.orientation === 'horizontal' && (item.children?.length || !!slots[(item.slot ? `${item.slot}-content` : 'item-content') as keyof NavigationMenuSlots<T>])) || (props.orientation === 'vertical' && item.children?.length) || item.trailingIcon || !!slots[(item.slot ? `${item.slot}-trailing` : 'item-trailing') as keyof NavigationMenuSlots<T>]"
+        v-if="(item.badge || item.badge === 0) || (props.orientation === 'horizontal' && item.children?.length) || (props.orientation === 'vertical' && item.children?.length) || item.trailingIcon || !!slots[(item.slot ? `${item.slot}-trailing` : 'item-trailing') as keyof NavigationMenuSlots<T>]"
         :as="props.orientation === 'vertical' && item.children?.length && !props.collapsed ? 'span' : undefined"
         data-slot="linkTrailing"
         :class="ui.linkTrailing({ class: [props.ui?.linkTrailing, item.ui?.linkTrailing] })"
         @click="(e: Event) => onLinkTrailingClick(e, item)"
       >
-        <slot :name="((item.slot ? `${item.slot}-trailing` : 'item-trailing') as keyof NavigationMenuSlots<T>)" :item="item" :active="active" :index="index" :ui="ui">
+        <template v-if="!!slots[(item.slot ? `${item.slot}-trailing` : 'item-trailing') as keyof NavigationMenuSlots<T>]">
+          <slot :name="((item.slot ? `${item.slot}-trailing` : 'item-trailing') as keyof NavigationMenuSlots<T>)" :item="item" :active="active" :index="index" :ui="ui" />
+        </template>
+        <template v-else>
           <UBadge
             v-if="item.badge || item.badge === 0"
             color="neutral"
@@ -386,9 +389,9 @@ function onLinkTrailingClick(e: Event, item: NavigationMenuItem) {
             :class="ui.linkTrailingBadge({ class: [props.ui?.linkTrailingBadge, item.ui?.linkTrailingBadge] })"
           />
 
-          <UIcon v-if="(props.orientation === 'horizontal' && (item.children?.length || !!slots[(item.slot ? `${item.slot}-content` : 'item-content') as keyof NavigationMenuSlots<T>])) || (props.orientation === 'vertical' && item.children?.length)" :name="item.trailingIcon || props.trailingIcon || appConfig.ui.icons.chevronDown" data-slot="linkTrailingIcon" :class="ui.linkTrailingIcon({ class: [props.ui?.linkTrailingIcon, item.ui?.linkTrailingIcon], active })" />
+          <UIcon v-if="(props.orientation === 'horizontal' && item.children?.length) || (props.orientation === 'vertical' && item.children?.length)" :name="item.trailingIcon || props.trailingIcon || appConfig.ui.icons.chevronDown" data-slot="linkTrailingIcon" :class="ui.linkTrailingIcon({ class: [props.ui?.linkTrailingIcon, item.ui?.linkTrailingIcon], active })" />
           <UIcon v-else-if="item.trailingIcon" :name="item.trailingIcon" data-slot="linkTrailingIcon" :class="ui.linkTrailingIcon({ class: [props.ui?.linkTrailingIcon, item.ui?.linkTrailingIcon], active })" />
-        </slot>
+        </template>
       </component>
     </slot>
   </DefineLinkTemplate>
@@ -405,7 +408,7 @@ function onLinkTrailingClick(e: Event, item: NavigationMenuItem) {
       </div>
       <ULink v-else-if="item.type !== 'label'" v-slot="{ active, ...slotProps }" v-bind="(props.orientation === 'vertical' && item.children?.length && !props.collapsed && item.type === 'trigger') ? {} : pickLinkProps(item as Omit<NavigationMenuItem, 'type'>)" custom>
         <component
-          :is="(props.orientation === 'horizontal' && (item.children?.length || !!slots[(item.slot ? `${item.slot}-content` : 'item-content') as keyof NavigationMenuSlots<T>])) ? NavigationMenuTrigger : ((props.orientation === 'vertical' && item.children?.length && !props.collapsed && !(slotProps as any).href) ? AccordionTrigger : NavigationMenuLink)"
+          :is="(props.orientation === 'horizontal' && item.children?.length) ? NavigationMenuTrigger : ((props.orientation === 'vertical' && item.children?.length && !props.collapsed && !(slotProps as any).href) ? AccordionTrigger : NavigationMenuLink)"
           as-child
           :active="active || item.active"
           :disabled="item.disabled"
@@ -458,7 +461,7 @@ function onLinkTrailingClick(e: Event, item: NavigationMenuItem) {
           </ULinkBase>
         </component>
 
-        <NavigationMenuContent v-if="props.orientation === 'horizontal' && (item.children?.length || !!slots[(item.slot ? `${item.slot}-content` : 'item-content') as keyof NavigationMenuSlots<T>])" v-bind="contentProps" data-slot="content" :class="ui.content({ class: [props.ui?.content, item.ui?.content] })">
+        <NavigationMenuContent v-if="props.orientation === 'horizontal' && item.children?.length" v-bind="contentProps" data-slot="content" :class="ui.content({ class: [props.ui?.content, item.ui?.content] })">
           <slot :name="((item.slot ? `${item.slot}-content` : 'item-content') as keyof NavigationMenuSlots<T>)" :item="item" :active="active || item.active" :index="index" :ui="ui">
             <ul data-slot="childList" :class="ui.childList({ class: [props.ui?.childList, item.ui?.childList] })">
               <li v-for="(childItem, childIndex) in item.children" :key="childIndex" data-slot="childItem" :class="ui.childItem({ class: [props.ui?.childItem, item.ui?.childItem] })">

--- a/test/components/NavigationMenu.spec.ts
+++ b/test/components/NavigationMenu.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, test } from 'vitest'
+import { h } from 'vue'
 import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { renderEach } from '../component-render'
@@ -128,6 +129,46 @@ describe('NavigationMenu', () => {
     })
 
     expect(await axe(wrapper.element)).toHaveNoViolations()
+  })
+
+  it('does not treat global item-content slot as a trigger for items without children', async () => {
+    const wrapper = await mountSuspended(NavigationMenu, {
+      props: {
+        orientation: 'horizontal',
+        variant: 'link',
+        items: [[
+          { label: 'NoChildren', to: '/' },
+          { label: 'WithChildren', to: '/', children: [{ label: 'Child', to: '/child' }] }
+        ]]
+      },
+      slots: {
+        'item-content': ({ item }: { item: { children?: unknown[] } }) => h('div', item.children?.length ? 'custom' : '')
+      }
+    })
+
+    // Only the item with `children` uses NavigationMenuTrigger; the slot must not force a trigger on plain links.
+    expect(wrapper.findAll('[data-navigation-menu-trigger]')).toHaveLength(1)
+  })
+
+  it('item-trailing slot fully overrides default trailing icons', async () => {
+    const wrapper = await mountSuspended(NavigationMenu, {
+      props: {
+        orientation: 'horizontal',
+        variant: 'link',
+        items: [[
+          { label: 'NoChildren', to: '/' },
+          { label: 'WithChildren', to: '/', children: [{ label: 'Child', to: '/child' }] }
+        ]]
+      },
+      slots: {
+        'item-trailing': ({ item }: { item: { children?: unknown[] } }) => item.children?.length
+          ? h('span', { 'data-testid': 'custom-trailing' }, 'V')
+          : undefined
+      }
+    })
+
+    expect(wrapper.findAll('[data-slot="linkTrailingIcon"]')).toHaveLength(0)
+    expect(wrapper.findAll('[data-testid="custom-trailing"]')).toHaveLength(1)
   })
 
   test('should have the correct types', () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

Resolves https://github.com/nuxt/ui/issues/6251

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

**Gate dropdown shell on `children` only (horizontal)**

Removed all uses of global `!!slots[…'item-content'…]` from:

- Whether to render `NavigationMenuTrigger` vs a plain link
- Whether to render `NavigationMenuContent`
- Default chevron visibility and the `linkTrailing` wrapper conditions tied to that pattern

Horizontal mega-menu UI is now driven by **`item.children?.length`**. `#item-content` only **customizes** the panel when those children exist; it no longer forces a panel for every row.

**Note:** If anyone relied on `#item-content` without `children` to force a panel, they need a real `children` list (or a future explicit API) instead.

**Full override for `#item-trailing`**

Replaced “slot with fallback” with an explicit branch:

- If the relevant trailing slot is present (`item-trailing` or `` `${item.slot}-trailing` ``), render **only** that `<slot>` (same scoped props as before).
- Otherwise render the previous default block (`UBadge` + conditional `UIcon`s).

### Demo

https://github.com/user-attachments/assets/de111f1e-2cc2-451f-9e83-b0e46c4a9f6a

Code of the demo (similar to the repro of the linked issue):

```vue
<script setup lang="ts">
import type { NavigationMenuItem } from '@nuxt/ui'

const items = computed<NavigationMenuItem[]>(() => [
  {
    label: 'Platforms',
    icon: 'i-lucide-server',
    children: [
      { label: 'Claude Code', to: '/claude-code' },
      { label: 'Claude Search', to: '/claude-search' },
      { label: 'Claude Vision', to: '/claude-vision' },
      { label: 'Claude Translate', to: '/claude-translate' },
      { label: 'Claude Write', to: '/claude-write' },
      { label: 'Claude Edit', to: '/claude-edit' },
      { label: 'Claude Generate', to: '/claude-generate' },
      { label: 'Claude Summarize', to: '/claude-summarize' }
    ]
  },
  {
    label: 'Models',
    icon: 'i-lucide-brain'
  },
  {
    label: 'Tools',
    icon: 'i-lucide-wrench'
  }
])
</script>

<template>
  <div>
    <UNavigationMenu :items="items">
      <template #item-trailing="{ item }">
        <span v-if="item.children">V</span>
      </template>

      <template #item-content="{ item }">
        <span v-if="item.children">More info...</span>
      </template>
    </UNavigationMenu>
  </div>
</template>
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
