### PR TITLE
feat(FileUpload): expose `removeFile` in slots

### DIFF
--- a/src/runtime/components/FileUpload.vue
+++ b/src/runtime/components/FileUpload.vue
@@ -125,14 +125,14 @@ export interface FileUploadSlots<M extends boolean = false> {
   'label'?(props?: {}): VNode[]
   'description'?(props?: {}): VNode[]
   'actions'?(props: { files: FileUploadFiles<M> | undefined, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): VNode[]
-  'files'?(props: { files: FileUploadFiles<M> }): VNode[]
+  'files'?(props: { files: FileUploadFiles<M>, removeFile: (index?: number) => void }): VNode[]
   'files-top'?(props: { files: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): VNode[]
   'files-bottom'?(props: { files: FileUploadFiles<M>, open: UseFileDialogReturn['open'], removeFile: (index?: number) => void }): VNode[]
-  'file'?(props: { file: File, index: number }): VNode[]
+  'file'?(props: { file: File, index: number, removeFile: (index?: number) => void }): VNode[]
   'file-leading'?(props: { file: File, index: number, ui: FileUpload['ui'] }): VNode[]
   'file-name'?(props: { file: File, index: number }): VNode[]
   'file-size'?(props: { file: File, index: number }): VNode[]
-  'file-trailing'?(props: { file: File, index: number, ui: FileUpload['ui'] }): VNode[]
+  'file-trailing'?(props: { file: File, index: number, ui: FileUpload['ui'], removeFile: (index?: number) => void }): VNode[]
 }
 </script>
 
@@ -297,9 +297,9 @@ defineExpose({
       <slot name="files-top" :files="modelValue" :open="open" :remove-file="removeFile" />
 
       <div data-slot="files" :class="ui.files({ class: props.ui?.files })">
-        <slot name="files" :files="modelValue">
+        <slot name="files" :files="modelValue" :remove-file="removeFile">
           <div v-for="(file, index) in Array.isArray(modelValue) ? modelValue : [modelValue]" :key="(file as File).name" data-slot="file" :class="ui.file({ class: props.ui?.file })">
-            <slot name="file" :file="file" :index="index">
+            <slot name="file" :file="file" :index="index" :remove-file="removeFile">
               <slot name="file-leading" :file="file" :index="index" :ui="ui">
                 <UAvatar
                   :as="{ img: 'img' }"
@@ -325,7 +325,7 @@ defineExpose({
                 </span>
               </div>
 
-              <slot name="file-trailing" :file="file" :index="index" :ui="ui">
+              <slot name="file-trailing" :file="file" :index="index" :ui="ui" :remove-file="removeFile">
                 <UButton
                   v-if="props.fileDelete"
                   color="neutral"


### PR DESCRIPTION
Resolves #6491

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `file` and `file-trailing` slots in `UFileUpload` did not expose the `removeFile` function, making it impossible to trigger file removal from within a custom slot template.

This change passes `removeFile` as a slot prop to both `file` and `file-trailing`, consistent with how `files-top` and `files-bottom` already expose it. Users can now do:

```vue
<UFileUpload multiple>
  <template #file="{ file, index, removeFile }">
    <div class="w-full">{{ file.name }}</div>
    <button @click="removeFile(index)">Remove</button>
  </template>
</UFileUpload>
```

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
