### PR TITLE
fix(Select): trailing set as false

### DIFF
--- a/playgrounds/nuxt/app/pages/components/select-menu.vue
+++ b/playgrounds/nuxt/app/pages/components/select-menu.vue
@@ -82,6 +82,7 @@ const valueMultiple = ref([fruits[0]!, vegetables[0]!])
     />
     <USelectMenu placeholder="Highlight" highlight :items="items" v-bind="props" />
     <USelectMenu placeholder="Disabled" disabled :items="items" v-bind="props" />
+    <USelectMenu placeholder="Disabled and trailing false" disabled :items="items" :trailing="false" v-bind="props" />
     <USelectMenu placeholder="Required" required :items="items" v-bind="props" />
     <USelectMenu placeholder="Search..." icon="i-lucide-search" :items="items" v-bind="props" />
     <USelectMenu placeholder="Search..." trailing-icon="i-lucide-search" :items="items" v-bind="props" />

--- a/playgrounds/nuxt/app/pages/components/select.vue
+++ b/playgrounds/nuxt/app/pages/components/select.vue
@@ -78,6 +78,7 @@ const valueMultiple = ref([fruits[0]!, vegetables[0]!])
     <USelect :default-value="valueMultiple" multiple placeholder="Multiple" :items="items" v-bind="props" />
     <USelect placeholder="Highlight" highlight :items="items" v-bind="props" />
     <USelect placeholder="Disabled" disabled :items="items" v-bind="props" />
+    <USelect placeholder="Disabled and trailing false" disabled :items="items" :trailing="false" v-bind="props" />
     <USelect placeholder="Required" required :items="items" v-bind="props" />
     <USelect placeholder="Search..." icon="i-lucide-search" :items="items" v-bind="props" />
     <USelect placeholder="Search..." trailing-icon="i-lucide-search" :items="items" v-bind="props" />

--- a/src/runtime/components/Select.vue
+++ b/src/runtime/components/Select.vue
@@ -171,7 +171,8 @@ const props = withDefaults(defineProps<SelectProps<T, VK, M, Mod>>(), {
   labelKey: 'label',
   descriptionKey: 'description',
   portal: true,
-  autofocusDelay: 0
+  autofocusDelay: 0,
+  trailing: undefined
 })
 const emits = defineEmits<SelectEmits<T, VK, M, Mod>>()
 const slots = defineSlots<SelectSlots<T, VK, M, Mod>>()

--- a/src/runtime/components/Select.vue
+++ b/src/runtime/components/Select.vue
@@ -187,7 +187,8 @@ const arrowProps = toRef(() => defu(props.arrow, { rounded: true }) as SelectArr
 
 const { emitFormChange, emitFormInput, emitFormBlur, emitFormFocus, size: formGroupSize, color, id, name, highlight, disabled, ariaAttrs } = useFormField<InputProps>(props)
 const { orientation, size: fieldGroupSize } = useFieldGroup<InputProps>(props)
-const { isLeading, isTrailing, leadingIconName, trailingIconName } = useComponentIcons(toRef(() => defu(props, { trailingIcon: appConfig.ui.icons.chevronDown })))
+const { isLeading, isTrailing: isTrailingFromComponentIcons, leadingIconName, trailingIconName } = useComponentIcons(toRef(() => defu(props, { trailingIcon: appConfig.ui.icons.chevronDown })))
+const isTrailing = computed(() => props.trailing === false ? false : isTrailingFromComponentIcons.value)
 
 const selectSize = computed(() => fieldGroupSize.value || formGroupSize.value)
 

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -257,7 +257,8 @@ const props = withDefaults(defineProps<SelectMenuProps<T, VK, M, Mod, C>>(), {
   resetSearchTermOnSelect: true,
   resetModelValueOnClear: true,
   autofocusDelay: 0,
-  virtualize: false
+  virtualize: false,
+  trailing: undefined
 })
 const emits = defineEmits<SelectMenuEmits<T, VK, M, Mod, C>>()
 const slots = defineSlots<SelectMenuSlots<T, VK, M, Mod, C>>()

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -286,7 +286,8 @@ const searchInputProps = toRef(() => defu(props.searchInput, { placeholder: t('s
 
 const { emitFormBlur, emitFormFocus, emitFormInput, emitFormChange, size: formGroupSize, color, id, name, highlight, disabled, ariaAttrs } = useFormField<InputProps>(props)
 const { orientation, size: fieldGroupSize } = useFieldGroup<InputProps>(props)
-const { isLeading, isTrailing, leadingIconName, trailingIconName } = useComponentIcons(toRef(() => defu(props, { trailingIcon: appConfig.ui.icons.chevronDown })))
+const { isLeading, isTrailing: isTrailingFromComponentIcons, leadingIconName, trailingIconName } = useComponentIcons(toRef(() => defu(props, { trailingIcon: appConfig.ui.icons.chevronDown })))
+const isTrailing = computed(() => props.trailing === false ? false : isTrailingFromComponentIcons.value)
 
 const selectSize = computed(() => fieldGroupSize.value || formGroupSize.value)
 

--- a/src/runtime/composables/useComponentIcons.ts
+++ b/src/runtime/composables/useComponentIcons.ts
@@ -41,7 +41,11 @@ export function useComponentIcons(componentProps: MaybeRefOrGetter<UseComponentI
   const props = computed(() => toValue(componentProps))
 
   const isLeading = computed(() => (props.value.icon && props.value.leading) || (props.value.icon && !props.value.trailing) || (props.value.loading && !props.value.trailing) || !!props.value.leadingIcon)
-  const isTrailing = computed(() => (props.value.icon && props.value.trailing) || (props.value.loading && props.value.trailing) || !!props.value.trailingIcon)
+
+  const isTrailing = computed(() => (props.value.trailing === false
+    ? false
+    : (!!props.value.icon || props.value.loading || !!props.value.trailingIcon)
+  ))
 
   const leadingIconName = computed(() => {
     if (props.value.loading) {

--- a/src/runtime/composables/useComponentIcons.ts
+++ b/src/runtime/composables/useComponentIcons.ts
@@ -46,12 +46,7 @@ export function useComponentIcons(componentProps: MaybeRefOrGetter<UseComponentI
     if (props.value.trailing === false) {
       return false
     }
-
-    return (
-      !!props.value.trailingIcon
-      || (!!props.value.icon && props.value.trailing === true)
-      || (props.value.loading && props.value.trailing === true)
-    )
+    return (props.value.icon && props.value.trailing) || (props.value.loading && props.value.trailing) || !!props.value.trailingIcon
   })
 
   const leadingIconName = computed(() => {

--- a/src/runtime/composables/useComponentIcons.ts
+++ b/src/runtime/composables/useComponentIcons.ts
@@ -41,13 +41,7 @@ export function useComponentIcons(componentProps: MaybeRefOrGetter<UseComponentI
   const props = computed(() => toValue(componentProps))
 
   const isLeading = computed(() => (props.value.icon && props.value.leading) || (props.value.icon && !props.value.trailing) || (props.value.loading && !props.value.trailing) || !!props.value.leadingIcon)
-
-  const isTrailing = computed(() => {
-    if (props.value.trailing === false) {
-      return false
-    }
-    return (props.value.icon && props.value.trailing) || (props.value.loading && props.value.trailing) || !!props.value.trailingIcon
-  })
+  const isTrailing = computed(() => (props.value.icon && props.value.trailing) || (props.value.loading && props.value.trailing) || !!props.value.trailingIcon)
 
   const leadingIconName = computed(() => {
     if (props.value.loading) {

--- a/src/runtime/composables/useComponentIcons.ts
+++ b/src/runtime/composables/useComponentIcons.ts
@@ -18,7 +18,7 @@ export interface UseComponentIconsProps {
    * @IconifyIcon
    */
   leadingIcon?: IconProps['name']
-  /** When `false`, the icon will not be displayed on the right side. */
+  /** When `true`, the icon will be displayed on the right side. */
   trailing?: boolean
   /**
    * Display an icon on the right side.
@@ -42,10 +42,17 @@ export function useComponentIcons(componentProps: MaybeRefOrGetter<UseComponentI
 
   const isLeading = computed(() => (props.value.icon && props.value.leading) || (props.value.icon && !props.value.trailing) || (props.value.loading && !props.value.trailing) || !!props.value.leadingIcon)
 
-  const isTrailing = computed(() => (props.value.trailing === false
-    ? false
-    : (!!props.value.icon || props.value.loading || !!props.value.trailingIcon)
-  ))
+  const isTrailing = computed(() => {
+    if (props.value.trailing === false) {
+      return false
+    }
+
+    return (
+      !!props.value.trailingIcon
+      || (!!props.value.icon && props.value.trailing === true)
+      || (props.value.loading && props.value.trailing === true)
+    )
+  })
 
   const leadingIconName = computed(() => {
     if (props.value.loading) {

--- a/src/runtime/composables/useComponentIcons.ts
+++ b/src/runtime/composables/useComponentIcons.ts
@@ -18,7 +18,7 @@ export interface UseComponentIconsProps {
    * @IconifyIcon
    */
   leadingIcon?: IconProps['name']
-  /** When `true`, the icon will be displayed on the right side. */
+  /** When `false`, the icon will not be displayed on the right side. */
   trailing?: boolean
   /**
    * Display an icon on the right side.

--- a/test/components/Select.spec.ts
+++ b/test/components/Select.spec.ts
@@ -300,4 +300,18 @@ describe('Select', () => {
       })).toEqualTypeOf<[string | number]>()
     })
   })
+
+  describe('trailing prop', () => {
+    test('hides trailing chevron when trailing is false (e.g. disabled select without arrow)', () => {
+      const wrapper = mount(Select, {
+        props: {
+          ...props,
+          disabled: true,
+          trailing: false
+        }
+      })
+
+      expect(wrapper.find('[data-slot="trailingIcon"]').exists()).toBe(false)
+    })
+  })
 })

--- a/test/components/Select.spec.ts
+++ b/test/components/Select.spec.ts
@@ -313,5 +313,20 @@ describe('Select', () => {
 
       expect(wrapper.find('[data-slot="trailingIcon"]').exists()).toBe(false)
     })
+
+    test.each([
+      ['trailing prop is omitted', {}],
+      ['trailing is true', { trailing: true }]
+    ])('shows trailing chevron when %s', (_, trailingProps) => {
+      const wrapper = mount(Select, {
+        props: {
+          ...props,
+          disabled: true,
+          ...trailingProps
+        }
+      })
+
+      expect(wrapper.find('[data-slot="trailingIcon"]').exists()).toBe(true)
+    })
   })
 })

--- a/test/components/SelectMenu.spec.ts
+++ b/test/components/SelectMenu.spec.ts
@@ -350,5 +350,20 @@ describe('SelectMenu', () => {
 
       expect(wrapper.find('[data-slot="trailingIcon"]').exists()).toBe(false)
     })
+
+    test.each([
+      ['trailing prop is omitted', {}],
+      ['trailing is true', { trailing: true }]
+    ])('shows trailing chevron when %s', (_, trailingProps) => {
+      const wrapper = mount(SelectMenu, {
+        props: {
+          ...props,
+          disabled: true,
+          ...trailingProps
+        }
+      })
+
+      expect(wrapper.find('[data-slot="trailingIcon"]').exists()).toBe(true)
+    })
   })
 })

--- a/test/components/SelectMenu.spec.ts
+++ b/test/components/SelectMenu.spec.ts
@@ -337,4 +337,18 @@ describe('SelectMenu', () => {
       })).toEqualTypeOf<[(string | number)[]]>()
     })
   })
+
+  describe('trailing prop', () => {
+    test('hides trailing chevron when trailing is false (e.g. disabled select without arrow)', () => {
+      const wrapper = mount(SelectMenu, {
+        props: {
+          ...props,
+          disabled: true,
+          trailing: false
+        }
+      })
+
+      expect(wrapper.find('[data-slot="trailingIcon"]').exists()).toBe(false)
+    })
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves [#6287](https://github.com/nuxt/ui/issues/6287)

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

- I set the default value for trailing as `undefined`.
- In the computed value `isTrailing`, if the `trailing` is `false`, it returns it. 
   - I added this change only in `Select` and `SelectMenu` because if I modify `useComponentIcons` it makes fails a lot of test in other components.
- I added tests for these changes

**Why is this change required? What problem does it solve?**
 
 This is what the [documentation](https://ui.nuxt.com/docs/components/select#props) says

> trailing: boolean 👉 When true, the icon will be displayed on the right side.

I expect that the down arrow icons will not be displayed in the select input. But even if I add `:trailing="false"`, the arrow is still there.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
