### PR TITLE
fix(module): merge custom variants into AppConfig type

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -323,7 +323,7 @@ type AppConfigUI = {
   tv?: typeof defaultConfig
 } & TVConfig<typeof ui>
 
-type AppConfigRuntimeUI = DeepRequired<Pick<AppConfigUI, 'colors' | 'icons' | 'tv'>> & Omit<AppConfigUI, 'colors' | 'icons' | 'tv'>
+type AppConfigRuntimeUI = DeepRequired<Pick<AppConfigUI, 'colors' | 'icons' | 'tv'>> & typeof ui
 
 declare module '@nuxt/schema' {
   interface AppConfigInput {
@@ -333,7 +333,7 @@ declare module '@nuxt/schema' {
      */
     ui?: AppConfigUI
   }
-  interface AppConfig {
+  interface CustomAppConfig {
     ui: AppConfigRuntimeUI
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6524

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

#6520 fixed `updateAppConfig`/`useAppConfig` autocompletion (#5673) by overriding `AppConfig.ui` with a resolved type, but that override clobbered Nuxt's resolved `AppConfig`, so custom variants declared in `app.config.ts` were no longer merged into component prop types (#6524).

This switches the augmentation to `CustomAppConfig` (the canonical bridge interface) so Nuxt's `MergedAppConfig` deep-merges the user's `app.config.ts` into the resolved type instead of replacing it. Component themes now resolve through `typeof ui`, which keeps literal variant keys so:

- custom variants (e.g. a new `avatar` `size`) flow back into props like `AvatarProps['size']` again, and
- component keys (e.g. `button`) stay exposed for `updateAppConfig`/`useAppConfig`, keeping #5673 fixed.

`TVConfig` can't be used for the resolved type: it widens variant keys and makes everything optional for the *input* side, which collapses the merge (drops custom variants) and reintroduces an excessively-deep type instantiation in `updateAppConfig`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.