### PR TITLE
fix(Form): add `method="post"` to prevent credential leaking via GET before hydration

### DIFF
--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -462,6 +462,7 @@ defineExpose(api)
     :is="parentBus ? 'div' : 'form'"
     :id="formId"
     ref="formRef"
+    method="post"
     :class="ui({ class: [props.ui?.base, props.class] })"
     @submit.prevent="onSubmitWrapper"
   >

--- a/test/components/__snapshots__/AuthForm-vue.spec.ts.snap
+++ b/test/components/__snapshots__/AuthForm-vue.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`AuthForm > renders with as correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -52,7 +52,7 @@ exports[`AuthForm > renders with class correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -102,7 +102,7 @@ exports[`AuthForm > renders with description correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -152,7 +152,7 @@ exports[`AuthForm > renders with description slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -198,7 +198,7 @@ exports[`AuthForm > renders with disabled correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -244,7 +244,7 @@ exports[`AuthForm > renders with fields correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -290,7 +290,7 @@ exports[`AuthForm > renders with footer slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -336,7 +336,7 @@ exports[`AuthForm > renders with header slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -386,7 +386,7 @@ exports[`AuthForm > renders with icon correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -436,7 +436,7 @@ exports[`AuthForm > renders with leading slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -482,7 +482,7 @@ exports[`AuthForm > renders with loading correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -536,7 +536,7 @@ exports[`AuthForm > renders with providers correctly 1`] = `
       <div data-slot="border" class="border-default w-full border-solid border-t"></div>
       <!--v-if-->
     </div>
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -582,7 +582,7 @@ exports[`AuthForm > renders with providers slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <div data-slot="providers" class="space-y-3">Providers</div>
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -628,7 +628,7 @@ exports[`AuthForm > renders with separator correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -674,7 +674,7 @@ exports[`AuthForm > renders with submit correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -720,7 +720,7 @@ exports[`AuthForm > renders with submit slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -767,7 +767,7 @@ exports[`AuthForm > renders with title correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -817,7 +817,7 @@ exports[`AuthForm > renders with title slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -863,7 +863,7 @@ exports[`AuthForm > renders with ui correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -909,7 +909,7 @@ exports[`AuthForm > renders with validation slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0" class="space-y-5" data-slot="form">
+    <form id="v-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-1" data-slot="label" class="block font-medium text-default">Email</label>

--- a/test/components/__snapshots__/AuthForm.spec.ts.snap
+++ b/test/components/__snapshots__/AuthForm.spec.ts.snap
@@ -6,7 +6,7 @@ exports[`AuthForm > renders with as correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -54,7 +54,7 @@ exports[`AuthForm > renders with class correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -106,7 +106,7 @@ exports[`AuthForm > renders with description correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -158,7 +158,7 @@ exports[`AuthForm > renders with description slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -206,7 +206,7 @@ exports[`AuthForm > renders with disabled correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -254,7 +254,7 @@ exports[`AuthForm > renders with fields correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -302,7 +302,7 @@ exports[`AuthForm > renders with footer slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -350,7 +350,7 @@ exports[`AuthForm > renders with header slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -402,7 +402,7 @@ exports[`AuthForm > renders with icon correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -454,7 +454,7 @@ exports[`AuthForm > renders with leading slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -502,7 +502,7 @@ exports[`AuthForm > renders with loading correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -558,7 +558,7 @@ exports[`AuthForm > renders with providers correctly 1`] = `
       <div data-slot="border" class="border-default w-full border-solid border-t"></div>
       <!--v-if-->
     </div>
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -606,7 +606,7 @@ exports[`AuthForm > renders with providers slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <div data-slot="providers" class="space-y-3">Providers</div>
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -654,7 +654,7 @@ exports[`AuthForm > renders with separator correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -702,7 +702,7 @@ exports[`AuthForm > renders with submit correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -750,7 +750,7 @@ exports[`AuthForm > renders with submit slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -799,7 +799,7 @@ exports[`AuthForm > renders with title correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -851,7 +851,7 @@ exports[`AuthForm > renders with title slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -899,7 +899,7 @@ exports[`AuthForm > renders with ui correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>
@@ -947,7 +947,7 @@ exports[`AuthForm > renders with validation slot correctly 1`] = `
   <div data-slot="body" class="gap-y-6 flex flex-col">
     <!--v-if-->
     <!--v-if-->
-    <form id="v-0-0-0" class="space-y-5" data-slot="form">
+    <form id="v-0-0-0" method="post" class="space-y-5" data-slot="form">
       <div data-orientation="vertical" data-slot="root" class="text-sm">
         <div data-slot="wrapper" class="">
           <div data-slot="labelWrapper" class="flex content-center items-center justify-between gap-1"><label for="v-0-0-1" data-slot="label" class="block font-medium text-default">Email</label>

--- a/test/components/__snapshots__/Form-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Form-vue.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Form > custom validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -32,7 +32,7 @@ exports[`Form > custom validation works > with error 1`] = `
 `;
 
 exports[`Form > custom validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -63,7 +63,7 @@ exports[`Form > custom validation works > without error 1`] = `
 `;
 
 exports[`Form > joi validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -94,7 +94,7 @@ exports[`Form > joi validation works > with error 1`] = `
 `;
 
 exports[`Form > joi validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -124,12 +124,12 @@ exports[`Form > joi validation works > without error 1`] = `
 </form>"
 `;
 
-exports[`Form > renders with default slot correctly 1`] = `"<form id="v-0" class="">Form slot</form>"`;
+exports[`Form > renders with default slot correctly 1`] = `"<form id="v-0" method="post" class="">Form slot</form>"`;
 
-exports[`Form > renders with state correctly 1`] = `"<form id="v-0" class=""></form>"`;
+exports[`Form > renders with state correctly 1`] = `"<form id="v-0" method="post" class=""></form>"`;
 
 exports[`Form > superstruct validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -160,7 +160,7 @@ exports[`Form > superstruct validation works > with error 1`] = `
 `;
 
 exports[`Form > superstruct validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -191,7 +191,7 @@ exports[`Form > superstruct validation works > without error 1`] = `
 `;
 
 exports[`Form > valibot validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -222,7 +222,7 @@ exports[`Form > valibot validation works > with error 1`] = `
 `;
 
 exports[`Form > valibot validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -253,7 +253,7 @@ exports[`Form > valibot validation works > without error 1`] = `
 `;
 
 exports[`Form > yup validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -284,7 +284,7 @@ exports[`Form > yup validation works > with error 1`] = `
 `;
 
 exports[`Form > yup validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -315,7 +315,7 @@ exports[`Form > yup validation works > without error 1`] = `
 `;
 
 exports[`Form > zod validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -346,7 +346,7 @@ exports[`Form > zod validation works > with error 1`] = `
 `;
 
 exports[`Form > zod validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->

--- a/test/components/__snapshots__/Form.spec.ts.snap
+++ b/test/components/__snapshots__/Form.spec.ts.snap
@@ -1,7 +1,7 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`Form > custom validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -32,7 +32,7 @@ exports[`Form > custom validation works > with error 1`] = `
 `;
 
 exports[`Form > custom validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -63,7 +63,7 @@ exports[`Form > custom validation works > without error 1`] = `
 `;
 
 exports[`Form > joi validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -94,7 +94,7 @@ exports[`Form > joi validation works > with error 1`] = `
 `;
 
 exports[`Form > joi validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -124,12 +124,12 @@ exports[`Form > joi validation works > without error 1`] = `
 </form>"
 `;
 
-exports[`Form > renders with default slot correctly 1`] = `"<form id="v-0-0" class="">Form slot</form>"`;
+exports[`Form > renders with default slot correctly 1`] = `"<form id="v-0-0" method="post" class="">Form slot</form>"`;
 
-exports[`Form > renders with state correctly 1`] = `"<form id="v-0-0" class=""></form>"`;
+exports[`Form > renders with state correctly 1`] = `"<form id="v-0-0" method="post" class=""></form>"`;
 
 exports[`Form > superstruct validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -160,7 +160,7 @@ exports[`Form > superstruct validation works > with error 1`] = `
 `;
 
 exports[`Form > superstruct validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -191,7 +191,7 @@ exports[`Form > superstruct validation works > without error 1`] = `
 `;
 
 exports[`Form > valibot validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -222,7 +222,7 @@ exports[`Form > valibot validation works > with error 1`] = `
 `;
 
 exports[`Form > valibot validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -253,7 +253,7 @@ exports[`Form > valibot validation works > without error 1`] = `
 `;
 
 exports[`Form > yup validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -284,7 +284,7 @@ exports[`Form > yup validation works > with error 1`] = `
 `;
 
 exports[`Form > yup validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -315,7 +315,7 @@ exports[`Form > yup validation works > without error 1`] = `
 `;
 
 exports[`Form > zod validation works > with error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->
@@ -346,7 +346,7 @@ exports[`Form > zod validation works > with error 1`] = `
 `;
 
 exports[`Form > zod validation works > without error 1`] = `
-"<form id="42" class="">
+"<form id="42" method="post" class="">
   <div data-orientation="vertical" data-slot="root" class="text-sm" id="emailField">
     <div data-slot="wrapper" class="">
       <!--v-if-->


### PR DESCRIPTION
### 🔗 Linked issue

Resolves GHSA-gj2h-2fpw-fhv9

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`UForm` renders a `<form>` with no `method` attribute, relying on `@submit.prevent` to intercept submission. Since `@submit.prevent` only exists after Vue hydration, submitting the form before hydration (autofill + Enter on a slow network, JS blocked by CSP/CDN failure, etc.) causes the browser to perform a native GET — serializing all fields including passwords into the URL query string.

This adds `method="post"` to the rendered `<form>` element so the pre-hydration fallback submits as POST rather than GET. `@submit.prevent` still intercepts the hydrated case as before. Users can opt back into GET by passing `method="get"` (flows through `$attrs`).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.