### PR TITLE
fix(ProseImg): respect markdown width attribute

### DIFF
--- a/src/runtime/components/prose/Img.vue
+++ b/src/runtime/components/prose/Img.vue
@@ -48,7 +48,7 @@ const open = ref(false)
 const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.img || {}) })({
   zoom: props.zoom,
   open: open.value,
-  hasWidth: !!props.width
+  width: !!props.width
 }))
 
 const refinedSrc = computed(() => resolveBaseURL(props.src, useRuntimeConfig().app.baseURL))

--- a/src/runtime/components/prose/Img.vue
+++ b/src/runtime/components/prose/Img.vue
@@ -47,7 +47,8 @@ const open = ref(false)
 
 const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.prose?.img || {}) })({
   zoom: props.zoom,
-  open: open.value
+  open: open.value,
+  hasWidth: !!props.width
 }))
 
 const refinedSrc = computed(() => resolveBaseURL(props.src, useRuntimeConfig().app.baseURL))

--- a/src/theme/prose/img.ts
+++ b/src/theme/prose/img.ts
@@ -12,7 +12,7 @@ export default {
     open: {
       true: ''
     },
-    hasWidth: {
+    width: {
       false: 'w-full'
     }
   },

--- a/src/theme/prose/img.ts
+++ b/src/theme/prose/img.ts
@@ -1,6 +1,6 @@
 export default {
   slots: {
-    base: 'rounded-md w-full',
+    base: 'rounded-md',
     overlay: 'fixed inset-0 bg-default/75 backdrop-blur-sm will-change-opacity',
     content: 'fixed inset-0 flex items-center justify-center cursor-zoom-out focus:outline-none',
     zoomedImage: 'w-full h-auto max-w-[95vw] max-h-[95vh] object-contain rounded-md'
@@ -11,6 +11,9 @@ export default {
     },
     open: {
       true: ''
+    },
+    hasWidth: {
+      false: 'w-full'
     }
   },
   compoundVariants: [{


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6349 

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`w-full` is applied by the ProseImg component without condition, which defeats markdown width attributes, meaning we cannot control width of images from markdown.

This bug is masked (a) in projects where tailwind isn't compiled and (b) instances where the image appears in a flex container (such as the Nuxt UI docs)

This fix introduces a check which conditionally applies `w-full` only when the width prop is not explicitly set by the markdown author

I patched the same fix onto my minimal repro and it appears to work as expected

<img width="1100" height="419" alt="image" src="https://github.com/user-attachments/assets/faabd4e9-c8d6-4bd0-88e4-3a31aa9444b2" />


### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.

(I do not feel any documentation updates are needed - this fix ensures image behaviour matches the intention of the existing documentation)
