### PR TITLE
fix(PinInput/InputDate): resolve double input and segment issues in IME mode

### DIFF
--- a/src/runtime/components/InputDate.vue
+++ b/src/runtime/components/InputDate.vue
@@ -127,20 +127,25 @@ function onCompositionStart() {
 
 function onCompositionEnd(event: Event) {
   isComposing.value = false
-  const target = event.target as HTMLInputElement
   const data = (event as CompositionEvent).data
 
-  if (target && data) {
-    // Dispatch fake keydown and input events for reka-ui to recognize numeric input during IME composition.
+  if (data) {
+    // Process each character from IME composition by dispatching fake events.
+    // We use document.activeElement to follow potential focus shifts between segments.
     for (const char of data) {
-      target.dispatchEvent(new KeyboardEvent('keydown', {
+      if (!/^\d$/.test(char)) continue
+
+      const currentTarget = document.activeElement as HTMLInputElement
+      if (!currentTarget) break
+
+      currentTarget.dispatchEvent(new KeyboardEvent('keydown', {
         key: char,
         code: `Digit${char}`,
         bubbles: true,
         cancelable: true
       }))
 
-      target.dispatchEvent(new InputEvent('input', {
+      currentTarget.dispatchEvent(new InputEvent('input', {
         data: char,
         bubbles: true,
         cancelable: true

--- a/src/runtime/components/InputDate.vue
+++ b/src/runtime/components/InputDate.vue
@@ -119,6 +119,51 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.inputDate ||
 
 const inputsRef = ref<ComponentPublicInstance[]>([])
 
+const isComposing = ref(false)
+
+function onCompositionStart() {
+  isComposing.value = true
+}
+
+function onCompositionEnd(event: Event) {
+  isComposing.value = false
+  const target = event.target as HTMLInputElement
+  const data = (event as CompositionEvent).data
+
+  if (target && data) {
+    // Dispatch fake keydown and input events for reka-ui to recognize numeric input during IME composition.
+    for (const char of data) {
+      target.dispatchEvent(new KeyboardEvent('keydown', {
+        key: char,
+        code: `Digit${char}`,
+        bubbles: true,
+        cancelable: true
+      }))
+
+      target.dispatchEvent(new InputEvent('input', {
+        data: char,
+        bubbles: true,
+        cancelable: true
+      }))
+    }
+  }
+}
+
+function onKeydown(event: KeyboardEvent) {
+  // Prevent IME keydown (229) from interfering with reka-ui's segment logic.
+  if (isComposing.value || event.keyCode === 229) {
+    event.stopPropagation()
+    event.stopImmediatePropagation()
+  }
+}
+
+function onInput(event: Event) {
+  // Prevent browser from inserting characters directly into segments during IME composition.
+  if (isComposing.value || (event as InputEvent).isComposing) {
+    event.stopImmediatePropagation()
+  }
+}
+
 function setInputRef(index: number, el: Element | ComponentPublicInstance | null) {
   // @ts-expect-error - ComponentPublicInstance type mismatch in Nuxt module augmentation
   inputsRef.value[index] = el
@@ -173,6 +218,10 @@ defineExpose({
       data-slot="segment"
       :class="ui.segment({ class: uiProp?.segment })"
       :data-segment="segment.part"
+      @input.capture="onInput"
+      @keydown.capture="onKeydown"
+      @compositionstart="onCompositionStart"
+      @compositionend="onCompositionEnd"
     >
       {{ segment.value.trim() }}
     </DateField.Input>

--- a/src/runtime/components/PinInput.vue
+++ b/src/runtime/components/PinInput.vue
@@ -89,6 +89,30 @@ function setInputRef(index: number, el: Element | ComponentPublicInstance | null
   inputsRef.value[index] = el
 }
 
+const isComposing = ref(false)
+
+function onCompositionStart() {
+  isComposing.value = true
+}
+
+function onCompositionEnd(event: Event) {
+  isComposing.value = false
+  // Some browsers may not fire an input event after compositionend, or reka-ui might miss it.
+  // We manually dispatch an input event to ensure reka-ui receives the final value.
+  const target = event.target as HTMLInputElement
+  if (target) {
+    target.dispatchEvent(new Event('input', { bubbles: true }))
+  }
+}
+
+function onInput(event: Event) {
+  // Prevent reka-ui from shifting focus too early during IME composition,
+  // which causes subsequent characters to be entered into the next input field.
+  if (isComposing.value || (event as InputEvent).isComposing) {
+    event.stopImmediatePropagation()
+  }
+}
+
 const completed = ref(false)
 function onComplete(value: string[] | number[]) {
   // @ts-expect-error - 'target' does not exist in type 'EventInit'
@@ -144,6 +168,9 @@ defineExpose({
       :disabled="disabled"
       @blur="onBlur"
       @focus="emitFormFocus"
+      @input.capture="onInput"
+      @compositionstart="onCompositionStart"
+      @compositionend="onCompositionEnd"
     />
   </PinInputRoot>
 </template>

--- a/src/runtime/components/PinInput.vue
+++ b/src/runtime/components/PinInput.vue
@@ -97,10 +97,12 @@ function onCompositionStart() {
 
 function onCompositionEnd(event: Event) {
   isComposing.value = false
-  // Some browsers may not fire an input event after compositionend, or reka-ui might miss it.
-  // We manually dispatch an input event to ensure reka-ui receives the final value.
+  // Some browsers (like Chrome/Safari) may not fire an input event after compositionend.
+  // Firefox DOES fire a native input event after compositionend, so we must skip the synthetic dispatch.
+  const isFirefox = typeof navigator !== 'undefined' && navigator.userAgent.toLowerCase().includes('firefox')
+
   const target = event.target as HTMLInputElement
-  if (target) {
+  if (target && !isFirefox) {
     target.dispatchEvent(new Event('input', { bubbles: true }))
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves (None) - Fixed based on local testing for IME compatibility.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR fixes several major issues encountered by users of CJK Input Method Editors (IME):

1. **PinInput Double Input & Firefox Compatibility**: 
    - **Problem**: When using an IME, `reka-ui` shifts focus to the next field too early, resulting in duplicate digits. 
    - **Fix**: We now capture and block `input` events during composition and manually dispatch a clean `input` event upon `compositionend`.
    - **Enhancement**: Added a user-agent check to skip the synthetic `input` dispatch on Firefox. Firefox natively fires a post-`compositionend` input event, so skipping our synthetic event prevents duplicate inputs specific to Firefox.

2. **InputDate Segment Recognition & Sanitization**: 
    - **Problem**: In IME mode, numeric inputs were often treated as raw text, corrupting segments (e.g., `mm1`).
    - **Fix**: We intercept IME `keydown` (229) and simulate standard numeric `keydown`/`input` events when composition ends.
    - **Enhancement**: Added regex validation (`/^\d$/.test()`) during `compositionend` to ensure only pure numeric digits are dispatched. This prevents invalid KeyboardEvent codes (like `DigitA`) if a user accidentally types letters or symbols during IME composition.

3. **InputDate Validation/Clamping Bypass**:
    - **Problem**: When typing an invalid value such as "33" in the "dd" (day) segment using an IME, the input would bypass the validation/clamping logic and immediately jump to the "yyyy" segment.
    - **Fix**: Ensured that values entered via IME are properly validated and clamped (e.g., automatically restricted to "3") before shifting focus to the next segment.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
- [x] My code follows the code style of this project.
- [x] I have performed a self-review of my own code.
