### PR TITLE
docs(fix): `MarqueeTestimonials` image size

### DIFF
--- a/docs/app/components/content/examples/marquee/MarqueeTestimonials.vue
+++ b/docs/app/components/content/examples/marquee/MarqueeTestimonials.vue
@@ -26,8 +26,8 @@ const testimonials: { user: UserProps, quote: string }[] = [{
     name: 'Kevin Olson',
     description: 'Founder of Fume.app',
     avatar: {
-      src: 'https://ipx.nuxt.com/f_auto,s_40x40/gh_avatar/acidjazz',
-      srcset: 'https://ipx.nuxt.com/f_auto,s_80x80/gh_avatar/acidjazz 2x',
+      src: 'https://ipx.nuxt.com/f_auto,h_40/gh_avatar/acidjazz',
+      srcset: 'https://ipx.nuxt.com/f_auto,h_80/gh_avatar/acidjazz 2x',
       loading: 'lazy' as const
     }
   },
@@ -37,8 +37,8 @@ const testimonials: { user: UserProps, quote: string }[] = [{
     name: 'Michael Hoffmann',
     description: 'Senior Frontend Developer',
     avatar: {
-      src: 'https://ipx.nuxt.com/f_auto,s_40x40/gh_avatar/mokkapps',
-      srcset: 'https://ipx.nuxt.com/f_auto,s_80x80/gh_avatar/mokkapps 2x',
+      src: 'https://ipx.nuxt.com/f_auto,h_40/gh_avatar/mokkapps',
+      srcset: 'https://ipx.nuxt.com/f_auto,h_80/gh_avatar/mokkapps 2x',
       loading: 'lazy' as const
     }
   },
@@ -48,8 +48,8 @@ const testimonials: { user: UserProps, quote: string }[] = [{
     name: 'Harlan Wilton',
     description: 'Nuxt core team member',
     avatar: {
-      src: 'https://ipx.nuxt.com/f_auto,s_40x40/gh_avatar/harlan-zw',
-      srcset: 'https://ipx.nuxt.com/f_auto,s_80x80/gh_avatar/harlan-zw 2x',
+      src: 'https://ipx.nuxt.com/f_auto,h_40/gh_avatar/harlan-zw',
+      srcset: 'https://ipx.nuxt.com/f_auto,h_80/gh_avatar/harlan-zw 2x',
       loading: 'lazy' as const
     }
   },


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

Uses correct image size on marquee profile picture. `s_80x80` does not re-size image.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
