### PR TITLE
fix(Accordion/Tabs): use item value as stable key to avoid remounts

### DIFF
--- a/src/runtime/components/Accordion.vue
+++ b/src/runtime/components/Accordion.vue
@@ -106,7 +106,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.accordion ||
     <AccordionItem
       v-for="(item, index) in props.items"
       v-slot="{ open }"
-      :key="index"
+      :key="get(item, props.valueKey as string) ?? index"
       :value="get(item, props.valueKey as string) ?? String(index)"
       :disabled="item.disabled"
       data-slot="item"

--- a/src/runtime/components/Accordion.vue
+++ b/src/runtime/components/Accordion.vue
@@ -22,7 +22,12 @@ export interface AccordionItem {
   trailingIcon?: IconProps['name']
   slot?: string
   content?: string
-  /** A unique value for the accordion item. Defaults to the index. */
+  /**
+   * A unique value for the accordion item. Defaults to the index.
+   * Also used as the Vue `key` for this item, so providing a stable value prevents
+   * accordion content (and its local state) from remounting when items are added, removed,
+   * or reordered.
+   */
   value?: string
   disabled?: boolean
   class?: any

--- a/src/runtime/components/Tabs.vue
+++ b/src/runtime/components/Tabs.vue
@@ -24,7 +24,11 @@ export interface TabsItem {
   badge?: string | number | BadgeProps
   slot?: string
   content?: string
-  /** A unique value for the tab item. Defaults to the index. */
+  /**
+   * A unique value for the tab item. Defaults to the index.
+   * Also used as the Vue `key` for this item, so providing a stable value prevents tab
+   * content (and its local state) from remounting when items are added, removed, or reordered.
+   */
   value?: string | number
   disabled?: boolean
   class?: any

--- a/src/runtime/components/Tabs.vue
+++ b/src/runtime/components/Tabs.vue
@@ -154,7 +154,7 @@ defineExpose({
 
       <TabsTrigger
         v-for="(item, index) of items"
-        :key="index"
+        :key="get(item, props.valueKey as string) ?? index"
         :ref="el => setTriggerRef(index, el)"
         :value="get(item, props.valueKey as string) ?? String(index)"
         :disabled="item.disabled"
@@ -187,7 +187,7 @@ defineExpose({
     </TabsList>
 
     <template v-if="!!content">
-      <TabsContent v-for="(item, index) of items" :key="index" :value="get(item, props.valueKey as string) ?? String(index)" data-slot="content" :class="ui.content({ class: [uiProp?.content, item.ui?.content, item.class] })">
+      <TabsContent v-for="(item, index) of items" :key="get(item, props.valueKey as string) ?? index" :value="get(item, props.valueKey as string) ?? String(index)" data-slot="content" :class="ui.content({ class: [uiProp?.content, item.ui?.content, item.class] })">
         <slot :name="((item.slot || 'content') as keyof TabsSlots<T>)" :item="(item as Extract<T, { slot: string; }>)" :index="index" :ui="ui">
           {{ item.content }}
         </slot>


### PR DESCRIPTION
### 🔗 Linked Issue

Closes #5841

### 📚 Description

Both `UTabs` and `UAccordion` currently key their `v-for` items by the iteration index:

```vue
<TabsTrigger v-for="(item, index) of items" :key="index" ... />
<TabsContent v-for="(item, index) of items" :key="index" ... />
<AccordionItem v-for="(item, index) in props.items" :key="index" ... />
```

When items are added, removed, or reordered, Vue sees "the same key at the same position," reuses the DOM element, and swaps its inner content — which unmounts any stateful descendant of the reused slot. For `UTabs` this means every tab after the changed position loses local state (counters, form inputs, subscriptions). For `UAccordion` the same pattern causes content remounts and — combined with lazy-loaded islands — occasional hydration oddness.

Switch both to `:key="get(item, valueKey) ?? index"` — the same expression already used for `:value` — so items with a user-provided `value` get a stable identity across reorders, while items without a value keep the previous index-based behaviour (no regression for existing users who don't provide `value`).

### 🔖 Checklist

- [x] Read [contribution guide](https://ui.nuxt.com/community/contribution).
- [x] Installed dependencies with `pnpm install`.
- [x] Code is properly formatted and linted with `pnpm lint --fix`.
- [x] Made sure the docs build correctly with `pnpm docs:build`.
- [x] Made sure tests are passing with `pnpm test`.