### PR TITLE
fix(InputTags): add missing field group variant

### DIFF
--- a/src/theme/input-tags.ts
+++ b/src/theme/input-tags.ts
@@ -1,6 +1,7 @@
 import { defuFn } from 'defu'
 import type { ModuleOptions } from '../module'
 import input from './input'
+import { fieldGroupVariant } from './field-group'
 
 export default (options: Required<ModuleOptions>) => {
   return defuFn({
@@ -14,6 +15,7 @@ export default (options: Required<ModuleOptions>) => {
       input: 'flex-1 border-0 bg-transparent placeholder:text-dimmed focus:outline-none disabled:cursor-not-allowed disabled:opacity-75'
     },
     variants: {
+      ...fieldGroupVariant,
       size: {
         xs: {
           item: 'text-[10px]/3',


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6325

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `InputTags` theme was missing the `fieldGroupVariant` spread in its `variants` definition. This caused the component to not properly adjust its border radius when used inside a `FieldGroup`.

This PR imports `fieldGroupVariant` from `./field-group` and spreads it into the `variants` object in `src/theme/input-tags.ts`, aligning `InputTags` with other form components like `Input`, `InputNumber`, `Select` and `SelectMenu`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
