### PR TITLE
fix(Icon): avoid recursive icon resolution

### DIFF
--- a/src/runtime/components/Icon.vue
+++ b/src/runtime/components/Icon.vue
@@ -12,6 +12,7 @@ export interface IconProps {
 <script setup lang="ts">
 import { useForwardProps } from 'reka-ui'
 import { reactivePick } from '@vueuse/core'
+import NuxtIcon from '@nuxt/icon/runtime/components/index.js'
 
 const props = defineProps<IconProps>()
 
@@ -19,6 +20,6 @@ const iconProps = useForwardProps(reactivePick(props, 'mode', 'size', 'customize
 </script>
 
 <template>
-  <Icon v-if="typeof name === 'string'" :name="name" v-bind="iconProps" />
+  <NuxtIcon v-if="typeof name === 'string'" :name="name" v-bind="iconProps" />
   <component :is="name" v-else />
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6480

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This makes `Icon.vue` render the Nuxt Icon runtime component through an explicit local import instead of relying on a global `<Icon>` lookup.

That avoids resolving back to Nuxt UI's own `Icon` component when the UI prefix is configured as an empty string, while keeping the existing forwarded icon props and dynamic component fallback unchanged.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

Validation:

- `node node_modules\eslint\bin\eslint.js src/runtime/components/Icon.vue`