### PR TITLE
AvatarGroup : add overflow slot for custom tooltip on hidden avatars

### DIFF
--- a/docs/app/components/content/examples/avatar-group/AvatarGroupOverflowTooltipExample.vue
+++ b/docs/app/components/content/examples/avatar-group/AvatarGroupOverflowTooltipExample.vue
@@ -1,0 +1,31 @@
+<script setup lang="ts">
+const getOverflowTooltip = (hiddenCount: number) => `${hiddenCount} more teammates`
+</script>
+
+<template>
+  <UAvatarGroup :max="2">
+    <UAvatar
+      src="https://github.com/benjamincanac.png"
+      alt="Benjamin Canac"
+      loading="lazy"
+    />
+
+    <UAvatar
+      src="https://github.com/romhml.png"
+      alt="Romain Hamel"
+      loading="lazy"
+    />
+
+    <UAvatar
+      src="https://github.com/noook.png"
+      alt="Neil Richter"
+      loading="lazy"
+    />
+
+    <template #overflow="{ hiddenCount, avatarProps }">
+      <UTooltip :text="getOverflowTooltip(hiddenCount)">
+        <UAvatar v-bind="avatarProps" />
+      </UTooltip>
+    </template>
+  </UAvatarGroup>
+</template>

--- a/docs/content/docs/2.components/avatar-group.md
+++ b/docs/content/docs/2.components/avatar-group.md
@@ -69,6 +69,12 @@ slots:
 :u-avatar{src="https://github.com/noook.png" alt="Neil Richter" loading="lazy"}
 ::
 
+### Overflow tooltip
+
+Use the `overflow` slot to customize the `+X` avatar. The slot receives the hidden count and the default avatar props, so you can wrap the overflow avatar with a [Tooltip](/docs/components/tooltip) and provide either a static string or a helper function that derives the label from the count.
+
+:component-example{name="avatar-group-overflow-tooltip-example"}
+
 ## Examples
 
 ### With tooltip

--- a/src/runtime/components/AvatarGroup.vue
+++ b/src/runtime/components/AvatarGroup.vue
@@ -26,6 +26,7 @@ export interface AvatarGroupProps {
 
 export interface AvatarGroupSlots {
   default?(props?: {}): VNode[]
+  overflow?(props: { hiddenCount: number, avatarProps: { text: string, class: any } }): VNode[]
 }
 </script>
 
@@ -90,6 +91,11 @@ const hiddenCount = computed(() => {
   return children.value.length - visibleAvatars.value.length
 })
 
+const overflowAvatarProps = computed(() => ({
+  text: `+${hiddenCount.value}`,
+  class: ui.value.base({ class: uiProp.value?.base })
+}))
+
 provide(avatarGroupInjectionKey, computed(() => ({
   size: props.size
 })))
@@ -97,7 +103,9 @@ provide(avatarGroupInjectionKey, computed(() => ({
 
 <template>
   <Primitive :as="as" data-slot="root" :class="ui.root({ class: [uiProp?.root, props.class] })">
-    <UAvatar v-if="hiddenCount > 0" :text="`+${hiddenCount}`" data-slot="base" :class="ui.base({ class: uiProp?.base })" />
+    <slot v-if="hiddenCount > 0" name="overflow" :hidden-count="hiddenCount" :avatar-props="overflowAvatarProps">
+      <UAvatar v-bind="overflowAvatarProps" data-slot="base" />
+    </slot>
     <component :is="avatar" v-for="(avatar, count) in visibleAvatars" :key="count" data-slot="base" :class="ui.base({ class: uiProp?.base })" />
   </Primitive>
 </template>

--- a/test/components/AvatarGroup.spec.ts
+++ b/test/components/AvatarGroup.spec.ts
@@ -19,6 +19,23 @@ const AvatarGroupWrapper = defineComponent({
 </UAvatarGroup>`
 })
 
+const AvatarGroupOverflowTooltipWrapper = defineComponent({
+  components: {
+    UAvatar: Avatar,
+    UAvatarGroup: AvatarGroup
+  },
+  template: `<UAvatarGroup :max="2">
+  <UAvatar src="https://github.com/benjamincanac.png" alt="Benjamin Canac" />
+  <UAvatar src="https://github.com/romhml.png" alt="Romain Hamel" />
+  <UAvatar src="https://github.com/noook.png" alt="Neil Richter" />
+  <template #overflow="{ hiddenCount, avatarProps }">
+    <span :data-hidden-count="hiddenCount">
+      <UAvatar v-bind="avatarProps" />
+    </span>
+  </template>
+</UAvatarGroup>`
+})
+
 describe('AvatarGroup', () => {
   const sizes = Object.keys(theme.variants.size) as any
 
@@ -32,6 +49,12 @@ describe('AvatarGroup', () => {
     // Slots
     ['with default slot', {}]
   ])
+
+  it('exposes the hidden count to the overflow slot', async () => {
+    const wrapper = await mountSuspended(AvatarGroupOverflowTooltipWrapper)
+
+    expect(wrapper.find('[data-hidden-count="1"]').exists()).toBe(true)
+  })
 
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(AvatarGroupWrapper, {


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This pull request adds support for customizable tooltips on the overflow (“+N”) avatar in the `AvatarGroup` component.
Added a new section in `avatar-group.md` with an example on how to use the slot

See https://github.com/nuxt/ui/pull/4870 for the original V3 PR

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
