### PR TITLE
fix(Form): support setting the `name` attribute

### DIFF
--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -32,10 +32,10 @@ export type FormProps<S extends FormSchema, T extends boolean = true, N extends 
   disabled?: boolean
 
   /**
-   * Path of the form's state within it's parent form.
-   * Used for nesting forms. Only available if `nested` is true.
+   * The `name` attribute of the form element.
+   * For nested forms (`nested` is true), this is also used as the path of the form's state within its parent form.
    */
-  name?: N extends true ? string : never
+  name?: string
 
   /**
    * Delay in milliseconds before validating the form on input events.
@@ -462,6 +462,7 @@ defineExpose(api)
     :is="parentBus ? 'div' : 'form'"
     :id="formId"
     ref="formRef"
+    :name="parentBus ? undefined : props.name"
     method="post"
     :class="ui({ class: [props.ui?.base, props.class] })"
     @submit.prevent="onSubmitWrapper"

--- a/test/components/Form.spec.ts
+++ b/test/components/Form.spec.ts
@@ -12,9 +12,20 @@ import { renderForm } from '../utils/form'
 import UForm from '../../src/runtime/components/Form.vue'
 
 describe('Form', () => {
+  const props = { state: {} }
+
   renderEach(UForm, [
-    ['with state', { props: { state: {} } }],
-    ['with default slot', { props: { state: {} }, slots: { default: () => 'Form slot' } }]
+    // Props
+    ['with state', { props }],
+    ['with name', { props: { ...props, name: 'contact' } }],
+    ['with method', { props: { ...props, method: 'get' } }],
+    ['with id', { props: { ...props, id: 'id' } }],
+    ['with class', { props: { ...props, class: 'gap-4' } }],
+    ['with ui', { props: { ...props, ui: { base: 'rounded-lg' } } }],
+    // Attrs
+    ['with aria-label', { props, attrs: { 'aria-label': 'Contact form' } }],
+    // Slots
+    ['with default slot', { props, slots: { default: () => 'Form slot' } }]
   ])
 
   it('passes accessibility tests', async () => {

--- a/test/components/__snapshots__/Form-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Form-vue.spec.ts.snap
@@ -124,9 +124,21 @@ exports[`Form > joi validation works > without error 1`] = `
 </form>"
 `;
 
+exports[`Form > renders with aria-label correctly 1`] = `"<form id="v-0" method="post" class="" aria-label="Contact form"></form>"`;
+
+exports[`Form > renders with class correctly 1`] = `"<form id="v-0" method="post" class="gap-4"></form>"`;
+
 exports[`Form > renders with default slot correctly 1`] = `"<form id="v-0" method="post" class="">Form slot</form>"`;
 
+exports[`Form > renders with id correctly 1`] = `"<form id="id" method="post" class=""></form>"`;
+
+exports[`Form > renders with method correctly 1`] = `"<form id="v-0" method="get" class=""></form>"`;
+
+exports[`Form > renders with name correctly 1`] = `"<form id="v-0" name="contact" method="post" class=""></form>"`;
+
 exports[`Form > renders with state correctly 1`] = `"<form id="v-0" method="post" class=""></form>"`;
+
+exports[`Form > renders with ui correctly 1`] = `"<form id="v-0" method="post" class="rounded-lg"></form>"`;
 
 exports[`Form > superstruct validation works > with error 1`] = `
 "<form id="42" method="post" class="">

--- a/test/components/__snapshots__/Form.spec.ts.snap
+++ b/test/components/__snapshots__/Form.spec.ts.snap
@@ -124,9 +124,21 @@ exports[`Form > joi validation works > without error 1`] = `
 </form>"
 `;
 
+exports[`Form > renders with aria-label correctly 1`] = `"<form id="v-0-0" method="post" class="" aria-label="Contact form"></form>"`;
+
+exports[`Form > renders with class correctly 1`] = `"<form id="v-0-0" method="post" class="gap-4"></form>"`;
+
 exports[`Form > renders with default slot correctly 1`] = `"<form id="v-0-0" method="post" class="">Form slot</form>"`;
 
+exports[`Form > renders with id correctly 1`] = `"<form id="id" method="post" class=""></form>"`;
+
+exports[`Form > renders with method correctly 1`] = `"<form id="v-0-0" method="get" class=""></form>"`;
+
+exports[`Form > renders with name correctly 1`] = `"<form id="v-0-0" name="contact" method="post" class=""></form>"`;
+
 exports[`Form > renders with state correctly 1`] = `"<form id="v-0-0" method="post" class=""></form>"`;
+
+exports[`Form > renders with ui correctly 1`] = `"<form id="v-0-0" method="post" class="rounded-lg"></form>"`;
 
 exports[`Form > superstruct validation works > with error 1`] = `
 "<form id="42" method="post" class="">


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #5983

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `name` prop was reserved for nested-form state paths, and the native `name` attribute was stripped via `Omit<FormHTMLAttributes, 'name'>`, so there was no way to set a `name` on the rendered `<form>` element. This blocks use cases like Netlify Forms, which require a `name` attribute matching a `form-name` input.

`name` is now typed `string` (instead of nested-only) and bound explicitly to the root `<form>`. It still acts as the state path for nested forms (which render a `div`), so the dual behaviour is preserved:

- root form → renders as the `<form name="...">` attribute
- nested form → used as the path of the form's state within its parent

Added `renderEach` coverage for `name` (plus `method`, `id`, `class`, `ui`, and `aria-label`).

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.