### PR TITLE
fix(ContentSearch): group FTS results by collection

### DIFF
--- a/src/runtime/components/content/ContentSearch.vue
+++ b/src/runtime/components/content/ContentSearch.vue
@@ -244,9 +244,10 @@ const searchGroups = computed(() => {
     const groups = []
     for (const collection of collections) {
       const items = searchResults.value.filter(item => item.collection === collection)
+      const navSection = props.navigation?.find(link => link.path === `/${collection}`)
       groups.push({
         id: `search-${collection}`,
-        label: collection.charAt(0).toUpperCase() + collection.slice(1),
+        label: navSection?.title || collection.charAt(0).toUpperCase() + collection.slice(1),
         items,
         ignoreFilter: true
       })

--- a/src/runtime/components/content/ContentSearch.vue
+++ b/src/runtime/components/content/ContentSearch.vue
@@ -29,6 +29,7 @@ export interface ContentSearchFile {
 }
 
 export interface ContentSearchResult extends ContentSearchFile {
+  collection?: string
   snippets?: {
     title?: string
     content?: string
@@ -48,6 +49,7 @@ export type ContentSearchStatus = 'idle' | 'loading' | 'ready' | 'error'
 export type ContentSearchFn = (query: string, opts?: ContentSearchOptions) => Promise<ContentSearchResult[]>
 
 export interface ContentSearchItem extends Omit<LinkProps, 'custom'>, CommandPaletteItem {
+  collection?: string
   level?: number
   /**
    * @IconifyIcon
@@ -235,6 +237,22 @@ const linksGroup = computed(() => {
 
 const searchGroups = computed(() => {
   if (!searchTerm.value || !searchResults.value.length) return []
+
+  const collections = new Set(searchResults.value.map(item => item.collection).filter((c): c is string => !!c))
+
+  if (collections.size) {
+    const groups = []
+    for (const collection of collections) {
+      const items = searchResults.value.filter(item => item.collection === collection)
+      groups.push({
+        id: `search-${collection}`,
+        label: collection.charAt(0).toUpperCase() + collection.slice(1),
+        items,
+        ignoreFilter: true
+      })
+    }
+    return groups
+  }
 
   return [{ id: 'search', label: t('contentSearch.search'), items: searchResults.value, ignoreFilter: true }]
 })

--- a/src/runtime/composables/useContentSearch.ts
+++ b/src/runtime/composables/useContentSearch.ts
@@ -135,6 +135,7 @@ function _useContentSearch() {
       const ancestorIcon = ancestors.findLast(a => a.icon)?.icon
 
       acc.push({
+        collection: result.collection,
         label: result.title,
         labelHtml: result.snippets?.title ? sanitizeSnippet(result.snippets.title) : undefined,
         prefix,


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When search results include a `collection` field (e.g. from `useSearchCollection(['docs', 'blog'])`), `searchGroups` now splits them into sepaof a single flat "Search" group. Each group is labeled with the capitalized collection name (e.g. `docs` → `Docs`).

Falls back to the existing single "Search" group when results have no `collection` field (backward-compatible).

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.