### PR TITLE
fix(CheckboxGroup): add label and description to theme slots

### DIFF
--- a/src/theme/checkbox-group.ts
+++ b/src/theme/checkbox-group.ts
@@ -5,7 +5,9 @@ export default (options: Required<ModuleOptions>) => ({
     root: 'relative',
     fieldset: 'flex gap-x-2',
     legend: 'mb-1 block font-medium text-default',
-    item: ''
+    item: '',
+    label: 'block font-medium text-default',
+    description: 'text-muted'
   },
   variants: {
     orientation: {


### PR DESCRIPTION
Per #6337, the `CheckboxGroup` theme only declares `root`, `fieldset`, `legend`, and `item` slots, even though `CheckboxGroupSlots` defines `label` and `description` slots that get forwarded to each inner `Checkbox`.

As a result, declaring:

```ts
ui: {
  checkboxGroup: {
    slots: {
      label: 'font-normal'
    }
  }
}
```

in `app.config.ts` raises a TypeScript error because `label` is not a known key of the slots object.

This PR adds `label` and `description` to the slots object, matching the existing `RadioGroup` theme pattern. Both keys become typeable in `app.config.ts` and pick up sensible defaults consistent with RadioGroup.

Closes #6337