### PR TITLE
feat(Sidebar): add `transition` prop

### DIFF
--- a/src/runtime/components/Sidebar.vue
+++ b/src/runtime/components/Sidebar.vue
@@ -63,6 +63,11 @@ export interface SidebarProps<T extends SidebarMode = SidebarMode> {
    */
   rail?: boolean
   /**
+   * Animate the sidebar when collapsing or expanding.
+   * @defaultValue true
+   */
+  transition?: boolean
+  /**
    * The mode of the sidebar menu on mobile.
    * @defaultValue 'slideover'
    */
@@ -110,6 +115,7 @@ const _props = withDefaults(defineProps<SidebarProps<T>>(), {
   collapsible: 'offcanvas',
   side: 'left',
   close: false,
+  transition: true,
   rail: false,
   mode: 'slideover' as never
 })
@@ -189,7 +195,8 @@ const hasHeader = computed(() => !!slots.header || props.title || !!slots.title 
 const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.sidebar || {}) })({
   side: props.side,
   variant: props.variant,
-  collapsible: props.collapsible
+  collapsible: props.collapsible,
+  transition: props.transition
 }))
 
 const Menu = computed(() => ({

--- a/src/theme/sidebar.ts
+++ b/src/theme/sidebar.ts
@@ -3,8 +3,8 @@ import type { ModuleOptions } from '../module'
 export default (options: Required<ModuleOptions>) => ({
   slots: {
     root: 'peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem]',
-    gap: 'relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear',
-    container: 'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex',
+    gap: 'relative w-(--sidebar-width) bg-transparent',
+    container: 'fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex',
     inner: 'flex size-full flex-col overflow-hidden divide-y divide-default',
     header: 'flex items-center gap-1.5 overflow-hidden px-4 min-h-(--ui-header-height)',
     wrapper: 'min-w-0 flex-1',
@@ -14,9 +14,16 @@ export default (options: Required<ModuleOptions>) => ({
     close: '',
     body: 'flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4',
     footer: 'flex items-center gap-1.5 overflow-hidden p-4',
-    rail: ['absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-px lg:flex hover:after:bg-(--ui-border-accented)', options.theme.transitions && 'after:transition-colors']
+    rail: ['absolute inset-y-0 z-20 hidden w-4 after:absolute after:inset-y-0 after:left-1/2 after:w-px lg:flex hover:after:bg-(--ui-border-accented)', options.theme.transitions && 'after:transition-colors']
   },
   variants: {
+    transition: {
+      true: {
+        gap: 'transition-[width] duration-200 ease-out',
+        container: 'transition-[left,right,width] duration-200 ease-out',
+        rail: 'transition-all ease-out'
+      }
+    },
     side: {
       left: {
         container: 'left-0 border-e border-default',

--- a/test/components/__snapshots__/Sidebar-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Sidebar-vue.spec.ts.snap
@@ -5,8 +5,8 @@ exports[`Sidebar > renders with actions slot correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <div data-slot="header" class="flex items-center gap-1.5 overflow-hidden px-4 min-h-(--ui-header-height)">
         <!--v-if-->
@@ -29,8 +29,8 @@ exports[`Sidebar > renders with class correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block bg-elevated/50">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -48,8 +48,8 @@ exports[`Sidebar > renders with close correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <div data-slot="header" class="flex items-center gap-1.5 overflow-hidden px-4 min-h-(--ui-header-height)">
         <div data-slot="wrapper" class="min-w-0 flex-1">
@@ -76,8 +76,8 @@ exports[`Sidebar > renders with collapsed icon correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="collapsed" data-collapsible="icon" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="collapsed" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="collapsed" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
+  <div data-slot="gap" data-state="collapsed" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="collapsed" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 group-data-[state=collapsed]/sidebar:overflow-hidden"></div>
@@ -95,8 +95,8 @@ exports[`Sidebar > renders with collapsed offcanvas correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="collapsed" data-collapsible="offcanvas" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="collapsed" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="collapsed" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="collapsed" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="collapsed" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -114,8 +114,8 @@ exports[`Sidebar > renders with collapsible icon correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 group-data-[state=collapsed]/sidebar:overflow-hidden"></div>
@@ -144,8 +144,8 @@ exports[`Sidebar > renders with collapsible offcanvas correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -163,8 +163,8 @@ exports[`Sidebar > renders with content slot correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -182,8 +182,8 @@ exports[`Sidebar > renders with default slot correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">Default slot</div>
@@ -201,8 +201,8 @@ exports[`Sidebar > renders with description correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <div data-slot="header" class="flex items-center gap-1.5 overflow-hidden px-4 min-h-(--ui-header-height)">
         <div data-slot="wrapper" class="min-w-0 flex-1">
@@ -226,8 +226,8 @@ exports[`Sidebar > renders with footer slot correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -245,8 +245,8 @@ exports[`Sidebar > renders with header slot correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <div data-slot="header" class="flex items-center gap-1.5 overflow-hidden px-4 min-h-(--ui-header-height)">Header slot</div>
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -264,8 +264,8 @@ exports[`Sidebar > renders with mode drawer correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -283,8 +283,8 @@ exports[`Sidebar > renders with mode modal correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -302,8 +302,8 @@ exports[`Sidebar > renders with mode slideover correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -321,13 +321,13 @@ exports[`Sidebar > renders with rail correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 group-data-[state=collapsed]/sidebar:overflow-hidden"></div>
       <!--v-if-->
-    </div><button data-slot="rail" data-state="expanded" aria-label="Toggle" tabindex="-1" class="absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-px lg:flex hover:after:bg-(--ui-border-accented) after:transition-colors end-0 translate-x-1/2 cursor-w-resize data-[state=collapsed]:cursor-e-resize"></button>
+    </div><button data-slot="rail" data-state="expanded" aria-label="Toggle" tabindex="-1" class="absolute inset-y-0 z-20 hidden w-4 after:absolute after:inset-y-0 after:left-1/2 after:w-px lg:flex hover:after:bg-(--ui-border-accented) after:transition-colors transition-all ease-out end-0 translate-x-1/2 cursor-w-resize data-[state=collapsed]:cursor-e-resize"></button>
   </div>
 </aside>
 <!-- Mobile menu -->
@@ -339,8 +339,8 @@ exports[`Sidebar > renders with side left correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -358,8 +358,8 @@ exports[`Sidebar > renders with side right correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="right" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex right-0 border-s border-default data-[state=collapsed]:-right-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out right-0 border-s border-default data-[state=collapsed]:-right-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -377,8 +377,8 @@ exports[`Sidebar > renders with title correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <div data-slot="header" class="flex items-center gap-1.5 overflow-hidden px-4 min-h-(--ui-header-height)">
         <div data-slot="wrapper" class="min-w-0 flex-1">
@@ -402,8 +402,8 @@ exports[`Sidebar > renders with ui correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 py-0"></div>
@@ -421,8 +421,8 @@ exports[`Sidebar > renders with variant floating correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="floating" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e p-4 border-transparent data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e p-4 border-transparent data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default rounded-lg ring ring-default shadow-lg">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -440,8 +440,8 @@ exports[`Sidebar > renders with variant inset correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="inset" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e py-4 border-transparent data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e py-4 border-transparent data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-transparent">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -459,8 +459,8 @@ exports[`Sidebar > renders with variant sidebar correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>

--- a/test/components/__snapshots__/Sidebar.spec.ts.snap
+++ b/test/components/__snapshots__/Sidebar.spec.ts.snap
@@ -5,8 +5,8 @@ exports[`Sidebar > renders with actions slot correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <div data-slot="header" class="flex items-center gap-1.5 overflow-hidden px-4 min-h-(--ui-header-height)">
         <!--v-if-->
@@ -29,8 +29,8 @@ exports[`Sidebar > renders with class correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block bg-elevated/50">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -48,8 +48,8 @@ exports[`Sidebar > renders with close correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <div data-slot="header" class="flex items-center gap-1.5 overflow-hidden px-4 min-h-(--ui-header-height)">
         <div data-slot="wrapper" class="min-w-0 flex-1">
@@ -76,8 +76,8 @@ exports[`Sidebar > renders with collapsed icon correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="collapsed" data-collapsible="icon" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="collapsed" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="collapsed" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
+  <div data-slot="gap" data-state="collapsed" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="collapsed" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 group-data-[state=collapsed]/sidebar:overflow-hidden"></div>
@@ -95,8 +95,8 @@ exports[`Sidebar > renders with collapsed offcanvas correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="collapsed" data-collapsible="offcanvas" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="collapsed" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="collapsed" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="collapsed" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="collapsed" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -114,8 +114,8 @@ exports[`Sidebar > renders with collapsible icon correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 group-data-[state=collapsed]/sidebar:overflow-hidden"></div>
@@ -144,8 +144,8 @@ exports[`Sidebar > renders with collapsible offcanvas correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -163,8 +163,8 @@ exports[`Sidebar > renders with content slot correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -182,8 +182,8 @@ exports[`Sidebar > renders with default slot correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4">Default slot</div>
@@ -201,8 +201,8 @@ exports[`Sidebar > renders with description correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <div data-slot="header" class="flex items-center gap-1.5 overflow-hidden px-4 min-h-(--ui-header-height)">
         <div data-slot="wrapper" class="min-w-0 flex-1">
@@ -226,8 +226,8 @@ exports[`Sidebar > renders with footer slot correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -245,8 +245,8 @@ exports[`Sidebar > renders with header slot correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <div data-slot="header" class="flex items-center gap-1.5 overflow-hidden px-4 min-h-(--ui-header-height)">Header slot</div>
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -264,8 +264,8 @@ exports[`Sidebar > renders with mode drawer correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -283,8 +283,8 @@ exports[`Sidebar > renders with mode modal correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -302,8 +302,8 @@ exports[`Sidebar > renders with mode slideover correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -321,13 +321,13 @@ exports[`Sidebar > renders with rail correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-(--sidebar-width-icon)"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:w-(--sidebar-width-icon)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 group-data-[state=collapsed]/sidebar:overflow-hidden"></div>
       <!--v-if-->
-    </div><button data-slot="rail" data-state="expanded" aria-label="Toggle" tabindex="-1" class="absolute inset-y-0 z-20 hidden w-4 transition-all ease-linear after:absolute after:inset-y-0 after:left-1/2 after:w-px lg:flex hover:after:bg-(--ui-border-accented) after:transition-colors end-0 translate-x-1/2 cursor-w-resize data-[state=collapsed]:cursor-e-resize"></button>
+    </div><button data-slot="rail" data-state="expanded" aria-label="Toggle" tabindex="-1" class="absolute inset-y-0 z-20 hidden w-4 after:absolute after:inset-y-0 after:left-1/2 after:w-px lg:flex hover:after:bg-(--ui-border-accented) after:transition-colors transition-all ease-out end-0 translate-x-1/2 cursor-w-resize data-[state=collapsed]:cursor-e-resize"></button>
   </div>
 </aside>
 <!-- Mobile menu -->
@@ -339,8 +339,8 @@ exports[`Sidebar > renders with side left correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -358,8 +358,8 @@ exports[`Sidebar > renders with side right correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="right" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex right-0 border-s border-default data-[state=collapsed]:-right-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out right-0 border-s border-default data-[state=collapsed]:-right-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -377,8 +377,8 @@ exports[`Sidebar > renders with title correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <div data-slot="header" class="flex items-center gap-1.5 overflow-hidden px-4 min-h-(--ui-header-height)">
         <div data-slot="wrapper" class="min-w-0 flex-1">
@@ -402,8 +402,8 @@ exports[`Sidebar > renders with ui correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4 py-0"></div>
@@ -421,8 +421,8 @@ exports[`Sidebar > renders with variant floating correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="floating" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e p-4 border-transparent data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e p-4 border-transparent data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default rounded-lg ring ring-default shadow-lg">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -440,8 +440,8 @@ exports[`Sidebar > renders with variant inset correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="inset" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e py-4 border-transparent data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e py-4 border-transparent data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-transparent">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>
@@ -459,8 +459,8 @@ exports[`Sidebar > renders with variant sidebar correctly 1`] = `
 <!-- Collapsible: fixed sidebar with gap spacer + mobile menu -->
 <aside data-slot="root" data-state="expanded" data-variant="sidebar" data-side="left" class="peer [--sidebar-width:16rem] [--sidebar-width-icon:4rem] group/sidebar hidden lg:block">
   <!-- Gap spacer: reserves layout space for the fixed sidebar -->
-  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-linear data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
-  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) transition-[left,right,width] duration-200 ease-linear lg:flex left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
+  <div data-slot="gap" data-state="expanded" class="relative w-(--sidebar-width) bg-transparent transition-[width] duration-200 ease-out data-[state=collapsed]:w-0"></div><!-- Fixed container: the actual visible sidebar -->
+  <div data-slot="container" data-state="expanded" class="fixed inset-y-0 z-10 hidden h-svh w-(--sidebar-width) lg:flex transition-[left,right,width] duration-200 ease-out left-0 border-e border-default data-[state=collapsed]:-left-(--sidebar-width)">
     <div data-slot="inner" class="flex size-full flex-col overflow-hidden divide-y divide-default">
       <!--v-if-->
       <div data-slot="body" class="flex min-h-0 flex-1 flex-col gap-4 overflow-y-auto p-4"></div>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- N/A -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add a `transition` prop to `USidebar` (defaults to `true`) thate collapse/expand animation. Follows the same pattern as `UModal`'s `transition` prop.

- Move transition classes from base theme slots into a `transition: true` variant
- Switch easing from `ease-linear` to `ease-out` for a more natural feel

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.