### PR TITLE
fix(ContentSearch): preserve intermediate ancestors in breadcrumb prefix

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -140,6 +140,7 @@ PR Review:
 - [ ] `pnpm run test` passes
 - [ ] Documentation is updated if applicable
 - [ ] Commit message follows conventional commits
+- [ ] PR description follows [.github/PULL_REQUEST_TEMPLATE.md](.github/PULL_REQUEST_TEMPLATE.md) (linked issue, type of change, description, checklist)
 
 Multiple commits are fine — PRs are squash merged, so no need to rebase or force push.
 

--- a/docs/app/components/chat/Chat.vue
+++ b/docs/app/components/chat/Chat.vue
@@ -11,6 +11,7 @@ const toast = useToast()
 const { track } = useAnalytics()
 const route = useRoute()
 const { open, messages } = useChat()
+const { open: searchOpen } = useContentSearch()
 const { framework } = useFrameworks()
 const { resetTheme, applyThemeSettings, hasCSSChanges, hasConfigChanges } = useTheme()
 
@@ -203,7 +204,12 @@ function clearMessages() {
 defineShortcuts({
   meta_i: {
     handler: () => {
-      open.value = !open.value
+      if (searchOpen.value) {
+        searchOpen.value = false
+        open.value = true
+      } else {
+        open.value = !open.value
+      }
     },
     usingInput: true
   }

--- a/docs/app/composables/useSearch.ts
+++ b/docs/app/composables/useSearch.ts
@@ -22,7 +22,6 @@ export function useSearch() {
 
   const links = computed(() => [{
     label: 'Ask AI',
-    description: 'Ask the AI assistant powered by our custom MCP server for help.',
     icon: 'i-lucide-bot-message-square',
     kbds: ['meta', 'i'],
     ui: {

--- a/src/runtime/composables/useContentSearch.ts
+++ b/src/runtime/composables/useContentSearch.ts
@@ -21,7 +21,7 @@ function _useContentSearch() {
     // top-level section title isn't repeated in the prefix — only the
     // intermediate ancestors between section and leaf are.
     const prefix = [...new Set([...ancestors.map(a => a.title), ...file.titles].filter(Boolean))]
-    const ancestorIcon = [...ancestors].reverse().find(a => a.icon)?.icon
+    const ancestorIcon = ancestors.findLast(a => a.icon)?.icon
 
     return {
       prefix: prefix?.length ? (prefix.join(' > ') + ' >') : undefined,
@@ -138,9 +138,7 @@ function _useContentSearch() {
       const prefixParts = [...new Set([...sectionChain.map(s => s.title), ...result.titles].filter(Boolean))]
       const prefix = prefixParts.length ? (prefixParts.join(' > ') + ' >') : undefined
 
-      // Walk ancestors closest-first so a deep result inherits the icon from
-      // its nearest annotated ancestor rather than the top-level section.
-      const ancestorIcon = [...ancestors].reverse().find(a => a.icon)?.icon
+      const ancestorIcon = ancestors.findLast(a => a.icon)?.icon
 
       acc.push({
         label: result.title,

--- a/src/runtime/composables/useContentSearch.ts
+++ b/src/runtime/composables/useContentSearch.ts
@@ -15,16 +15,20 @@ function _useContentSearch() {
   function mapFile(
     file: ContentSearchFile,
     link: ContentNavigationItem,
-    parent?: ContentNavigationItem
+    ancestors: ContentNavigationItem[] = []
   ): ContentSearchItem {
-    const prefix = [...new Set([parent?.title, ...file.titles].filter(Boolean))]
+    // Items here are rendered grouped under their section's label, so the
+    // top-level section title isn't repeated in the prefix — only the
+    // intermediate ancestors between section and leaf are.
+    const prefix = [...new Set([...ancestors.map(a => a.title), ...file.titles].filter(Boolean))]
+    const ancestorIcon = [...ancestors].reverse().find(a => a.icon)?.icon
 
     return {
       prefix: prefix?.length ? (prefix.join(' > ') + ' >') : undefined,
       label: file.id === link.path ? link.title : file.title,
       suffix: file.content.replaceAll('<', '&lt;').replaceAll('>', '&gt;'),
       to: file.id,
-      icon: (link.icon || parent?.icon || (file.level > 1 ? appConfig.ui.icons.hash : appConfig.ui.icons.file)) as string,
+      icon: (link.icon || ancestorIcon || (file.level > 1 ? appConfig.ui.icons.hash : appConfig.ui.icons.file)) as string,
       level: file.level
     }
   }
@@ -53,19 +57,19 @@ function _useContentSearch() {
 
     function visit(
       nodes: ContentNavigationItem[],
-      nodeParent?: ContentNavigationItem
+      ancestors: ContentNavigationItem[]
     ): ContentSearchItem[] {
       return nodes.flatMap((link) => {
         if (link.children?.length) {
-          return visit(link.children, link)
+          return visit(link.children, [...ancestors, link])
         }
 
         const matched = link.path ? filesByPath.get(link.path) : undefined
-        return matched?.map(file => mapFile(file, link, nodeParent)) || []
+        return matched?.map(file => mapFile(file, link, ancestors)) || []
       })
     }
 
-    return visit(children, parent)
+    return visit(children, parent ? [parent] : [])
   }
 
   /**
@@ -88,14 +92,15 @@ function _useContentSearch() {
   }
 
   /**
-   * Find a navigation item by path
+   * Find a navigation item by path, returning the full ancestor chain
+   * (root → ... → immediate parent) so callers can render the complete
+   * breadcrumb prefix instead of just the top-level section + parent.
    */
-  function findNavItem(path: string, nodes?: ContentNavigationItem[], root?: ContentNavigationItem, parent?: ContentNavigationItem): { link?: ContentNavigationItem, parent?: ContentNavigationItem, root?: ContentNavigationItem } {
+  function findNavItem(path: string, nodes?: ContentNavigationItem[], ancestors: ContentNavigationItem[] = []): { link?: ContentNavigationItem, ancestors?: ContentNavigationItem[] } {
     for (const node of nodes || []) {
-      const currentRoot = root || node
-      if (node.path === path) return { link: node, parent, root: currentRoot }
+      if (node.path === path) return { link: node, ancestors }
       if (node.children?.length) {
-        const found = findNavItem(path, node.children, currentRoot, node)
+        const found = findNavItem(path, node.children, [...ancestors, node])
         if (found.link) return found
       }
     }
@@ -120,17 +125,22 @@ function _useContentSearch() {
         nav = findNavItem(basePath, navigation)
         navCache.set(basePath, nav)
       }
-      const { link, parent, root } = nav
+      const { link, ancestors = [] } = nav
 
       if (navigation?.length && !link) return acc
 
-      // Include `root?.title` so index pages still show their section name in the
-      // prefix. `findNavItem` returns the section root when a result's path matches
-      // a top-level node directly (e.g. `/docs/typography` from `1.index.md`), which
-      // leaves `parent` undefined and would otherwise drop the section context.
-      // For sub-pages, `root.title === parent.title`, and the `Set` dedupes it.
-      const prefixParts = [...new Set([root?.title, parent?.title, ...result.titles].filter(Boolean))]
+      // Build the prefix from every ancestor title (root → immediate parent) so
+      // deep results keep their full section context. When the matched link is
+      // itself a top-level section (e.g. `/docs` from `1.index.md`), there are
+      // no ancestors above it — fall back to the link so its title still
+      // appears in the prefix.
+      const sectionChain = ancestors.length ? ancestors : (link ? [link] : [])
+      const prefixParts = [...new Set([...sectionChain.map(s => s.title), ...result.titles].filter(Boolean))]
       const prefix = prefixParts.length ? (prefixParts.join(' > ') + ' >') : undefined
+
+      // Walk ancestors closest-first so a deep result inherits the icon from
+      // its nearest annotated ancestor rather than the top-level section.
+      const ancestorIcon = [...ancestors].reverse().find(a => a.icon)?.icon
 
       acc.push({
         label: result.title,
@@ -139,7 +149,7 @@ function _useContentSearch() {
         description: result.content.replaceAll('<', '&lt;').replaceAll('>', '&gt;'),
         descriptionHtml: result.snippets?.content ? sanitizeSnippet(result.snippets.content) : undefined,
         to: result.id,
-        icon: (link?.icon || parent?.icon || root?.icon || (result.level > 1 ? appConfig.ui.icons.hash : appConfig.ui.icons.file)) as string,
+        icon: (link?.icon || ancestorIcon || (result.level > 1 ? appConfig.ui.icons.hash : appConfig.ui.icons.file)) as string,
         level: result.level
       })
 

--- a/src/runtime/composables/useContentSearch.ts
+++ b/src/runtime/composables/useContentSearch.ts
@@ -17,9 +17,7 @@ function _useContentSearch() {
     link: ContentNavigationItem,
     ancestors: ContentNavigationItem[] = []
   ): ContentSearchItem {
-    // Items here are rendered grouped under their section's label, so the
-    // top-level section title isn't repeated in the prefix — only the
-    // intermediate ancestors between section and leaf are.
+    // Top-level section title is omitted — items render under their section's group label.
     const prefix = [...new Set([...ancestors.map(a => a.title), ...file.titles].filter(Boolean))]
     const ancestorIcon = ancestors.findLast(a => a.icon)?.icon
 
@@ -92,9 +90,7 @@ function _useContentSearch() {
   }
 
   /**
-   * Find a navigation item by path, returning the full ancestor chain
-   * (root → ... → immediate parent) so callers can render the complete
-   * breadcrumb prefix instead of just the top-level section + parent.
+   * Find a navigation item by path, returning the full ancestor chain (root → parent).
    */
   function findNavItem(path: string, nodes?: ContentNavigationItem[], ancestors: ContentNavigationItem[] = []): { link?: ContentNavigationItem, ancestors?: ContentNavigationItem[] } {
     for (const node of nodes || []) {
@@ -129,11 +125,9 @@ function _useContentSearch() {
 
       if (navigation?.length && !link) return acc
 
-      // Build the prefix from every ancestor title (root → immediate parent) so
-      // deep results keep their full section context. When the matched link is
-      // itself a top-level section (e.g. `/docs` from `1.index.md`), there are
-      // no ancestors above it — fall back to the link so its title still
-      // appears in the prefix.
+      // Fall back to the matched link when ancestors is empty so top-level
+      // index-page results still show their section title (results are flat
+      // here — no group label like `mapFile`).
       const sectionChain = ancestors.length ? ancestors : (link ? [link] : [])
       const prefixParts = [...new Set([...sectionChain.map(s => s.title), ...result.titles].filter(Boolean))]
       const prefix = prefixParts.length ? (prefixParts.join(' > ') + ' >') : undefined

--- a/test/components/content/ContentSearch.spec.ts
+++ b/test/components/content/ContentSearch.spec.ts
@@ -202,5 +202,53 @@ describe('ContentSearch', () => {
 
       wrapper.unmount()
     })
+
+    // Regression test: results more than two nav levels deep used to drop
+    // every intermediate ancestor because `findNavItem` only tracked the
+    // top-level root and the immediate parent.
+    it('includes every intermediate ancestor in the prefix for deeply nested results', async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true })
+      const deepNavigation = [{
+        title: 'Docs',
+        path: '/docs',
+        children: [{
+          title: 'Guide',
+          path: '/docs/guide',
+          children: [{
+            title: 'Best Practices',
+            path: '/docs/guide/best-practices',
+            children: [{
+              title: 'Nuxt Plugins',
+              path: '/docs/guide/best-practices/plugins'
+            }]
+          }]
+        }]
+      }]
+      const search = vi.fn(async () => [{
+        id: '/docs/guide/best-practices/plugins',
+        title: 'Nuxt Plugins',
+        titles: [],
+        level: 1,
+        content: 'lorem ipsum'
+      }])
+
+      const wrapper = await mountSuspended(ContentSearch, {
+        props: {
+          open: true,
+          portal: false,
+          navigation: deepNavigation,
+          search,
+          searchTerm: ''
+        }
+      })
+
+      await wrapper.setProps({ searchTerm: 'lorem' })
+      await vi.advanceTimersByTimeAsync(150)
+      await wrapper.vm.$nextTick()
+
+      expect(wrapper.text()).toContain('Docs > Guide > Best Practices >')
+
+      wrapper.unmount()
+    })
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- Internal report (PR #6432 follow-up) -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`findNavItem` only tracked the top-level `root` and the immediate `parent`, so any search result more than two nav levels deep silently dropped every ancestor in between. Searching `nuxt plugins` on nuxt.com rendered `Docs > Best Practices > Nuxt Plugins` instead of `Docs > Guide > Best Practices > Nuxt Plugins`.

- Thread the full ancestor chain through both code paths: the async search results (`mapSearchResults` / `findNavItem`) and the static nav-walking path (`mapNavigationItems` / `mapFile`). For top-level matches (e.g. index pages), `mapSearchResults` falls back to the matched link so the section title still appears in flat results — `mapFile` doesn't, because those items render under their section's group label.
- Icon fallback now walks ancestors closest-first so deep results inherit the nearest annotated section icon instead of always defaulting to the root.
- Drive-by chore: close the content search modal when the user triggers the `⌘I` chat shortcut, and drop a redundant "Ask AI" link description.

**Verification**

- `pnpm vitest run test/components/content/ContentSearch.spec.ts` — all 17 tests pass, including the regression test at [test/components/content/ContentSearch.spec.ts:177](../blob/v4/test/components/content/ContentSearch.spec.ts#L177) for index-page prefixes.
- Manual repro target: this repo's docs have one 4-level path (`Getting Started > Integrations > i18n > Nuxt`) that should now render with all four segments.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.