### PR TITLE
fix(InputMenu/SelectMenu): re-highlight first item when items change

### DIFF
--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -231,7 +231,7 @@ export interface InputMenuSlots<
 </script>
 
 <script setup lang="ts" generic="T extends ArrayOrNested<InputMenuItem>, VK extends GetItemKeys<T> | undefined = undefined, M extends boolean = false, Mod extends Omit<ModelModifiers, 'lazy'> = Omit<ModelModifiers, 'lazy'>, C extends boolean | object = false">
-import { computed, useTemplateRef, toRef, onMounted, toRaw, nextTick, watch } from 'vue'
+import { computed, ref, useTemplateRef, toRef, onMounted, toRaw, nextTick, watch } from 'vue'
 import { TagsInputRoot, TagsInputItem, TagsInputItemText, TagsInputItemDelete, TagsInputInput } from 'reka-ui'
 import { useForwardProps } from '../composables/useForwardProps'
 import { Combobox, Autocomplete } from 'reka-ui/namespaced'
@@ -459,7 +459,10 @@ function onFocus(event: FocusEvent) {
   emitFormFocus()
 }
 
+const isOpen = ref(false)
 function onUpdateOpen(value: boolean) {
+  isOpen.value = value
+
   let timeoutId
 
   if (!value) {
@@ -530,6 +533,21 @@ function onClear() {
 }
 
 const viewportRef = useTemplateRef('viewportRef')
+
+const comboboxRootRef = useTemplateRef('comboboxRootRef')
+
+// reka-ui only re-highlights the first item when the list goes from empty to non-empty.
+// With `create-item`, the create item is always registered so the count never drops to 0,
+// leaving the highlight stale when async `items` load. Re-highlight when items change while open.
+// Wait an extra tick so freshly mounted items are registered in reka-ui's collection before highlighting.
+watch(() => props.items, async () => {
+  if (!isOpen.value) {
+    return
+  }
+
+  await nextTick()
+  comboboxRootRef.value?.highlightFirstItem?.()
+}, { flush: 'post' })
 
 defineExpose({
   inputRef: toRef(() => inputRef.value?.$el as HTMLInputElement),
@@ -610,6 +628,7 @@ defineExpose({
   </DefineItemTemplate>
 
   <Component.Root
+    ref="comboboxRootRef"
     v-slot="{ modelValue, open }"
     v-bind="rootProps"
     :name="name"

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -225,7 +225,7 @@ export interface SelectMenuSlots<
 </script>
 
 <script setup lang="ts" generic="T extends ArrayOrNested<SelectMenuItem>, VK extends GetItemKeys<T> | undefined = undefined, M extends boolean = false, Mod extends Omit<ModelModifiers, 'lazy'> = Omit<ModelModifiers, 'lazy'>, C extends boolean | object = false">
-import { useTemplateRef, computed, onMounted, toRef, toRaw } from 'vue'
+import { useTemplateRef, computed, ref, onMounted, toRef, toRaw, watch, nextTick } from 'vue'
 import { ComboboxRoot, ComboboxArrow, ComboboxAnchor, ComboboxInput, ComboboxTrigger, ComboboxCancel, ComboboxPortal, ComboboxContent, ComboboxEmpty, ComboboxGroup, ComboboxVirtualizer, ComboboxLabel, ComboboxSeparator, ComboboxItem, ComboboxItemIndicator, FocusScope } from 'reka-ui'
 import { useForwardProps } from '../composables/useForwardProps'
 import { defu } from 'defu'
@@ -426,7 +426,10 @@ function onUpdate(value: any) {
   }
 }
 
+const isOpen = ref(false)
 function onUpdateOpen(value: boolean) {
+  isOpen.value = value
+
   let timeoutId
 
   if (!value) {
@@ -488,6 +491,21 @@ function onClear() {
 }
 
 const viewportRef = useTemplateRef('viewportRef')
+
+const comboboxRootRef = useTemplateRef('comboboxRootRef')
+
+// reka-ui only re-highlights the first item when the list goes from empty to non-empty.
+// With `create-item`, the create item is always registered so the count never drops to 0,
+// leaving the highlight stale when async `items` load. Re-highlight when items change while open.
+// Wait an extra tick so freshly mounted items are registered in reka-ui's collection before highlighting.
+watch(() => props.items, async () => {
+  if (!isOpen.value) {
+    return
+  }
+
+  await nextTick()
+  comboboxRootRef.value?.highlightFirstItem?.()
+}, { flush: 'post' })
 
 defineExpose({
   triggerRef: toRef(() => triggerRef.value?.$el as HTMLButtonElement),
@@ -569,6 +587,7 @@ defineExpose({
 
   <ComboboxRoot
     :id="id"
+    ref="comboboxRootRef"
     v-slot="{ modelValue, open }"
     v-bind="({ ...rootProps, ...$attrs, ...ariaAttrs } as any)"
     ignore-filter

--- a/test/components/InputMenu.spec.ts
+++ b/test/components/InputMenu.spec.ts
@@ -205,6 +205,44 @@ describe('InputMenu', () => {
     })
   })
 
+  describe('create-item', () => {
+    // With `create-item`, the create item is always registered so reka-ui's collection
+    // never goes from empty to non-empty, leaving the highlight stale when async items load.
+    test('re-highlights first item when items change while open', async () => {
+      const wrapper = mount(InputMenu, {
+        attachTo: document.body,
+        props: {
+          open: true,
+          portal: false,
+          ignoreFilter: true,
+          createItem: 'always',
+          multiple: true,
+          items: []
+        }
+      })
+
+      const root = wrapper.findComponent({ name: 'ComboboxRoot' })
+      // Track open state (the watcher only re-highlights while the menu is open)
+      await root.vm.$emit('update:open', true)
+      await flushPromises()
+
+      // `searchTerm` is reset on mount, so set it afterwards to render the create item.
+      // It becomes the only (highlighted) item, mirroring the autocomplete bug.
+      await wrapper.setProps({ searchTerm: 'a' })
+      await flushPromises()
+
+      // Items arrive asynchronously (e.g. fetched from a backend)
+      await wrapper.setProps({ items: ['Option 1', 'Option 2'] })
+      await flushPromises()
+
+      const highlighted = wrapper.find('[role="option"][data-highlighted]')
+      expect(highlighted.exists()).toBe(true)
+      expect(highlighted.text()).toContain('Option 1')
+
+      wrapper.unmount()
+    })
+  })
+
   describe('it should display correct label', () => {
     test.each([null, undefined, ''])('falsy model value %s should display placeholder', (modelValue) => {
       const wrapper = mount(InputMenu, {

--- a/test/components/SelectMenu.spec.ts
+++ b/test/components/SelectMenu.spec.ts
@@ -173,6 +173,43 @@ describe('SelectMenu', () => {
     })
   })
 
+  describe('create-item', () => {
+    // With `create-item`, the create item is always registered so reka-ui's collection
+    // never goes from empty to non-empty, leaving the highlight stale when async items load.
+    test('re-highlights first item when items change while open', async () => {
+      const wrapper = mount(SelectMenu, {
+        attachTo: document.body,
+        props: {
+          open: true,
+          portal: false,
+          ignoreFilter: true,
+          createItem: 'always',
+          multiple: true,
+          items: []
+        }
+      })
+
+      const root = wrapper.findComponent({ name: 'ComboboxRoot' })
+      // Track open state (the watcher only re-highlights while the menu is open)
+      await root.vm.$emit('update:open', true)
+      await flushPromises()
+
+      // Set the search term so the create item renders and becomes the only (highlighted) item.
+      await wrapper.setProps({ searchTerm: 'a' })
+      await flushPromises()
+
+      // Items arrive asynchronously (e.g. fetched from a backend)
+      await wrapper.setProps({ items: ['Option 1', 'Option 2'] })
+      await flushPromises()
+
+      const highlighted = wrapper.find('[role="option"][data-highlighted]')
+      expect(highlighted.exists()).toBe(true)
+      expect(highlighted.text()).toContain('Option 1')
+
+      wrapper.unmount()
+    })
+  })
+
   describe('it should display correct label', () => {
     test.each([null, undefined, ''])('falsy model value %s should display placeholder', (modelValue) => {
       const wrapper = mount(SelectMenu, {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #5974

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

reka-ui only re-highlights the first item when its collection goes from empty to non-empty (`ComboboxInput`'s `filterState` watch guards on `oldValue.count === 0`). With `create-item`, the create item is always registered, so the count never drops to `0` and the highlight stays stale when async `items` load.

This caused the issues reported in #5974:
- After async items load, the stale "Create" item stays highlighted, so pressing Enter creates instead of selecting the first option.
- When focus ends up outside the combobox (e.g. items disappear), Enter falls through to `TagsInput`'s internal add, producing a phantom tag and inconsistent `onCreate`.

Fix: re-highlight the first item via reka-ui's exposed `highlightFirstItem()` whenever `items` change while the menu is open. We wait one extra tick first, since freshly mounted items only register in reka-ui's collection after their element ref is set (otherwise the empty→populated transition re-highlights the stale create item).

No custom Enter handler is needed: once the correct item is highlighted, reka-ui's native Enter handling selects/creates it.

Added regression tests for both components covering the async-items + `create-item` flow.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.