### PR TITLE
fix(DashboardSidebar): guard against null persisted storage in `useResizable`

### DIFF
--- a/src/runtime/composables/useResizable.ts
+++ b/src/runtime/composables/useResizable.ts
@@ -116,8 +116,12 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
       : useStorage<StorageType>(key, defaultStorageValue, undefined, opts.value.storageOptions)
     : ref(defaultStorageValue)
 
+  if (storageData.value == null || typeof storageData.value !== 'object') {
+    storageData.value = { ...defaultStorageValue }
+  }
+
   const isCollapsed = computed({
-    get: () => storageData.value.collapsed,
+    get: () => storageData.value?.collapsed ?? defaultStorageValue.collapsed,
     set: (value: boolean) => {
       if (!opts.value.collapsible) {
         return
@@ -133,7 +137,7 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
   const previousSize = ref(opts.value.defaultSize)
 
   const size = computed({
-    get: () => storageData.value.size,
+    get: () => storageData.value?.size ?? defaultStorageValue.size,
     set: (value) => { storageData.value.size = value }
   })
 
@@ -328,7 +332,7 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
   }
 
   // Initial sync of storage value to external collapsed ref
-  if (isRef(collapsed) && storageData.value.collapsed) {
+  if (isRef(collapsed) && storageData.value?.collapsed) {
     collapsed.value = storageData.value.collapsed
   }
 
@@ -339,8 +343,12 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
         return
       }
 
-      if (storageData.value.collapsed !== value) {
-        storageData.value.collapsed = value
+      if (storageData.value?.collapsed !== value) {
+        if (storageData.value == null || typeof storageData.value !== 'object') {
+          storageData.value = { ...defaultStorageValue, collapsed: value }
+        } else {
+          storageData.value.collapsed = value
+        }
       }
     })
   }

--- a/src/runtime/composables/useResizable.ts
+++ b/src/runtime/composables/useResizable.ts
@@ -332,7 +332,7 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
   }
 
   // Initial sync of storage value to external collapsed ref
-  if (isRef(collapsed) && storageData.value?.collapsed) {
+  if (isRef(collapsed) && typeof storageData.value?.collapsed === 'boolean') {
     collapsed.value = storageData.value.collapsed
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6517

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`useResizable` crashes with `Cannot read properties of null (reading 'collapsed')` when the persisted cookie or localStorage value parses to `null` instead of the expected `{ size, collapsed }` object.

This happens because `useCookie`'s `default` option only fires when the cookie is **undefined**, not when `destr` parses it to `null`. Any of these puts the ref into a `null` state and crashes the sidebar permanently for that user:

- Cookie manually set to the literal string `null`
- `localStorage` entry containing `"null"`
- A browser extension or server-side injection writing `null`

**Fix:**

1. Eagerly reset corrupted storage — after reading `storageData`, if the value is `null` or not an object, immediately reset it to `defaultStorageValue` (self-heals the persisted value).
2. Defensive getters — `isCollapsed` and `size` computed getters use optional chaining with nullish coalescing so they never throw.
3. Guarded watch/sync — the external `collapsed` ref sync and watcher both handle the nullish case.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.