### PR TITLE
fix(CheckboxGroup): add label and description to theme slots

### DIFF
--- a/src/theme/checkbox-group.ts
+++ b/src/theme/checkbox-group.ts
@@ -5,7 +5,9 @@ export default (options: Required<ModuleOptions>) => ({
     root: 'relative',
     fieldset: 'flex gap-x-2',
     legend: 'mb-1 block font-medium text-default',
-    item: ''
+    item: '',
+    label: 'block font-medium text-default',
+    description: 'text-muted'
   },
   variants: {
     orientation: {


### PR DESCRIPTION
Fixes #6337

## Problem

`CheckboxGroupSlots` defines `label` and `description` slots (they are forwarded to each inner `Checkbox`), but `src/theme/checkbox-group.ts` only declares `root`, `fieldset`, `legend`, and `item`.

This means customising via `app.config.ts` throws a type error:

```ts
export default defineAppConfig({
  ui: {
    checkboxGroup: {
      slots: {
        label: 'font-normal' // ❌ Type error: Object literal may only specify known properties
      }
    }
  }
})
```

...even though it works correctly at runtime.

## Fix

Add `label` and `description` to the `slots` map with the same default classes already used in `checkbox.ts` and `radio-group.ts`:

```ts
label: 'block font-medium text-default',
description: 'text-muted'
```

## Why it's safe

- Purely additive — no existing slot is changed
- Default classes are identical to sibling components (`Checkbox`, `RadioGroup`)
- No runtime behavior changes; this only makes the existing behavior typeable