### PR TITLE
fix(InputDate): trigger form validation on external model value changes

### DIFF
--- a/src/runtime/components/InputDate.vue
+++ b/src/runtime/components/InputDate.vue
@@ -131,9 +131,6 @@ function onUpdate(value: any) {
   // @ts-expect-error - 'target' does not exist in type 'EventInit'
   const event = new Event('change', { target: { value } })
   emits('change', event)
-
-  emitFormChange()
-  emitFormInput()
 }
 
 watch(() => props.modelValue, () => {

--- a/src/runtime/components/InputDate.vue
+++ b/src/runtime/components/InputDate.vue
@@ -69,7 +69,7 @@ export interface InputDateSlots {
 </script>
 
 <script setup lang="ts" generic="R extends boolean">
-import { computed, onMounted, ref } from 'vue'
+import { computed, onMounted, ref, watch } from 'vue'
 import { } from 'reka-ui'
 import { useForwardProps } from '../composables/useForwardProps'
 import { DateField as SingleDateField, DateRangeField as RangeDateField } from 'reka-ui/namespaced'
@@ -135,6 +135,11 @@ function onUpdate(value: any) {
   emitFormChange()
   emitFormInput()
 }
+
+watch(() => props.modelValue, () => {
+  emitFormChange()
+  emitFormInput()
+})
 
 function onBlur(event: FocusEvent) {
   emitFormBlur()


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #5920

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When the `modelValue` of `InputDate` is updated externally (e.g. via a `UCalendar` in the trailing slot), Reka UI's `DateField.Root` reflects the new value but does not emit `update:model-value` — that only fires for internal segment edits. This means `emitFormChange` / `emitFormInput` are never called, and form validation never runs.

Added a `watch` on `props.modelValue` that emits form change and input events for external updates. The `onUpdate` handler (from Reka's `@update:model-value`) and the watcher cover two distinct paths — segment edits vs prop-driven changes — so they don't conflict.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.