### PR TITLE
fix(ContentToc): use links for scrollspy instead of hardcoded h2/h3

### DIFF
--- a/src/runtime/components/content/ContentToc.vue
+++ b/src/runtime/components/content/ContentToc.vue
@@ -75,7 +75,7 @@ export interface ContentTocSlots<T extends ContentTocLink = ContentTocLink> {
 import { useAppConfig, useNuxtApp, useRouter } from '#imports'
 import { createReusableTemplate, reactivePick } from '@vueuse/core'
 import { CollapsibleContent, CollapsibleRoot, CollapsibleTrigger, useForwardPropsEmits } from 'reka-ui'
-import { computed } from 'vue'
+import { computed, onUnmounted } from 'vue'
 import { useComponentUI } from '../../composables/useComponentUI'
 import { useLocale } from '../../composables/useLocale'
 import { useScrollspy } from '../../composables/useScrollspy'
@@ -193,24 +193,24 @@ const circuitMaskStyle = computed(() => {
 
 const nuxtApp = useNuxtApp()
 
-nuxtApp.hooks.hook("page:loading:end", () => {
-  const flatLinks = flattenLinks(props.links || []);
-  const headings = Array.from(
-    document.querySelectorAll(
-      flatLinks.map((l) => `#${CSS.escape(l.id)}`).join(", "),
-    ),
-  );
-  updateHeadings(headings);
-});
-nuxtApp.hooks.hook("page:transition:finish", () => {
-  const flatLinks = flattenLinks(props.links || []);
-  const headings = Array.from(
-    document.querySelectorAll(
-      flatLinks.map((l) => `#${CSS.escape(l.id)}`).join(", "),
-    ),
-  );
-  updateHeadings(headings);
-});
+function refreshHeadings() {
+  const flatLinks = flattenLinks(props.links || [])
+  if (!flatLinks.length) {
+    updateHeadings([])
+    return
+  }
+  const selector = flatLinks.map(l => `#${CSS.escape(l.id)}`).join(', ')
+  const headings = Array.from(document.querySelectorAll(selector))
+  updateHeadings(headings)
+}
+
+const offLoadingEnd = nuxtApp.hooks.hook('page:loading:end', refreshHeadings)
+const offTransitionFinish = nuxtApp.hooks.hook('page:transition:finish', refreshHeadings)
+
+onUnmounted(() => {
+  offLoadingEnd()
+  offTransitionFinish()
+})
 </script>
 
 <template>

--- a/src/runtime/components/content/ContentToc.vue
+++ b/src/runtime/components/content/ContentToc.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import theme from '#build/ui/content/content-toc'
+import type { CollapsibleRootProps, CollapsibleRootEmits } from 'reka-ui'
+import type { VNode } from 'vue'
 import type { TocLink } from '@nuxt/content'
 import type { AppConfig } from '@nuxt/schema'
-import type { CollapsibleRootEmits, CollapsibleRootProps } from 'reka-ui'
-import type { VNode } from 'vue'
+import theme from '#build/ui/content/content-toc'
 import type { IconProps } from '../../types'
 import type { ComponentConfig } from '../../types/tv'
 
@@ -72,13 +72,13 @@ export interface ContentTocSlots<T extends ContentTocLink = ContentTocLink> {
 </script>
 
 <script setup lang="ts" generic="T extends ContentTocLink">
-import { useAppConfig, useNuxtApp, useRouter } from '#imports'
-import { createReusableTemplate, reactivePick } from '@vueuse/core'
-import { CollapsibleContent, CollapsibleRoot, CollapsibleTrigger, useForwardPropsEmits } from 'reka-ui'
 import { computed, onUnmounted } from 'vue'
+import { CollapsibleRoot, CollapsibleTrigger, CollapsibleContent, useForwardPropsEmits } from 'reka-ui'
+import { reactivePick, createReusableTemplate } from '@vueuse/core'
+import { useRouter, useAppConfig, useNuxtApp } from '#imports'
 import { useComponentUI } from '../../composables/useComponentUI'
-import { useLocale } from '../../composables/useLocale'
 import { useScrollspy } from '../../composables/useScrollspy'
+import { useLocale } from '../../composables/useLocale'
 import { tv } from '../../utils/tv'
 import UIcon from '../Icon.vue'
 

--- a/src/runtime/components/content/ContentToc.vue
+++ b/src/runtime/components/content/ContentToc.vue
@@ -1,9 +1,9 @@
 <script lang="ts">
-import type { CollapsibleRootProps, CollapsibleRootEmits } from 'reka-ui'
-import type { VNode } from 'vue'
+import theme from '#build/ui/content/content-toc'
 import type { TocLink } from '@nuxt/content'
 import type { AppConfig } from '@nuxt/schema'
-import theme from '#build/ui/content/content-toc'
+import type { CollapsibleRootEmits, CollapsibleRootProps } from 'reka-ui'
+import type { VNode } from 'vue'
 import type { IconProps } from '../../types'
 import type { ComponentConfig } from '../../types/tv'
 
@@ -72,13 +72,13 @@ export interface ContentTocSlots<T extends ContentTocLink = ContentTocLink> {
 </script>
 
 <script setup lang="ts" generic="T extends ContentTocLink">
+import { useAppConfig, useNuxtApp, useRouter } from '#imports'
+import { createReusableTemplate, reactivePick } from '@vueuse/core'
+import { CollapsibleContent, CollapsibleRoot, CollapsibleTrigger, useForwardPropsEmits } from 'reka-ui'
 import { computed } from 'vue'
-import { CollapsibleRoot, CollapsibleTrigger, CollapsibleContent, useForwardPropsEmits } from 'reka-ui'
-import { reactivePick, createReusableTemplate } from '@vueuse/core'
-import { useRouter, useAppConfig, useNuxtApp } from '#imports'
 import { useComponentUI } from '../../composables/useComponentUI'
-import { useScrollspy } from '../../composables/useScrollspy'
 import { useLocale } from '../../composables/useLocale'
+import { useScrollspy } from '../../composables/useScrollspy'
 import { tv } from '../../utils/tv'
 import UIcon from '../Icon.vue'
 
@@ -193,14 +193,24 @@ const circuitMaskStyle = computed(() => {
 
 const nuxtApp = useNuxtApp()
 
-nuxtApp.hooks.hook('page:loading:end', () => {
-  const headings = Array.from(document.querySelectorAll('h2, h3'))
-  updateHeadings(headings)
-})
-nuxtApp.hooks.hook('page:transition:finish', () => {
-  const headings = Array.from(document.querySelectorAll('h2, h3'))
-  updateHeadings(headings)
-})
+nuxtApp.hooks.hook("page:loading:end", () => {
+  const flatLinks = flattenLinks(props.links || []);
+  const headings = Array.from(
+    document.querySelectorAll(
+      flatLinks.map((l) => `#${CSS.escape(l.id)}`).join(", "),
+    ),
+  );
+  updateHeadings(headings);
+});
+nuxtApp.hooks.hook("page:transition:finish", () => {
+  const flatLinks = flattenLinks(props.links || []);
+  const headings = Array.from(
+    document.querySelectorAll(
+      flatLinks.map((l) => `#${CSS.escape(l.id)}`).join(", "),
+    ),
+  );
+  updateHeadings(headings);
+});
 </script>
 
 <template>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #5967

### ❓ Type of change



- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description



&nbsp;

In the ContentToc component, the [useScrollSpy](https://github.com/nuxt/ui/blob/v4/src/runtime/composables/useScrollspy.ts) was attached to `h2` and `h3` headings independently of the links passed in the props or the `content/build/markdown/toc/depth` configuration entry of Nuxt Content.
This caused the height of the indicator to be "wrong".

The fix was to instruct the spy to only look for the actual links passed in the props.

### 📝 Checklist



&nbsp;

&nbsp;

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

