### PR TITLE
docs: improve agent readability score

### DIFF
--- a/docs/app/pages/docs/[...slug].vue
+++ b/docs/app/pages/docs/[...slug].vue
@@ -82,10 +82,30 @@ useHead({
   link: [
     {
       rel: 'alternate',
-      href: joinURL(site.url, 'raw', `${path.value}.md`),
+      href: `${site.url}${path.value}.md`,
       type: 'text/markdown'
     }
-  ]
+  ],
+  script: [{
+    type: 'application/ld+json',
+    innerHTML: JSON.stringify({
+      '@context': 'https://schema.org',
+      '@type': 'TechArticle',
+      'headline': `${prefix}${title} ${suffix}`.trim(),
+      'description': description,
+      'url': joinURL(site.url, path.value),
+      'dateModified': new Date().toISOString(),
+      'breadcrumb': {
+        '@type': 'BreadcrumbList',
+        'itemListElement': breadcrumb.value?.map((item, index) => ({
+          '@type': 'ListItem',
+          'position': index + 1,
+          'name': item.label,
+          'item': item.to ? joinURL(site.url, String(item.to)) : undefined
+        })) || []
+      }
+    })
+  }]
 })
 
 const { open, messages } = useChat()

--- a/docs/app/pages/docs/[...slug].vue
+++ b/docs/app/pages/docs/[...slug].vue
@@ -94,7 +94,6 @@ useHead({
       'headline': `${prefix}${title} ${suffix}`.trim(),
       'description': description,
       'url': joinURL(site.url, path.value),
-      'dateModified': new Date().toISOString(),
       'breadcrumb': {
         '@type': 'BreadcrumbList',
         'itemListElement': breadcrumb.value?.map((item, index) => ({
@@ -104,7 +103,7 @@ useHead({
           'item': item.to ? joinURL(site.url, String(item.to)) : undefined
         })) || []
       }
-    })
+    }).replace(/</g, '\\u003c').replace(/>/g, '\\u003e')
   }]
 })
 

--- a/docs/modules/md-rewrite.ts
+++ b/docs/modules/md-rewrite.ts
@@ -12,25 +12,28 @@ export default defineNuxtModule((_options, nuxt) => {
       const vcJSON = resolve(nitro.options.output.dir, 'config.json')
       const vcConfig = JSON.parse(await readFile(vcJSON, 'utf8'))
       vcConfig.routes.unshift(
+        // Add Vary header so CDNs don't serve cached HTML to agents or vice versa
+        {
+          src: '^/docs/.*$',
+          headers: { 'Vary': 'Accept, User-Agent' },
+          continue: true
+        },
         // Rewrite /docs/*.md URLs to the raw markdown handler
         {
           src: '^/docs/(.*)\\.md$',
-          dest: '/raw/docs/$1.md',
-          check: true
+          dest: '/raw/docs/$1.md'
         },
         // Serve markdown when Accept: text/markdown is requested
         {
           src: '^/docs/(.*)$',
           dest: '/raw/docs/$1.md',
-          has: [{ type: 'header', key: 'accept', value: '(.*)text/markdown(.*)' }],
-          check: true
+          has: [{ type: 'header', key: 'accept', value: '(.*)text/markdown(.*)' }]
         },
         // Serve markdown to known AI agent user agents
         {
           src: '^/docs/(.*)$',
           dest: '/raw/docs/$1.md',
-          has: [{ type: 'header', key: 'user-agent', value: '.*(GPTBot|ChatGPT-User|ClaudeBot|Claude-Web|CCBot|Google-Extended|PerplexityBot|Amazonbot|cohere-ai|AI2Bot|AnthropicBot).*' }],
-          check: true
+          has: [{ type: 'header', key: 'user-agent', value: '.*(GPTBot|ChatGPT-User|ClaudeBot|Claude-Web|CCBot|Google-Extended|PerplexityBot|Amazonbot|cohere-ai|AI2Bot|AnthropicBot).*' }]
         }
       )
       await writeFile(vcJSON, JSON.stringify(vcConfig, null, 2), 'utf8')

--- a/docs/modules/md-rewrite.ts
+++ b/docs/modules/md-rewrite.ts
@@ -14,7 +14,7 @@ export default defineNuxtModule((_options, nuxt) => {
       vcConfig.routes.unshift(
         // Add Vary header so CDNs don't serve cached HTML to agents or vice versa
         {
-          src: '^/docs/.*$',
+          src: '^/docs/(?!.*\\.md$).*$',
           headers: { Vary: 'Accept, User-Agent' },
           continue: true
         },
@@ -33,7 +33,7 @@ export default defineNuxtModule((_options, nuxt) => {
         {
           src: '^/docs/(.*)$',
           dest: '/raw/docs/$1.md',
-          has: [{ type: 'header', key: 'user-agent', value: '.*(GPTBot|ChatGPT-User|ClaudeBot|Claude-Web|CCBot|Google-Extended|PerplexityBot|Amazonbot|cohere-ai|AI2Bot|AnthropicBot).*' }]
+          has: [{ type: 'header', key: 'user-agent', value: '.*(ClaudeBot|Claude-Web|anthropic-ai|GPTBot|ChatGPT-User|OAI-SearchBot|Google-Extended|Google-CloudVertexBot|Meta-ExternalAgent|Meta-ExternalFetcher|PerplexityBot|YouBot|DeepSeekBot|Amazonbot|cohere-ai|AI2Bot|Applebot-Extended|Bytespider).*' }]
         }
       )
       await writeFile(vcJSON, JSON.stringify(vcConfig, null, 2), 'utf8')

--- a/docs/modules/md-rewrite.ts
+++ b/docs/modules/md-rewrite.ts
@@ -15,7 +15,7 @@ export default defineNuxtModule((_options, nuxt) => {
         // Add Vary header so CDNs don't serve cached HTML to agents or vice versa
         {
           src: '^/docs/.*$',
-          headers: { 'Vary': 'Accept, User-Agent' },
+          headers: { Vary: 'Accept, User-Agent' },
           continue: true
         },
         // Rewrite /docs/*.md URLs to the raw markdown handler

--- a/docs/modules/md-rewrite.ts
+++ b/docs/modules/md-rewrite.ts
@@ -11,12 +11,28 @@ export default defineNuxtModule((_options, nuxt) => {
         = process.getBuiltinModule('node:fs/promises')
       const vcJSON = resolve(nitro.options.output.dir, 'config.json')
       const vcConfig = JSON.parse(await readFile(vcJSON, 'utf8'))
-      vcConfig.routes.unshift({
-        src: '^/docs/(.*)$',
-        dest: '/raw/docs/$1.md',
-        has: [{ type: 'header', key: 'accept', value: '(.*)text/markdown(.*)' }],
-        check: true
-      })
+      vcConfig.routes.unshift(
+        // Rewrite /docs/*.md URLs to the raw markdown handler
+        {
+          src: '^/docs/(.*)\\.md$',
+          dest: '/raw/docs/$1.md',
+          check: true
+        },
+        // Serve markdown when Accept: text/markdown is requested
+        {
+          src: '^/docs/(.*)$',
+          dest: '/raw/docs/$1.md',
+          has: [{ type: 'header', key: 'accept', value: '(.*)text/markdown(.*)' }],
+          check: true
+        },
+        // Serve markdown to known AI agent user agents
+        {
+          src: '^/docs/(.*)$',
+          dest: '/raw/docs/$1.md',
+          has: [{ type: 'header', key: 'user-agent', value: '.*(GPTBot|ChatGPT-User|ClaudeBot|Claude-Web|CCBot|Google-Extended|PerplexityBot|Amazonbot|cohere-ai|AI2Bot|AnthropicBot).*' }],
+          check: true
+        }
+      )
       await writeFile(vcJSON, JSON.stringify(vcConfig, null, 2), 'utf8')
     })
   })

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -67,6 +67,7 @@ export default defineNuxtConfig({
   },
 
   routeRules: {
+    '/docs/**': { headers: { Vary: 'Accept, User-Agent' } },
     // v4 redirects - moved to `docs/`
     '/getting-started/**': { redirect: { to: '/docs/getting-started/**', statusCode: 301 }, prerender: false },
     '/components/**': { redirect: { to: '/docs/components/**', statusCode: 301 }, prerender: false },

--- a/docs/public/robots.txt
+++ b/docs/public/robots.txt
@@ -1,1 +1,31 @@
-user-agent: *
+User-agent: *
+Allow: /
+
+User-agent: GPTBot
+Allow: /
+
+User-agent: ChatGPT-User
+Allow: /
+
+User-agent: ClaudeBot
+Allow: /
+
+User-agent: Claude-Web
+Allow: /
+
+User-agent: CCBot
+Allow: /
+
+User-agent: Google-Extended
+Allow: /
+
+User-agent: PerplexityBot
+Allow: /
+
+User-agent: Amazonbot
+Allow: /
+
+User-agent: cohere-ai
+Allow: /
+
+Sitemap: https://ui.nuxt.com/sitemap.xml

--- a/docs/server/routes/raw/[...slug].md.get.ts
+++ b/docs/server/routes/raw/[...slug].md.get.ts
@@ -27,9 +27,7 @@ export default eventHandler(async (event) => {
   let page: PageCollectionItemBase | null = null
   for (const collection of _collections) {
     page = await queryCollection(event, collection as keyof Collections).path(path).first() as PageCollectionItemBase | null
-    if (page) {
-      break
-    }
+    if (page) break
   }
 
   if (!page) {
@@ -46,12 +44,13 @@ export default eventHandler(async (event) => {
     page.body.value.unshift(['h1', {}, page.title])
   }
 
-  const canonicalUrl = `${DOMAIN}${path}`
+  const canonicalUrl = `${DOMAIN}${page.path}`
   const frontmatter = [
     '---',
     `title: ${JSON.stringify(page.title || '')}`,
     `description: ${JSON.stringify(page.description || '')}`,
     `canonical_url: ${JSON.stringify(canonicalUrl)}`,
+    `last_updated: ${JSON.stringify(new Date().toISOString().split('T')[0])}`,
     '---',
     ''
   ].join('\n')

--- a/docs/server/routes/raw/[...slug].md.get.ts
+++ b/docs/server/routes/raw/[...slug].md.get.ts
@@ -2,14 +2,17 @@ import { withLeadingSlash } from 'ufo'
 import { stringify } from 'minimark/stringify'
 import { queryCollection } from '@nuxt/content/server'
 import type { Collections, PageCollectionItemBase } from '@nuxt/content'
-import { getRouterParams, eventHandler, createError, setHeader } from 'h3'
+import { getRouterParams, eventHandler, setHeader } from 'h3'
 import collections from '#content/manifest'
 import { transformMDC } from '../../utils/transformMDC'
+
+const DOMAIN = 'https://ui.nuxt.com'
 
 export default eventHandler(async (event) => {
   const slug = getRouterParams(event)['slug.md']
   if (!slug?.endsWith('.md')) {
-    throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
+    setHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')
+    return '---\ntitle: Not Found\n---\n\n# Page Not Found\n\nThe requested page does not exist. Browse the [sitemap](/sitemap.md) to find available pages.\n'
   }
 
   let path = withLeadingSlash(slug.replace('.md', ''))
@@ -30,7 +33,8 @@ export default eventHandler(async (event) => {
   }
 
   if (!page) {
-    throw createError({ statusCode: 404, statusMessage: 'Page not found', fatal: true })
+    setHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')
+    return `---\ntitle: Not Found\n---\n\n# Page Not Found\n\nThe page \`${path}\` does not exist. Browse the [sitemap](/sitemap.md) to find available pages.\n`
   }
 
   // Transform MDC components to standard elements for LLM consumption
@@ -42,6 +46,19 @@ export default eventHandler(async (event) => {
     page.body.value.unshift(['h1', {}, page.title])
   }
 
+  const canonicalUrl = `${DOMAIN}${path}`
+  const frontmatter = [
+    '---',
+    `title: "${(page.title || '').replace(/"/g, '\\"')}"`,
+    `description: "${(page.description || '').replace(/"/g, '\\"')}"`,
+    `canonical_url: "${canonicalUrl}"`,
+    `last_updated: "${new Date().toISOString()}"`,
+    '---',
+    ''
+  ].join('\n')
+
   setHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')
-  return stringify({ ...page.body, type: 'minimark' }, { format: 'markdown/html' })
+  setHeader(event, 'Link', `<${canonicalUrl}>; rel="canonical"`)
+  const body = stringify({ ...page.body, type: 'minimark' }, { format: 'markdown/html' })
+  return frontmatter + body + '\n\n## Sitemap\n\nSee the full [sitemap](/sitemap.md) for all pages.\n'
 })

--- a/docs/server/routes/raw/[...slug].md.get.ts
+++ b/docs/server/routes/raw/[...slug].md.get.ts
@@ -49,10 +49,9 @@ export default eventHandler(async (event) => {
   const canonicalUrl = `${DOMAIN}${path}`
   const frontmatter = [
     '---',
-    `title: "${(page.title || '').replace(/"/g, '\\"')}"`,
-    `description: "${(page.description || '').replace(/"/g, '\\"')}"`,
-    `canonical_url: "${canonicalUrl}"`,
-    `last_updated: "${new Date().toISOString()}"`,
+    `title: ${JSON.stringify(page.title || '')}`,
+    `description: ${JSON.stringify(page.description || '')}`,
+    `canonical_url: ${JSON.stringify(canonicalUrl)}`,
     '---',
     ''
   ].join('\n')

--- a/docs/server/routes/raw/[...slug].md.get.ts
+++ b/docs/server/routes/raw/[...slug].md.get.ts
@@ -50,7 +50,6 @@ export default eventHandler(async (event) => {
     `title: ${JSON.stringify(page.title || '')}`,
     `description: ${JSON.stringify(page.description || '')}`,
     `canonical_url: ${JSON.stringify(canonicalUrl)}`,
-    `last_updated: ${JSON.stringify(new Date().toISOString().split('T')[0])}`,
     '---',
     ''
   ].join('\n')

--- a/docs/server/routes/sitemap.md.get.ts
+++ b/docs/server/routes/sitemap.md.get.ts
@@ -1,0 +1,43 @@
+import { queryCollection } from '@nuxt/content/server'
+import { eventHandler, setHeader } from 'h3'
+
+export default eventHandler(async (event) => {
+  const pages = await queryCollection(event, 'docs')
+    .select('path', 'title')
+    .where('extension', '=', 'md')
+    .where('path', 'NOT LIKE', '%/.navigation')
+    .order('path', 'ASC')
+    .all()
+
+  const sections: Record<string, { title: string, path: string }[]> = {}
+
+  for (const page of pages) {
+    const parts = page.path.replace(/^\/docs\//, '').split('/')
+    const sectionKey = parts[0] || 'docs'
+    if (!sections[sectionKey]) {
+      sections[sectionKey] = []
+    }
+    sections[sectionKey].push({ title: page.title, path: page.path })
+  }
+
+  const sectionLabels: Record<string, string> = {
+    'getting-started': 'Getting Started',
+    'components': 'Components',
+    'composables': 'Composables',
+    'typography': 'Typography'
+  }
+
+  let md = '# Sitemap\n\n'
+
+  for (const [key, pages] of Object.entries(sections)) {
+    const label = sectionLabels[key] || key.charAt(0).toUpperCase() + key.slice(1).replace(/-/g, ' ')
+    md += `## ${label}\n\n`
+    for (const page of pages) {
+      md += `- [${page.title}](https://ui.nuxt.com${page.path}.md)\n`
+    }
+    md += '\n'
+  }
+
+  setHeader(event, 'Content-Type', 'text/markdown; charset=utf-8')
+  return md
+})

--- a/docs/server/routes/sitemap.md.get.ts
+++ b/docs/server/routes/sitemap.md.get.ts
@@ -33,8 +33,8 @@ export default eventHandler(async (event) => {
     const label = sectionLabels[key] || key.charAt(0).toUpperCase() + key.slice(1).replace(/-/g, ' ')
     md += `## ${label}\n\n`
     for (const page of pages) {
-      const label = (page.title || page.path).replace(/\[/g, '\\[').replace(/\]/g, '\\]')
-      md += `- [${label}](https://ui.nuxt.com${page.path}.md)\n`
+      const pageLabel = (page.title || page.path).replace(/\[/g, '\\[').replace(/\]/g, '\\]')
+      md += `- [${pageLabel}](https://ui.nuxt.com${page.path}.md)\n`
     }
     md += '\n'
   }

--- a/docs/server/routes/sitemap.md.get.ts
+++ b/docs/server/routes/sitemap.md.get.ts
@@ -33,7 +33,10 @@ export default eventHandler(async (event) => {
     const label = sectionLabels[key] || key.charAt(0).toUpperCase() + key.slice(1).replace(/-/g, ' ')
     md += `## ${label}\n\n`
     for (const page of pages) {
-      const pageLabel = (page.title || page.path).replace(/\[/g, '\\[').replace(/\]/g, '\\]')
+      const pageLabel = (page.title || page.path)
+        .replace(/\\/g, '\\\\')
+        .replace(/\[/g, '\\[')
+        .replace(/\]/g, '\\]')
       md += `- [${pageLabel}](https://ui.nuxt.com${page.path}.md)\n`
     }
     md += '\n'

--- a/docs/server/routes/sitemap.md.get.ts
+++ b/docs/server/routes/sitemap.md.get.ts
@@ -33,7 +33,8 @@ export default eventHandler(async (event) => {
     const label = sectionLabels[key] || key.charAt(0).toUpperCase() + key.slice(1).replace(/-/g, ' ')
     md += `## ${label}\n\n`
     for (const page of pages) {
-      md += `- [${page.title}](https://ui.nuxt.com${page.path}.md)\n`
+      const label = (page.title || page.path).replace(/\[/g, '\\[').replace(/\]/g, '\\]')
+      md += `- [${label}](https://ui.nuxt.com${page.path}.md)\n`
     }
     md += '\n'
   }

--- a/docs/server/routes/sitemap.xml.get.ts
+++ b/docs/server/routes/sitemap.xml.get.ts
@@ -3,6 +3,10 @@ import { eventHandler, setHeader } from 'h3'
 
 const DOMAIN = 'https://ui.nuxt.com'
 
+function xmlEscape(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/"/g, '&quot;').replace(/'/g, '&apos;')
+}
+
 export default eventHandler(async (event) => {
   const pages = await queryCollection(event, 'docs')
     .select('path')
@@ -11,9 +15,8 @@ export default eventHandler(async (event) => {
     .order('path', 'ASC')
     .all()
 
-  const today = new Date().toISOString().split('T')[0]
   const urls = pages.map(page =>
-    `  <url>\n    <loc>${DOMAIN}${page.path}</loc>\n    <lastmod>${today}</lastmod>\n  </url>`
+    `  <url>\n    <loc>${xmlEscape(`${DOMAIN}${page.path}`)}</loc>\n  </url>`
   ).join('\n')
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>

--- a/docs/server/routes/sitemap.xml.get.ts
+++ b/docs/server/routes/sitemap.xml.get.ts
@@ -1,0 +1,26 @@
+import { queryCollection } from '@nuxt/content/server'
+import { eventHandler, setHeader } from 'h3'
+
+const DOMAIN = 'https://ui.nuxt.com'
+
+export default eventHandler(async (event) => {
+  const pages = await queryCollection(event, 'docs')
+    .select('path')
+    .where('extension', '=', 'md')
+    .where('path', 'NOT LIKE', '%/.navigation')
+    .order('path', 'ASC')
+    .all()
+
+  const today = new Date().toISOString().split('T')[0]
+  const urls = pages.map(page =>
+    `  <url>\n    <loc>${DOMAIN}${page.path}</loc>\n    <lastmod>${today}</lastmod>\n  </url>`
+  ).join('\n')
+
+  const xml = `<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+${urls}
+</urlset>`
+
+  setHeader(event, 'Content-Type', 'application/xml; charset=utf-8')
+  return xml
+})

--- a/docs/server/routes/sitemap.xml.get.ts
+++ b/docs/server/routes/sitemap.xml.get.ts
@@ -15,8 +15,9 @@ export default eventHandler(async (event) => {
     .order('path', 'ASC')
     .all()
 
+  const today = new Date().toISOString().split('T')[0]
   const urls = pages.map(page =>
-    `  <url>\n    <loc>${xmlEscape(`${DOMAIN}${page.path}`)}</loc>\n  </url>`
+    `  <url>\n    <loc>${xmlEscape(`${DOMAIN}${page.path}`)}</loc>\n    <lastmod>${today}</lastmod>\n  </url>`
   ).join('\n')
 
   const xml = `<?xml version="1.0" encoding="UTF-8"?>

--- a/docs/server/utils/transformMDC.ts
+++ b/docs/server/utils/transformMDC.ts
@@ -616,15 +616,7 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
     })
   }
 
-  // Transform field-group to remove wrapper (fields already handled)
-  const fieldWrappers = ['field-group', 'collapsible']
-  for (const wrapperType of fieldWrappers) {
-    visitAndReplace(doc, wrapperType, (node) => {
-      replaceWithChildren(node, node.slice(2))
-    })
-  }
-
-  // Transform field to a definition format
+  // Transform field to a definition format (before field-group unwrapping so attrs are intact)
   visitAndReplace(doc, 'field', (node) => {
     const attrs = node[1] || {}
     const content = node.slice(2)
@@ -662,6 +654,14 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
       node.push(part)
     }
   })
+
+  // Remove field-group / collapsible wrappers (after fields are transformed to <p>)
+  const fieldWrappers = ['field-group', 'collapsible']
+  for (const wrapperType of fieldWrappers) {
+    visitAndReplace(doc, wrapperType, (node) => {
+      replaceWithChildren(node, node.slice(2))
+    })
+  }
 
   // Transform code-preview to extract the Vue code as a code block
   visitAndReplace(doc, 'code-preview', (node) => {

--- a/docs/server/utils/transformMDC.ts
+++ b/docs/server/utils/transformMDC.ts
@@ -87,6 +87,54 @@ function visitAndReplace(doc: Document, type: string, handler: (node: any[]) => 
   }, node => node)
 }
 
+const BLOCK_ELEMENTS = new Set([
+  'pre', 'p', 'h1', 'h2', 'h3', 'h4', 'h5', 'h6',
+  'ul', 'ol', 'li', 'blockquote', 'table', 'hr'
+])
+
+function collectBlockChildren(nodes: any[]): any[] {
+  const result: any[] = []
+  for (const child of nodes) {
+    if (typeof child === 'string') {
+      if (child.trim()) {
+        result.push(['p', {}, child])
+      }
+    } else if (Array.isArray(child)) {
+      if (BLOCK_ELEMENTS.has(child[0])) {
+        result.push(child)
+      } else {
+        result.push(...collectBlockChildren(child.slice(2)))
+      }
+    }
+  }
+  return result
+}
+
+function replaceWithChildren(node: any[], newChildren: any[]) {
+  const collected = collectBlockChildren(newChildren)
+  node[0] = '__flatten'
+  node[1] = {}
+  node.length = 2
+  for (const child of collected) {
+    node.push(child)
+  }
+}
+
+function flattenMarkers(node: any): void {
+  if (!Array.isArray(node)) return
+  let i = 2
+  while (i < node.length) {
+    const child = node[i]
+    if (Array.isArray(child) && (child[0] === '__flatten' || child[0] === 'div')) {
+      const innerChildren = child.slice(2)
+      node.splice(i, 1, ...innerChildren)
+    } else {
+      flattenMarkers(child)
+      i++
+    }
+  }
+}
+
 function generateTSInterface(
   name: string,
   items: any[],
@@ -407,7 +455,12 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
 
     node[0] = 'p'
     node[1] = {}
-    node[2] = `See commit history for [component](https://github.com/nuxt/ui/commits/v4/${componentPath}) and [theme](https://github.com/nuxt/ui/commits/v4/${themePath}).`
+    node[2] = 'See commit history for '
+    node[3] = ['a', { href: `https://github.com/nuxt/ui/commits/v4/${componentPath}` }, 'component']
+    node[4] = ' and '
+    node[5] = ['a', { href: `https://github.com/nuxt/ui/commits/v4/${themePath}` }, 'theme']
+    node[6] = '.'
+    node.length = 7
   })
 
   // Transform callout components (tip, note, warning, caution, callout) to blockquotes
@@ -426,73 +479,29 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
       const content = node.slice(2)
       const label = calloutLabels[calloutType]
 
-      // Build the blockquote content
-      let blockquoteText = `> [!${label}]`
+      const blockquoteChildren: any[] = []
 
-      // Add link if present
+      let firstLine = `[!${label}]`
       if (attrs.to) {
-        blockquoteText += `\n> See: ${attrs.to}`
+        firstLine += `\nSee: ${attrs.to}`
       }
+      blockquoteChildren.push(['p', {}, firstLine])
 
-      // Extract text content from children
-      const extractText = (children: any[]): string => {
-        return children.map((child) => {
-          if (typeof child === 'string') return child
-          if (Array.isArray(child)) {
-            const tag = child[0]
-            const childAttrs = child[1] || {}
-            const childContent = child.slice(2)
-            if (tag === 'code') return `\`${extractText(childContent)}\``
-            if (tag === 'a') return `[${extractText(childContent)}](${childAttrs.href || ''})`
-            if (tag === 'pre') {
-              const lang = childAttrs.language || ''
-              const code = childAttrs.code || extractText(childContent)
-              return `\n\`\`\`${lang}\n${code}\n\`\`\`\n`
-            }
-            return extractText(childContent)
-          }
-          return ''
-        }).join('')
-      }
+      blockquoteChildren.push(...collectBlockChildren(content))
 
-      if (content.length > 0) {
-        const textContent = extractText(content)
-        if (textContent.trim()) {
-          blockquoteText += `\n> ${textContent.trim().split('\n').join('\n> ')}`
-        }
-      }
-
-      node[0] = 'p'
+      node[0] = 'blockquote'
       node[1] = {}
-      node[2] = blockquoteText
-      node.length = 3
+      node.length = 2
+      for (const child of blockquoteChildren) {
+        node.push(child)
+      }
     })
   }
 
   // Transform framework-only - extract content from both slots and label them
   visitAndReplace(doc, 'framework-only', (node) => {
     const children = node.slice(2)
-    let nuxtContent = ''
-    let vueContent = ''
-
-    // Helper to extract text from AST nodes
-    const extractContent = (nodes: any[]): string => {
-      return nodes.map((n: any) => {
-        if (typeof n === 'string') return n
-        if (Array.isArray(n)) {
-          const tag = n[0]
-          const attrs = n[1] || {}
-          const content = n.slice(2)
-          if (tag === 'pre') {
-            const lang = attrs.language || ''
-            const code = attrs.code || ''
-            return `\n\`\`\`${lang}\n${code}\n\`\`\`\n`
-          }
-          return extractContent(content)
-        }
-        return ''
-      }).join('')
-    }
+    const allChildren: any[] = []
 
     for (const child of children) {
       if (Array.isArray(child) && child[0] === 'template') {
@@ -500,26 +509,21 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
           ? 'nuxt'
           : child[1]?.['v-slot:vue'] !== undefined ? 'vue' : null
         if (slotAttr === 'nuxt') {
-          nuxtContent = extractContent(child.slice(2))
+          allChildren.push(['p', {}, ['strong', {}, 'Nuxt:']])
+          allChildren.push(...collectBlockChildren(child.slice(2)))
         } else if (slotAttr === 'vue') {
-          vueContent = extractContent(child.slice(2))
+          allChildren.push(['p', {}, ['strong', {}, 'Vue:']])
+          allChildren.push(...collectBlockChildren(child.slice(2)))
         }
       }
     }
 
-    let output = ''
-    if (nuxtContent.trim()) {
-      output += '**Nuxt:**\n' + nuxtContent.trim()
-    }
-    if (vueContent.trim()) {
-      if (output) output += '\n\n'
-      output += '**Vue:**\n' + vueContent.trim()
-    }
-
-    node[0] = 'p'
+    node[0] = '__flatten'
     node[1] = {}
-    node[2] = output || ''
-    node.length = 3
+    node.length = 2
+    for (const child of allChildren) {
+      node.push(child)
+    }
   })
 
   // Transform badge to inline text
@@ -538,33 +542,18 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
     const content = node.slice(2)
     const title = attrs.title || ''
 
-    // Extract text content from children
-    const extractText = (children: any[]): string => {
-      return children.map((child) => {
-        if (typeof child === 'string') return child
-        if (Array.isArray(child)) {
-          const tag = child[0]
-          const childContent = child.slice(2)
-          if (tag === 'code') return `\`${extractText(childContent)}\``
-          if (tag === 'a') return `[${extractText(childContent)}](${child[1]?.href || ''})`
-          return extractText(childContent)
-        }
-        return ''
-      }).join('')
+    const allChildren: any[] = []
+    if (title) {
+      allChildren.push(['p', {}, ['strong', {}, title]])
     }
+    allChildren.push(...collectBlockChildren(content))
 
-    let cardText = title ? `**${title}**` : ''
-    if (content.length > 0) {
-      const textContent = extractText(content)
-      if (textContent.trim()) {
-        cardText += cardText ? `\n${textContent.trim()}` : textContent.trim()
-      }
-    }
-
-    node[0] = 'p'
+    node[0] = '__flatten'
     node[1] = {}
-    node[2] = cardText
-    node.length = 3
+    node.length = 2
+    for (const child of allChildren) {
+      node.push(child)
+    }
   })
 
   // Transform accordion-item to Q&A format
@@ -573,34 +562,18 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
     const content = node.slice(2)
     const label = attrs.label || ''
 
-    // Extract text content from children
-    const extractText = (children: any[]): string => {
-      return children.map((child) => {
-        if (typeof child === 'string') return child
-        if (Array.isArray(child)) {
-          const tag = child[0]
-          const childContent = child.slice(2)
-          if (tag === 'code') return `\`${extractText(childContent)}\``
-          if (tag === 'a') return `[${extractText(childContent)}](${child[1]?.href || ''})`
-          if (tag === 'p') return extractText(childContent)
-          return extractText(childContent)
-        }
-        return ''
-      }).join('')
+    const allChildren: any[] = []
+    if (label) {
+      allChildren.push(['p', {}, ['strong', {}, `Q: ${label}`]])
     }
+    allChildren.push(...collectBlockChildren(content))
 
-    let itemText = label ? `**Q: ${label}**` : ''
-    if (content.length > 0) {
-      const textContent = extractText(content)
-      if (textContent.trim()) {
-        itemText += `\n\nA: ${textContent.trim()}`
-      }
-    }
-
-    node[0] = 'p'
+    node[0] = '__flatten'
     node[1] = {}
-    node[2] = itemText
-    node.length = 3
+    node.length = 2
+    for (const child of allChildren) {
+      node.push(child)
+    }
   })
 
   const componentsListNodes: any[] = []
@@ -623,49 +596,23 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
       .select('path', 'title')
       .all()
 
-    const links = components.map((c: any) => `- [${c.title}](https://ui.nuxt.com/raw${c.path}.md)`).join('\n')
+    const listItems = components.map((c: any) =>
+      ['li', {}, ['a', { href: `https://ui.nuxt.com/raw${c.path}.md` }, c.title]]
+    )
 
-    node[0] = 'p'
+    node[0] = 'ul'
     node[1] = {}
-    node[2] = links
+    node.length = 2
+    for (const item of listItems) {
+      node.push(item)
+    }
   }
 
   // Remove wrapper elements by extracting children content
-  const wrapperTypes = ['card-group', 'accordion', 'steps', 'code-group', 'code-collapse', 'tabs']
+  const wrapperTypes = ['card-group', 'accordion', 'steps', 'code-group', 'code-collapse', 'tabs', 'div']
   for (const wrapperType of wrapperTypes) {
     visitAndReplace(doc, wrapperType, (node) => {
-      const children = node.slice(2)
-
-      // Extract text from transformed children (they should be paragraphs now)
-      const extractFromChildren = (nodes: any[]): string => {
-        return nodes.map((child: any) => {
-          if (typeof child === 'string') return child
-          if (Array.isArray(child)) {
-            const tag = child[0]
-            const attrs = child[1] || {}
-            const content = child.slice(2)
-            // Handle pre/code blocks
-            if (tag === 'pre') {
-              const lang = attrs.language || ''
-              const code = attrs.code || ''
-              return `\n\`\`\`${lang}\n${code}\n\`\`\`\n`
-            }
-            // Handle paragraphs and other text
-            if (tag === 'p') {
-              const text = content.map((c: any) => typeof c === 'string' ? c : '').join('')
-              return text + '\n\n'
-            }
-            return extractFromChildren(content)
-          }
-          return ''
-        }).join('')
-      }
-
-      const extracted = extractFromChildren(children).trim()
-      node[0] = 'p'
-      node[1] = {}
-      node[2] = extracted
-      node.length = 3
+      replaceWithChildren(node, node.slice(2))
     })
   }
 
@@ -673,33 +620,7 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
   const fieldWrappers = ['field-group', 'collapsible']
   for (const wrapperType of fieldWrappers) {
     visitAndReplace(doc, wrapperType, (node) => {
-      const children = node.slice(2)
-      const extractFromChildren = (nodes: any[]): string => {
-        return nodes.map((child: any) => {
-          if (typeof child === 'string') return child
-          if (Array.isArray(child)) {
-            const tag = child[0]
-            const attrs = child[1] || {}
-            const content = child.slice(2)
-            if (tag === 'pre') {
-              const lang = attrs.language || ''
-              const code = attrs.code || ''
-              return `\n\`\`\`${lang}\n${code}\n\`\`\`\n`
-            }
-            if (tag === 'p') {
-              const text = content.map((c: any) => typeof c === 'string' ? c : '').join('')
-              return text + '\n\n'
-            }
-            return extractFromChildren(content)
-          }
-          return ''
-        }).join('')
-      }
-      const extracted = extractFromChildren(children).trim()
-      node[0] = 'p'
-      node[1] = {}
-      node[2] = extracted
-      node.length = 3
+      replaceWithChildren(node, node.slice(2))
     })
   }
 
@@ -715,23 +636,31 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
       return nodes.map((child: any) => {
         if (typeof child === 'string') return child
         if (Array.isArray(child)) {
-          const content = child.slice(2)
-          return extractText(content)
+          const innerContent = child.slice(2)
+          return extractText(innerContent)
         }
         return ''
       }).join('')
     }
 
-    let fieldText = `**${name}**`
-    if (type) fieldText += ` (\`${type}\`)`
-    if (required) fieldText += ' *required*'
+    const parts: any[] = [['strong', {}, name]]
+    if (type) {
+      parts.push(' (', ['code', {}, type], ')')
+    }
+    if (required) {
+      parts.push(' ', ['em', {}, 'required'])
+    }
     const desc = extractText(content).trim()
-    if (desc) fieldText += `: ${desc}`
+    if (desc) {
+      parts.push(`: ${desc}`)
+    }
 
     node[0] = 'p'
     node[1] = {}
-    node[2] = fieldText
-    node.length = 3
+    node.length = 2
+    for (const part of parts) {
+      node.push(part)
+    }
   })
 
   // Transform code-preview to extract the Vue code as a code block
@@ -776,7 +705,7 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
   visitAndReplace(doc, 'icons-theme', (node) => {
     node[0] = 'p'
     node[1] = {}
-    node[2] = '*See the interactive theme picker on the documentation website.*'
+    node[2] = ['em', {}, 'See the interactive theme picker on the documentation website.']
     node.length = 3
   })
 
@@ -791,7 +720,7 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
   visitAndReplace(doc, 'supported-languages', (node) => {
     node[0] = 'p'
     node[1] = {}
-    node[2] = '*See the full list of supported languages on the documentation website.*'
+    node[2] = ['em', {}, 'See the full list of supported languages on the documentation website.']
     node.length = 3
   })
 
@@ -800,11 +729,25 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
     const attrs = node[1] || {}
     const label = attrs.label || ''
     const to = attrs.to || ''
-    node[0] = 'p'
-    node[1] = {}
-    node[2] = to ? `[${label}](${to})` : label
-    node.length = 3
+    if (to) {
+      node[0] = 'p'
+      node[1] = {}
+      node[2] = ['a', { href: to }, label]
+      node.length = 3
+    } else {
+      node[0] = 'p'
+      node[1] = {}
+      node[2] = label
+      node.length = 3
+    }
   })
+
+  // Flatten __flatten markers by splicing their children into parents
+  if (Array.isArray(doc.body)) {
+    flattenMarkers(doc.body)
+  } else if (doc.body?.value && Array.isArray(doc.body.value)) {
+    flattenMarkers(doc.body.value)
+  }
 
   return doc
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
Improve agent readability for `ui.nuxt.com` docs based on the [Vercel Agent Readability Spec](https://vercel.com/kb/guide/agent-readability-spec).
- Add `sitemap.xml` and `sitemap.md` server routes for search engines and AI agents
- Add Vercel rewrites for `.md` URLs, `Accept: text/markdown`, and AI bot user agents
- Add JSON-LD structured data (`TechArticle` + `BreadcrumbList`) to docs pages
- Add YAML frontmatter and `Link: rel="canonical"` to raw markdown responses
- Add `Vary: Accept, User-Agent` header on `/docs/**` routes
- Return helpful markdown (not error) for missing pages in the raw handler
- Expand `robots.txt` with AI bot rules and sitemap reference
- Add `rel="alternate"` link to `.md` version on docs pages

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
