### PR TITLE
fix(ChatMessages): render indicator as div to prevent layout jump

### DIFF
--- a/src/runtime/components/ChatMessages.vue
+++ b/src/runtime/components/ChatMessages.vue
@@ -329,7 +329,6 @@ onMounted(() => {
     <UChatMessage
       v-if="showIndicator"
       id="indicator"
-      as="div"
       role="assistant"
       v-bind="{ ...assistantProps, actions: undefined, parts: [] }"
       :compact="compact"

--- a/src/runtime/components/ChatMessages.vue
+++ b/src/runtime/components/ChatMessages.vue
@@ -329,6 +329,7 @@ onMounted(() => {
     <UChatMessage
       v-if="showIndicator"
       id="indicator"
+      as="div"
       role="assistant"
       v-bind="{ ...assistantProps, actions: undefined, parts: [] }"
       :compact="compact"

--- a/src/theme/chat-messages.ts
+++ b/src/theme/chat-messages.ts
@@ -1,6 +1,6 @@
 export default {
   slots: {
-    root: 'w-full flex flex-col gap-1 flex-1 px-2.5 [&>article]:last-of-type:min-h-(--last-message-height)',
+    root: 'w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)',
     indicator: 'h-6 flex items-center gap-1 py-3 *:size-2 *:rounded-full *:bg-elevated [&>*:nth-child(1)]:animate-[bounce_1s_infinite] [&>*:nth-child(2)]:animate-[bounce_1s_0.15s_infinite] [&>*:nth-child(3)]:animate-[bounce_1s_0.3s_infinite]',
     viewport: 'absolute inset-x-0 top-[86%] data-[state=open]:animate-[fade-in_200ms_ease-out] data-[state=closed]:animate-[fade-out_200ms_ease-in]',
     autoScroll: 'rounded-full absolute right-1/2 translate-x-1/2 bottom-0'

--- a/test/components/__snapshots__/ChatMessages-vue.spec.ts.snap
+++ b/test/components/__snapshots__/ChatMessages-vue.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ChatMessages > renders with assistant correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -24,7 +24,7 @@ exports[`ChatMessages > renders with assistant correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with class correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height) max-w-3xl" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height) max-w-3xl" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -47,7 +47,7 @@ exports[`ChatMessages > renders with class correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with compact correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-3">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-1.5 pb-3">
@@ -70,7 +70,7 @@ exports[`ChatMessages > renders with compact correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with content slot correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -93,14 +93,14 @@ exports[`ChatMessages > renders with content slot correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with default slot correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">Default slot
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">Default slot
   <!--v-if-->
   <!---->
 </div>"
 `;
 
 exports[`ChatMessages > renders with files slot correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -123,7 +123,7 @@ exports[`ChatMessages > renders with files slot correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with indicator slot correctly 1`] = `
-"<div data-status="submitted" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-status="submitted" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -153,7 +153,7 @@ exports[`ChatMessages > renders with indicator slot correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with messages correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -176,7 +176,7 @@ exports[`ChatMessages > renders with messages correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with status error correctly 1`] = `
-"<div data-status="error" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-status="error" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -199,7 +199,7 @@ exports[`ChatMessages > renders with status error correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with status ready correctly 1`] = `
-"<div data-status="ready" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-status="ready" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -222,7 +222,7 @@ exports[`ChatMessages > renders with status ready correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with status streaming correctly 1`] = `
-"<div data-status="streaming" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-status="streaming" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -245,7 +245,7 @@ exports[`ChatMessages > renders with status streaming correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with status submitted correctly 1`] = `
-"<div data-status="submitted" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-status="submitted" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -277,7 +277,7 @@ exports[`ChatMessages > renders with status submitted correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with ui correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -300,7 +300,7 @@ exports[`ChatMessages > renders with ui correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with user correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -323,7 +323,7 @@ exports[`ChatMessages > renders with user correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with viewport slot correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">

--- a/test/components/__snapshots__/ChatMessages.spec.ts.snap
+++ b/test/components/__snapshots__/ChatMessages.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ChatMessages > renders with assistant correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -24,7 +24,7 @@ exports[`ChatMessages > renders with assistant correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with class correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height) max-w-3xl" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height) max-w-3xl" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -47,7 +47,7 @@ exports[`ChatMessages > renders with class correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with compact correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-3">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-1.5 pb-3">
@@ -70,7 +70,7 @@ exports[`ChatMessages > renders with compact correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with content slot correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -93,14 +93,14 @@ exports[`ChatMessages > renders with content slot correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with default slot correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">Default slot
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">Default slot
   <!--v-if-->
   <!---->
 </div>"
 `;
 
 exports[`ChatMessages > renders with files slot correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -123,7 +123,7 @@ exports[`ChatMessages > renders with files slot correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with indicator slot correctly 1`] = `
-"<div data-status="submitted" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-status="submitted" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -153,7 +153,7 @@ exports[`ChatMessages > renders with indicator slot correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with messages correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -176,7 +176,7 @@ exports[`ChatMessages > renders with messages correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with status error correctly 1`] = `
-"<div data-status="error" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-status="error" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -199,7 +199,7 @@ exports[`ChatMessages > renders with status error correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with status ready correctly 1`] = `
-"<div data-status="ready" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-status="ready" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -222,7 +222,7 @@ exports[`ChatMessages > renders with status ready correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with status streaming correctly 1`] = `
-"<div data-status="streaming" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-status="streaming" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -245,7 +245,7 @@ exports[`ChatMessages > renders with status streaming correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with status submitted correctly 1`] = `
-"<div data-status="submitted" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-status="submitted" data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -277,7 +277,7 @@ exports[`ChatMessages > renders with status submitted correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with ui correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -300,7 +300,7 @@ exports[`ChatMessages > renders with ui correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with user correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">
@@ -323,7 +323,7 @@ exports[`ChatMessages > renders with user correctly 1`] = `
 `;
 
 exports[`ChatMessages > renders with viewport slot correctly 1`] = `
-"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 [&amp;>article]:last-of-type:min-h-(--last-message-height)" style="--last-message-height: 0px;">
+"<div data-slot="root" class="w-full flex flex-col gap-1 flex-1 px-2.5 pb-(--last-message-height)" style="--last-message-height: 0px;">
   <article data-role="user" data-slot="root" class="group/message relative w-full scroll-mt-4 sm:scroll-mt-6">
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start justify-end ms-auto max-w-[75%] gap-3 pb-8">


### PR DESCRIPTION
## Summary

- Adds `as="div"` to the indicator `UChatMessage` in `ChatMessages.vue` so it no longer renders as an `<article>`.
- This prevents the CSS selector `[&>article]:last-of-type:min-h-(--last-message-height)` from targeting the indicator instead of the actual last message, which caused a layout jump when transitioning from an index page to a chat page.

## Details

Since the `showIndicator` change (commit 195cce8), the indicator stays in the DOM during streaming until the first content arrives. Because it rendered as `<article>`, it was matched by the `:last-of-type` selector, causing the last message's `min-height` to apply to the indicator instead, resulting in a visible layout shift.

The scroll logic is unaffected because `registerMessageRef` and `updateLastMessageHeight` only reference actual messages, not the indicator.