### PR TITLE
fix(Header/DashboardSidebar/Sidebar): allow auto focus in menu for proper focus trapping

### DIFF
--- a/src/runtime/components/DashboardSidebar.vue
+++ b/src/runtime/components/DashboardSidebar.vue
@@ -133,11 +133,7 @@ const Menu = computed(() => ({
   drawer: UDrawer
 })[props.mode as DashboardSidebarMode])
 
-const menuProps = toRef(() => defu(props.menu, {
-  content: {
-    onOpenAutoFocus: (e: Event) => e.preventDefault()
-  }
-}, props.mode === 'modal' ? { fullscreen: true, transition: false } : props.mode === 'slideover' ? { side: 'left' } : {}) as DashboardSidebarMenu<T>)
+const menuProps = toRef(() => defu(props.menu, {}, props.mode === 'modal' ? { fullscreen: true, transition: false } : props.mode === 'slideover' ? { side: 'left' } : {}) as DashboardSidebarMenu<T>)
 
 function toggleOpen() {
   open.value = !open.value

--- a/src/runtime/components/Header.vue
+++ b/src/runtime/components/Header.vue
@@ -120,11 +120,7 @@ const Menu = computed(() => ({
   drawer: UDrawer
 })[props.mode as HeaderMode])
 
-const menuProps = toRef(() => defu(props.menu, {
-  content: {
-    onOpenAutoFocus: (e: Event) => e.preventDefault()
-  }
-}, props.mode === 'modal' ? { fullscreen: true, transition: false } : {}) as HeaderMenu<T>)
+const menuProps = toRef(() => defu(props.menu, {}, props.mode === 'modal' ? { fullscreen: true, transition: false } : {}) as HeaderMenu<T>)
 
 function toggleOpen() {
   open.value = !open.value

--- a/src/runtime/components/Sidebar.vue
+++ b/src/runtime/components/Sidebar.vue
@@ -200,10 +200,7 @@ const menuProps = toRef(() => defu(props.menu, {
   title: props.title,
   description: props.description,
   close: props.close,
-  closeIcon: props.closeIcon,
-  content: {
-    onOpenAutoFocus: (e: Event) => e.preventDefault()
-  }
+  closeIcon: props.closeIcon
 }, props.mode === 'modal' ? { } : props.mode === 'slideover' ? { side: props.side, inset: props.variant === 'inset' } : {}) as SidebarMenu<T>)
 </script>
 

--- a/test/components/Header.spec.ts
+++ b/test/components/Header.spec.ts
@@ -40,17 +40,4 @@ describe('Header', () => {
 
     expect(await axe(wrapper.element)).toHaveNoViolations()
   })
-
-  it('does not suppress auto-focus when modal menu opens', async () => {
-    const wrapper = await mountSuspended(Header, {
-      props: {
-        open: true,
-        mode: 'modal',
-        menu: { portal: false }
-      }
-    })
-
-    const dialog = wrapper.find('[role="dialog"]')
-    expect(dialog.exists()).toBe(true)
-  })
 })

--- a/test/components/Header.spec.ts
+++ b/test/components/Header.spec.ts
@@ -40,4 +40,17 @@ describe('Header', () => {
 
     expect(await axe(wrapper.element)).toHaveNoViolations()
   })
+
+  it('does not suppress auto-focus in modal menu props', async () => {
+    const wrapper = await mountSuspended(Header, {
+      props: {
+        open: true,
+        mode: 'modal',
+        menu: { portal: false }
+      }
+    })
+
+    // Verify the modal content is rendered when open
+    expect(wrapper.html()).toBeTruthy()
+  })
 })

--- a/test/components/Header.spec.ts
+++ b/test/components/Header.spec.ts
@@ -41,7 +41,7 @@ describe('Header', () => {
     expect(await axe(wrapper.element)).toHaveNoViolations()
   })
 
-  it('does not suppress auto-focus in modal menu props', async () => {
+  it('does not suppress auto-focus when modal menu opens', async () => {
     const wrapper = await mountSuspended(Header, {
       props: {
         open: true,
@@ -50,7 +50,7 @@ describe('Header', () => {
       }
     })
 
-    // Verify the modal content is rendered when open
-    expect(wrapper.html()).toBeTruthy()
+    const dialog = wrapper.find('[role="dialog"]')
+    expect(dialog.exists()).toBe(true)
   })
 })


### PR DESCRIPTION
### Description

Fixes #6257

When `UHeader`, `UDashboardSidebar`, and `USidebar` open their mobile menu modal via keyboard, focus should automatically move inside the modal content. Instead, the `onOpenAutoFocus` handler in `menuProps` called `e.preventDefault()`, which suppressed reka-ui's Dialog auto-focus behavior. This caused Tab navigation to traverse background page content before the focus trap engaged.

### Root Cause

All three components configured the menu's content props with:

```typescript
content: {
  onOpenAutoFocus: (e: Event) => e.preventDefault()
}
```

This blocks the default WAI-ARIA Dialog focus management that reka-ui provides.

### Fix

Removed the `onOpenAutoFocus` handler from `menuProps` defaults in `Header.vue`, `DashboardSidebar.vue`, and `Sidebar.vue`, allowing reka-ui to handle focus management correctly on modal open (auto-focus first focusable element inside the dialog).

### Opt-out

Users who need the previous behavior can still suppress auto-focus via the `menu` prop:

```vue
<UHeader :menu="{ content: { onOpenAutoFocus: (e) => e.preventDefault() } }" />
```

Since `defu` merges user-provided values with highest priority, this overrides the default.

### WCAG Reference

- [WCAG 2.4.3 - Focus Order](https://www.w3.org/WAI/WCAG21/Understanding/focus-order): Focus must move in a meaningful sequence. Tabbing through hidden background content violates this.