### PR TITLE
fix(locale): improve Thai translation accuracy and consistency

### DIFF
--- a/src/runtime/locale/th.ts
+++ b/src/runtime/locale/th.ts
@@ -110,7 +110,7 @@ export default defineLocale<Messages>({
       close: 'ปิด'
     },
     pricingTable: {
-      caption: 'การเปรียบเทียบราคาสินค้า'
+      caption: 'การเปรียบเทียบราคา'
     },
     prose: {
       codeCollapse: {

--- a/src/runtime/locale/th.ts
+++ b/src/runtime/locale/th.ts
@@ -34,11 +34,6 @@ export default defineLocale<Messages>({
     chatPromptSubmit: {
       label: 'ส่ง'
     },
-    chatReasoning: {
-      thinking: 'กำลังคิด…',
-      thought: 'คิดแล้ว',
-      thoughtFor: 'คิดเป็นเวลา {duration}'
-    },
     colorMode: {
       dark: 'มืด',
       light: 'สว่าง',
@@ -130,6 +125,11 @@ export default defineLocale<Messages>({
         copy: 'คัดลอกพรอมต์',
         openIn: 'เปิดใน {name}'
       }
+    },
+    chatReasoning: {
+      thinking: 'กำลังคิด…',
+      thought: 'คิดแล้ว',
+      thoughtFor: 'คิดเป็นเวลา {duration}'
     },
     sidebar: {
       close: 'ปิด',


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue — this is a minor translation improvement PR.

### ❓ Type of change

- [x] 👌 Enhancement (improving an existing functionality)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

This PR improves the Thai locale file with two focused changes:

**1. Fixed pricingTable caption translation**

Changed `การเปรียบเทียบราคาสินค้า` (product price comparison) to `การเปรียบเทียบราคา` (price comparison).

**Why:** The previous translation was too specific to physical goods (`สินค้า` = products/merchandise), while the PricingTable component is typically used for SaaS pricing tiers and plans. The new translation is more generic and works across all contexts — whether comparing software plans, services, or physical products. This better aligns with the English source text "Pricing plan comparison" which doesn't specify goods.

**2. Reordered chatReasoning keys to match English source**

Moved the `chatReasoning` block from between `chatPromptSubmit` and `colorMode` to between `prose` and `sidebar`, matching the key order in `en.ts`.

**Why:** Consistent key ordering across locale files makes it easier for contributors to compare translations against the English source. When keys are in the same order, maintainers can scroll both files side-by-side and quickly spot missing or mismatched entries without hunting for keys across the file.

### 📝 Checklist

- [x] I have read the contribution guidelines.
- [x] The changes are minimal and focused on translation quality.
- [x] No breaking changes introduced.