### PR TITLE
fix(Header): move container slot classes into theme for doc accuracy

### DIFF
--- a/src/runtime/components/Header.vue
+++ b/src/runtime/components/Header.vue
@@ -172,7 +172,7 @@ function toggleOpen() {
   <Primitive :as="as" v-bind="$attrs" data-slot="root" :class="ui.root({ class: [uiProp?.root, props.class] })">
     <slot name="top" />
 
-    <div data-slot="container" :class="ui.container({ class: uiProp?.container })">
+    <div :class="ui.container({ class: uiProp?.container })" data-slot="container">
       <ReuseLeftTemplate />
 
       <div data-slot="center" :class="ui.center({ class: uiProp?.center })">

--- a/src/runtime/components/Header.vue
+++ b/src/runtime/components/Header.vue
@@ -71,7 +71,6 @@ import { getSlotChildrenText } from '../utils'
 import { tv } from '../utils/tv'
 import UButton from './Button.vue'
 import ULink from './Link.vue'
-import UContainer from './Container.vue'
 import USlideover from './Slideover.vue'
 import UModal from './Modal.vue'
 import UDrawer from './Drawer.vue'
@@ -173,7 +172,7 @@ function toggleOpen() {
   <Primitive :as="as" v-bind="$attrs" data-slot="root" :class="ui.root({ class: [uiProp?.root, props.class] })">
     <slot name="top" />
 
-    <UContainer data-slot="container" :class="ui.container({ class: uiProp?.container })">
+    <div data-slot="container" :class="ui.container({ class: uiProp?.container })">
       <ReuseLeftTemplate />
 
       <div data-slot="center" :class="ui.center({ class: uiProp?.center })">
@@ -181,7 +180,7 @@ function toggleOpen() {
       </div>
 
       <ReuseRightTemplate />
-    </UContainer>
+    </div>
 
     <slot name="bottom" />
   </Primitive>

--- a/src/theme/header.ts
+++ b/src/theme/header.ts
@@ -1,7 +1,7 @@
 export default {
   slots: {
     root: 'bg-default/75 backdrop-blur border-b border-default h-(--ui-header-height) sticky top-0 z-50',
-    container: 'flex items-center justify-between gap-3 h-full',
+    container: 'w-full max-w-(--ui-container) mx-auto px-4 sm:px-6 lg:px-8 flex items-center justify-between gap-3 h-full',
     left: 'lg:flex-1 flex items-center gap-1.5',
     center: 'hidden lg:flex',
     right: 'flex items-center justify-end lg:flex-1 gap-1.5',


### PR DESCRIPTION
### Description

Fixes #6298

The `UHeader` container slot was rendered via `<UContainer>`, which silently adds its own base classes (`w-full max-w-(--ui-container) mx-auto px-4 sm:px-6 lg:px-8`) to the element. The `header.ts` theme only defined `flex items-center justify-between gap-3 h-full`, so the docs showed an incomplete class list.

### Root Cause

`Header.vue` used `<UContainer>` for the container slot, but `UContainer` injects its own base classes outside the theming system. This caused a mismatch between what the docs display (from `header.ts`) and what is actually rendered in the DOM.

### Fix

- Replace `<UContainer>` with a plain `<div>` in `Header.vue`
- Add the `UContainer` base classes directly to the `container` slot in `header.ts`
- Remove the now-unused `UContainer` import

The rendered output is identical -- the snapshots confirm this. The only change is that all container classes are now explicitly defined in the theme, making the docs accurate and the slot fully customizable via the `ui` prop.

### Tests

All existing tests and snapshots pass without modification.