### PR TITLE
fix(module): expose component theme keys in AppConfig type

### DIFF
--- a/src/module.ts
+++ b/src/module.ts
@@ -211,7 +211,7 @@ export default defineNuxtModule<ModuleOptions>({
 
     nuxt.options.alias['#ui'] = resolve('./runtime')
 
-    nuxt.options.appConfig.ui = defu(nuxt.options.appConfig.ui || {}, getDefaultConfig(options.theme))
+    nuxt.options.appConfig.ui = defu(nuxt.options.appConfig.ui || {}, getDefaultConfig(options.theme)) as typeof nuxt.options.appConfig.ui
 
     nuxt.options.build.transpile.push('reka-ui')
 

--- a/src/runtime/types/tv.ts
+++ b/src/runtime/types/tv.ts
@@ -52,11 +52,17 @@ type ComponentAppConfig<
   A extends Record<string, any>,
   K extends string,
   U extends string = 'ui' | 'ui.prose'
-> = A & (
-  U extends 'ui.prose'
-    ? { ui?: { prose?: { [k in K]?: Partial<T> } } }
-    : { [key in Exclude<U, 'ui.prose'>]?: { [k in K]?: Partial<T> } }
-)
+> = Omit<A, 'ui'> & {
+  ui: U extends 'ui.prose'
+    ? (A extends { ui: infer UI } ? Omit<UI, 'prose'> : Record<string, never>) & {
+      prose?: (A extends { ui: { prose?: infer P } } ? Omit<NonNullable<P>, K> : Record<string, never>) & {
+        [k in K]?: Partial<T>
+      }
+    }
+    : (A extends { ui: infer UI } ? Omit<UI, K> : Record<string, never>) & {
+      [k in K]?: Partial<T>
+    }
+}
 
 /**
  * Defines the configuration shape expected for a component.

--- a/src/runtime/types/utils.ts
+++ b/src/runtime/types/utils.ts
@@ -5,6 +5,10 @@ export type DeepPartial<T> = {
   [P in keyof T]?: T[P] extends object ? DeepPartial<T[P]> : T[P] | undefined
 }
 
+export type DeepRequired<T> = {
+  [P in keyof T]-?: NonNullable<T[P]> extends object ? DeepRequired<NonNullable<T[P]>> : NonNullable<T[P]>
+}
+
 export type DynamicSlotsKeys<Name extends string | undefined, Suffix extends string | undefined = undefined> = (
   Name extends string
     ? Suffix extends string

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -323,6 +323,8 @@ type AppConfigUI = {
   tv?: typeof defaultConfig
 } & TVConfig<typeof ui>
 
+type AppConfigRuntimeUI = Required<Pick<AppConfigUI, 'colors' | 'icons' | 'tv'>> & Omit<AppConfigUI, 'colors' | 'icons' | 'tv'>
+
 declare module '@nuxt/schema' {
   interface AppConfigInput {
     /**
@@ -330,6 +332,9 @@ declare module '@nuxt/schema' {
      * @see https://ui.nuxt.com/docs/getting-started/theme/components
      */
     ui?: AppConfigUI
+  }
+  interface AppConfig {
+    ui: AppConfigRuntimeUI
   }
 }
 

--- a/src/templates.ts
+++ b/src/templates.ts
@@ -304,7 +304,7 @@ ${themeBlocks}`
       const iconUnion = iconKeys.length ? iconKeys.map(i => JSON.stringify(i)).join(' | ') : 'string'
 
       return `import * as ui from '#build/ui'
-import type { TVConfig } from '@nuxt/ui'
+import type { TVConfig, DeepRequired } from '@nuxt/ui'
 import type { defaultConfig } from 'tailwind-variants'
 import colors from 'tailwindcss/colors'
 
@@ -323,7 +323,7 @@ type AppConfigUI = {
   tv?: typeof defaultConfig
 } & TVConfig<typeof ui>
 
-type AppConfigRuntimeUI = Required<Pick<AppConfigUI, 'colors' | 'icons' | 'tv'>> & Omit<AppConfigUI, 'colors' | 'icons' | 'tv'>
+type AppConfigRuntimeUI = DeepRequired<Pick<AppConfigUI, 'colors' | 'icons' | 'tv'>> & Omit<AppConfigUI, 'colors' | 'icons' | 'tv'>
 
 declare module '@nuxt/schema' {
   interface AppConfigInput {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #5673

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`updateAppConfig` and `useAppConfig` only exposed `colors`, `icons`, and `tv` under `ui` because component keys were augmented on `AppConfigInput` (used by `defineAppConfig`) but never flowed into the resolved `AppConfig` type.

This adds a generated `AppConfigRuntimeUI` type that keeps `colors`, `icons`, and `tv` required while including all component theme keys from `TVConfig`, and augments `AppConfig` directly so the types reach `useAppConfig()` and `updateAppConfig()`.

`ComponentAppConfig` is also updated to preserve global `ui` keys (`icons`, `colors`, etc.) while replacing only the current component key with `Partial<Theme>`, avoiding TVConfig widening conflicts inside components.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.