### PR TITLE
docs: fix missing CSS variables on prerendered pages

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -220,6 +220,9 @@ export default defineNuxtConfig({
   compatibilityDate: '2026-01-14',
 
   nitro: {
+    experimental: {
+      asyncContext: true
+    },
     publicAssets: [{
       dir: resolve('../skills'),
       baseURL: '/.well-known/skills',

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -210,7 +210,6 @@ export default defineNuxtConfig({
   },
 
   experimental: {
-    asyncContext: true,
     defaults: {
       nuxtLink: {
         externalRelAttribute: 'noopener'

--- a/src/runtime/plugins/colors.ts
+++ b/src/runtime/plugins/colors.ts
@@ -45,7 +45,7 @@ export default defineNuxtPlugin(() => {
   const headData: UseHeadInput = {
     style: [{
       innerHTML: root,
-      tagPriority: -2,
+      tagPriority: 'critical',
       id: 'nuxt-ui-colors'
     }]
   }


### PR DESCRIPTION
### 🔗 Linked issue
Related to https://github.com/nuxt/nuxt/pull/35011
Reverts https://github.com/nuxt/ui/commit/2dac77803466b79a12a2c806c90a6b48b75a5a63
### ❓ Type of change
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
### 📚 Description
`experimental.asyncContext: true` was added alongside `@nuxtjs/mcp-toolkit` in #5548, but mcp-toolkit only needs `nitro.experimental.asyncContext` (Nitro-level), not the Nuxt/Vue-level flag. the Nuxt-level flag enables ALS for `tryUseNuxtApp()` in Vue SSR, which combined with top-level `await` in `app.vue` and concurrent prerendering, triggers a cross-request `currentInstance` leak (nuxt/nuxt#35011). this causes `useHead` calls from the module's colors plugin to land on the wrong request's head context, resulting in `<style id="nuxt-ui-colors">` being missing from prerendered pages.
also reverts `tagPriority` back to `'critical'` (restoring Harlan's fix for unjs/unhead#693) since the missing style was caused by the context leak, not the priority value.
### 📝 Checklist
- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
