### PR TITLE
fix(Tabs): preserve state when items change

### DIFF
--- a/src/runtime/components/Tabs.vue
+++ b/src/runtime/components/Tabs.vue
@@ -91,10 +91,10 @@ export type TabsSlots<T extends TabsItem = TabsItem> = {
 </script>
 
 <script setup lang="ts" generic="T extends TabsItem">
-import { ref, computed } from 'vue'
+import { ref, computed, nextTick, onMounted, watch } from 'vue'
 import { TabsRoot, TabsList, TabsIndicator, TabsTrigger, TabsContent, useForwardPropsEmits } from 'reka-ui'
 import { reactivePick } from '@vueuse/core'
-import { useAppConfig } from '#imports'
+import { useAppConfig, useNuxtApp } from '#imports'
 import { useComponentUI } from '../composables/useComponentUI'
 import { get } from '../utils'
 import { tv } from '../utils/tv'
@@ -114,6 +114,7 @@ const emits = defineEmits<TabsEmits>()
 const slots = defineSlots<TabsSlots<T>>()
 
 const appConfig = useAppConfig() as Tabs['AppConfig']
+const nuxtApp = useNuxtApp()
 const uiProp = useComponentUI('tabs', props)
 
 const rootProps = useForwardPropsEmits(reactivePick(props, 'as', 'unmountOnHide'), emits)
@@ -125,12 +126,79 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.tabs || {}) 
   orientation: props.orientation
 }))
 
+const hydrationKeyPrefix = ref(import.meta.server || nuxtApp.isHydrating ? 0 : 1)
+const rootRef = ref<Element | ComponentPublicInstance | null>(null)
+
+const resolvedItems = computed(() => {
+  if (!props.items) {
+    return []
+  }
+
+  return props.items.map((item, index) => {
+    const value = get(item, props.valueKey as string) ?? String(index)
+    const stableId = get(item, props.valueKey as string) ?? get(item, props.labelKey as string) ?? String(index)
+
+    return {
+      key: `${hydrationKeyPrefix.value}-${stableId}`,
+      item,
+      index,
+      value
+    }
+  })
+})
+
 const triggersRef = ref<ComponentPublicInstance[]>([])
+
+watch(resolvedItems, (items) => {
+  triggersRef.value = triggersRef.value.slice(0, items.length)
+}, { immediate: true })
+
+function getElement(el: Element | ComponentPublicInstance | null) {
+  if (!el) {
+    return null
+  }
+
+  if ('$el' in el) {
+    return el.$el as HTMLElement
+  }
+
+  return el as HTMLElement
+}
 
 function setTriggerRef(index: number, el: Element | ComponentPublicInstance | null) {
   // @ts-expect-error - ComponentPublicInstance type mismatch in Nuxt module augmentation
   triggersRef.value[index] = el
 }
+
+function shouldRefreshHydratedItems() {
+  if (props.modelValue === undefined) {
+    return false
+  }
+
+  const rootEl = getElement(rootRef.value)
+
+  if (!rootEl) {
+    return false
+  }
+
+  const tabs = Array.from(rootEl.querySelectorAll<HTMLElement>(':scope > [data-slot="list"] > [data-slot="trigger"][role="tab"]'))
+  const activeIndexes = tabs.flatMap((tab, index) => tab.dataset.state === 'active' ? [index] : [])
+  const expectedIndex = resolvedItems.value.findIndex(item => item.value === props.modelValue)
+
+  return expectedIndex !== -1 && (activeIndexes.length !== 1 || activeIndexes[0] !== expectedIndex)
+}
+
+onMounted(async () => {
+  if (hydrationKeyPrefix.value !== 0) {
+    return
+  }
+
+  await nextTick()
+
+  if (shouldRefreshHydratedItems()) {
+    hydrationKeyPrefix.value = 1
+  }
+})
 
 defineExpose({
   triggersRef
@@ -139,6 +207,8 @@ defineExpose({
 
 <template>
   <TabsRoot
+    :key="hydrationKeyPrefix"
+    ref="rootRef"
     v-bind="rootProps"
     :model-value="modelValue"
     :default-value="defaultValue"
@@ -153,10 +223,10 @@ defineExpose({
       <slot name="list-leading" />
 
       <TabsTrigger
-        v-for="(item, index) of items"
-        :key="index"
+        v-for="{ item, index, key, value } of resolvedItems"
+        :key="key"
         :ref="el => setTriggerRef(index, el)"
-        :value="get(item, props.valueKey as string) ?? String(index)"
+        :value="value"
         :disabled="item.disabled"
         data-slot="trigger"
         :class="ui.trigger({ class: [uiProp?.trigger, item.ui?.trigger] })"
@@ -187,7 +257,7 @@ defineExpose({
     </TabsList>
 
     <template v-if="!!content">
-      <TabsContent v-for="(item, index) of items" :key="index" :value="get(item, props.valueKey as string) ?? String(index)" data-slot="content" :class="ui.content({ class: [uiProp?.content, item.ui?.content, item.class] })">
+      <TabsContent v-for="{ item, index, key, value } of resolvedItems" :key="key" :value="value" data-slot="content" :class="ui.content({ class: [uiProp?.content, item.ui?.content, item.class] })">
         <slot :name="((item.slot || 'content') as keyof TabsSlots<T>)" :item="(item as Extract<T, { slot: string; }>)" :index="index" :ui="ui">
           {{ item.content }}
         </slot>

--- a/test/components/Tabs.spec.ts
+++ b/test/components/Tabs.spec.ts
@@ -183,34 +183,37 @@ describe('Tabs', () => {
     const container = document.createElement('div')
 
     document.body.appendChild(container)
+    let app: ReturnType<typeof createSSRApp> | undefined
 
-    container.innerHTML = await renderToString(createSSRApp(Tabs, {
-      content: false,
-      items: serverItems,
-      labelKey: 'label',
-      modelValue: 'third',
-      valueKey: 'value'
-    }))
+    try {
+      container.innerHTML = await renderToString(createSSRApp(Tabs, {
+        content: false,
+        items: serverItems,
+        labelKey: 'label',
+        modelValue: 'third',
+        valueKey: 'value'
+      }))
 
-    const app = createSSRApp(Tabs, {
-      content: false,
-      items: clientItems,
-      labelKey: 'label',
-      modelValue: 'third',
-      valueKey: 'value'
-    })
+      app = createSSRApp(Tabs, {
+        content: false,
+        items: clientItems,
+        labelKey: 'label',
+        modelValue: 'third',
+        valueKey: 'value'
+      })
 
-    app.mount(container)
+      app.mount(container)
 
-    await nextTick()
-    await nextTick()
+      await nextTick()
+      await nextTick()
 
-    const activeTabs = Array.from(container.querySelectorAll<HTMLElement>('[data-slot="trigger"][role="tab"][data-state="active"]'))
+      const activeTabs = Array.from(container.querySelectorAll<HTMLElement>('[data-slot="trigger"][role="tab"][data-state="active"]'))
 
-    expect(activeTabs).toHaveLength(1)
-    expect(activeTabs[0]?.textContent).toContain('Third')
-
-    app.unmount()
-    container.remove()
+      expect(activeTabs).toHaveLength(1)
+      expect(activeTabs[0]?.textContent).toContain('Third')
+    } finally {
+      app?.unmount()
+      container.remove()
+    }
   })
 })

--- a/test/components/Tabs.spec.ts
+++ b/test/components/Tabs.spec.ts
@@ -1,9 +1,14 @@
+import { createSSRApp, defineComponent, nextTick, onUnmounted, ref } from 'vue'
+import { mount } from '@vue/test-utils'
 import { describe, it, expect } from 'vitest'
 import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { renderToString } from 'vue/server-renderer'
 import { renderEach } from '../component-render'
 import Tabs from '../../src/runtime/components/Tabs.vue'
 import theme from '#build/ui/tabs'
+
+const hydrationIt = (globalThis as { __NUXT_VITEST_ENVIRONMENT__?: boolean }).__NUXT_VITEST_ENVIRONMENT__ ? it.skip : it
 
 describe('Tabs', () => {
   const variants = Object.keys(theme.variants.variant) as any
@@ -63,5 +68,149 @@ describe('Tabs', () => {
     })
 
     expect(await axe(wrapper.element)).toHaveNoViolations()
+  })
+
+  it('keeps tab content mounted when removing a leading item', async () => {
+    const unmounted: string[] = []
+    let nextInstanceId = 0
+
+    const statefulItems = [{
+      label: 'First',
+      value: 'first'
+    }, {
+      label: 'Second',
+      value: 'second'
+    }, {
+      label: 'Third',
+      value: 'third'
+    }]
+
+    const StatefulContent = defineComponent({
+      props: {
+        value: {
+          type: String,
+          required: true
+        }
+      },
+      setup(props) {
+        const instanceId = ++nextInstanceId
+
+        onUnmounted(() => {
+          unmounted.push(props.value)
+        })
+
+        return { instanceId }
+      },
+      template: '<div :data-tab-value="value" :data-instance-id="instanceId">{{ value }}</div>'
+    })
+
+    const TestTabs = defineComponent({
+      components: {
+        StatefulContent,
+        Tabs
+      },
+      props: {
+        items: {
+          type: Array,
+          required: true
+        }
+      },
+      setup() {
+        const modelValue = ref('third')
+
+        return { modelValue }
+      },
+      template: `
+        <Tabs
+          v-model="modelValue"
+          :items="items"
+          value-key="value"
+          label-key="label"
+          :unmount-on-hide="false"
+        >
+          <template #content="{ item }">
+            <StatefulContent :value="item.value" />
+          </template>
+        </Tabs>
+      `
+    })
+
+    const wrapper = mount(TestTabs, {
+      props: {
+        items: statefulItems
+      }
+    })
+
+    const getInstances = () => Object.fromEntries(
+      wrapper.findAll('[data-instance-id]').map((node) => {
+        return [node.attributes('data-tab-value'), node.attributes('data-instance-id')]
+      })
+    )
+
+    const initialInstances = getInstances()
+
+    await wrapper.setProps({
+      items: statefulItems.slice(1)
+    })
+
+    const nextInstances = getInstances()
+    const activeTabs = wrapper.findAll('[role="tab"][data-state="active"]')
+
+    expect(nextInstances.second).toBe(initialInstances.second)
+    expect(nextInstances.third).toBe(initialInstances.third)
+    expect(unmounted).toContain('first')
+    expect(unmounted).not.toContain('second')
+    expect(unmounted).not.toContain('third')
+    expect(activeTabs).toHaveLength(1)
+    expect(activeTabs[0]?.text()).toContain('Third')
+  })
+
+  hydrationIt('refreshes hydrated tabs when the active trigger state does not match modelValue', async () => {
+    const serverItems = [{
+      label: 'Third',
+      value: 'third'
+    }]
+    const clientItems = [{
+      label: 'First',
+      value: 'first'
+    }, {
+      label: 'Second',
+      value: 'second'
+    }, {
+      label: 'Third',
+      value: 'third'
+    }]
+    const container = document.createElement('div')
+
+    document.body.appendChild(container)
+
+    container.innerHTML = await renderToString(createSSRApp(Tabs, {
+      content: false,
+      items: serverItems,
+      labelKey: 'label',
+      modelValue: 'third',
+      valueKey: 'value'
+    }))
+
+    const app = createSSRApp(Tabs, {
+      content: false,
+      items: clientItems,
+      labelKey: 'label',
+      modelValue: 'third',
+      valueKey: 'value'
+    })
+
+    app.mount(container)
+
+    await nextTick()
+    await nextTick()
+
+    const activeTabs = Array.from(container.querySelectorAll<HTMLElement>('[data-slot="trigger"][role="tab"][data-state="active"]'))
+
+    expect(activeTabs).toHaveLength(1)
+    expect(activeTabs[0]?.textContent).toContain('Third')
+
+    app.unmount()
+    container.remove()
   })
 })


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves #5841

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR keeps the `UTabs` fix focused on the reported issue and the hydration mismatch reproduced in the linked portal case.

It fixes the state-loss problem when tab items with stable values are inserted or removed before the active tab by switching trigger/content identity away from render indexes.

It also keeps the hydration-specific repair for the direct-load case where the server renders only `Third`, the client hydrates with `First`, `Second`, `Third`, and `v-model` stays `third`. In that situation, stable keys alone are not enough, so the component performs a one-time post-mount refresh only when the hydrated active tab DOM does not match `modelValue`.

Intentionally out of scope for this PR:
- generalized duplicate-label / no-value identity guarantees
- `Accordion` or any other component

The reduced test coverage now focuses on:
- preserving mounted tab content when a leading tab is removed with `unmountOnHide=false`
- keeping a single active tab in the SSR/client hydration mismatch case above

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
