### PR TITLE
fix(InputMenu/Select/SelectMenu): respect `trailing: false` over default `trailingIcon`

### DIFF
--- a/src/runtime/composables/useComponentIcons.ts
+++ b/src/runtime/composables/useComponentIcons.ts
@@ -41,7 +41,7 @@ export function useComponentIcons(componentProps: MaybeRefOrGetter<UseComponentI
   const props = computed(() => toValue(componentProps))
 
   const isLeading = computed(() => (props.value.icon && props.value.leading) || (props.value.icon && !props.value.trailing) || (props.value.loading && !props.value.trailing) || !!props.value.leadingIcon)
-  const isTrailing = computed(() => (props.value.icon && props.value.trailing) || (props.value.loading && props.value.trailing) || !!props.value.trailingIcon)
+  const isTrailing = computed(() => (props.value.icon && props.value.trailing) || (props.value.loading && props.value.trailing) || (!!props.value.trailingIcon && props.value.trailing !== false))
 
   const leadingIconName = computed(() => {
     if (props.value.loading) {

--- a/test/components/InputMenu.spec.ts
+++ b/test/components/InputMenu.spec.ts
@@ -123,6 +123,18 @@ describe('InputMenu', () => {
     }
   )
 
+  it('with trailing false should not render trailing section', () => {
+    const wrapper = mount(InputMenu, {
+      props: {
+        ...props,
+        trailing: false
+      }
+    })
+
+    expect(wrapper.find('[data-slot="trailing"]').exists()).toBe(false)
+    expect(wrapper.find('[data-slot="trailingIcon"]').exists()).toBe(false)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(InputMenu, {
       props: {

--- a/test/components/Select.spec.ts
+++ b/test/components/Select.spec.ts
@@ -110,6 +110,18 @@ describe('Select', () => {
     }
   )
 
+  it('with trailing false should not render trailing section', () => {
+    const wrapper = mount(Select, {
+      props: {
+        ...props,
+        trailing: false
+      }
+    })
+
+    expect(wrapper.find('[data-slot="trailing"]').exists()).toBe(false)
+    expect(wrapper.find('[data-slot="trailingIcon"]').exists()).toBe(false)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(Select, {
       props: {

--- a/test/components/SelectMenu.spec.ts
+++ b/test/components/SelectMenu.spec.ts
@@ -118,6 +118,18 @@ describe('SelectMenu', () => {
     }
   )
 
+  it('with trailing false should not render trailing section', () => {
+    const wrapper = mount(SelectMenu, {
+      props: {
+        ...props,
+        trailing: false
+      }
+    })
+
+    expect(wrapper.find('[data-slot="trailing"]').exists()).toBe(false)
+    expect(wrapper.find('[data-slot="trailingIcon"]').exists()).toBe(false)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(SelectMenu, {
       props: {


### PR DESCRIPTION
## Linked issue

Resolves #6287 

﻿## What changed

This makes `trailing="false"` fully opt out of the trailing section, even when a component provides a default trailing icon internally.

`Select`, `SelectMenu`, and `InputMenu` all provide a default chevron through `trailingIcon`, so the shared icon helper now lets an explicit `trailing: false` win over that default.

## Why

Before this, `USelect` still rendered the chevron because `useComponentIcons` treated any `trailingIcon` as enough reason to show trailing content. That made the public `trailing` prop feel a bit surprising: passing `false` did not actually hide the trailing icon.

This keeps the normal default chevron behavior, while allowing users to intentionally remove it.
