### PR TITLE
feat(Form): automatically focus the first field with an error upon submission failure

### DIFF
--- a/docs/app/components/content/examples/form/FormExampleOnError.vue
+++ b/docs/app/components/content/examples/form/FormExampleOnError.vue
@@ -22,10 +22,9 @@ async function onSubmit(event: FormSubmitEvent<Schema>) {
 }
 
 async function onError(event: FormErrorEvent) {
-  if (event?.errors?.[0]?.id) {
-    const element = document.getElementById(event.errors[0].id)
-    element?.focus()
-    element?.scrollIntoView({ behavior: 'smooth', block: 'center' })
+  const error = event.errors[0]
+  if (error) {
+    toast.add({ title: 'Error', description: `Please check the form ${error.name}.`, color: 'error' })
   }
 }
 </script>

--- a/docs/content/docs/2.components/form.md
+++ b/docs/content/docs/2.components/form.md
@@ -162,7 +162,7 @@ You can listen to the `@error` event to handle errors. This event is triggered w
 By default, the form automatically focuses the first field with an error when submission fails through the `focus-on-error` prop. You can disable this by passing `:focus-on-error="false"`.
 ::
 
-Here's an example of using the `@error` event to add custom behavior, such as smoothly scrolling the focused element into view:
+Here's an example of using the `@error` event to add custom behavior, such as displaying a toast notification when validation fails:
 
 ::component-example
 ---

--- a/docs/content/docs/2.components/form.md
+++ b/docs/content/docs/2.components/form.md
@@ -158,7 +158,11 @@ You can listen to the `@error` event to handle errors. This event is triggered w
 - `name` - the `name` of the `FormField`
 - `message` - the error message to display.
 
-Here's an example that focuses the first input element with an error after the form is submitted:
+::tip
+By default, the form automatically focuses the first field with an error when submission fails through the `focus-on-error` prop. You can disable this by passing `:focus-on-error="false"`.
+::
+
+Here's an example of using the `@error` event to add custom behavior, such as smoothly scrolling the focused element into view:
 
 ::component-example
 ---

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -286,10 +286,6 @@ async function onSubmitWrapper(payload: Event) {
       throw error
     }
 
-    if (props.focusOnError) {
-      scrollToErrorEl(error.errors)
-    }
-
     const errorEvent: FormErrorEvent = {
       ...event,
       errors: error.errors
@@ -297,6 +293,11 @@ async function onSubmitWrapper(payload: Event) {
     emits('error', errorEvent)
   } finally {
     loading.value = false
+  }
+
+  if (props.focusOnError && errors.value.length > 0) {
+    await nextTick()
+    scrollToErrorEl(errors.value)
   }
 }
 

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -60,6 +60,10 @@ export type FormProps<S extends FormSchema, T extends boolean = true, N extends 
    * @defaultValue `true`
    */
   loadingAuto?: boolean
+  /**
+   * when `true`, form component will be auto focus on first Element
+   */
+  focusOnError?: boolean
   class?: any
   ui?: { base?: any }
   onSubmit?: ((event: FormSubmitEvent<FormData<S, T>>) => void | Promise<void>) | (() => void | Promise<void>)
@@ -82,7 +86,7 @@ import { useAppConfig } from '#imports'
 import { formOptionsInjectionKey, formInputsInjectionKey, formBusInjectionKey, formLoadingInjectionKey, formErrorsInjectionKey, formStateInjectionKey } from '../composables/useFormField'
 import { tv } from '../utils/tv'
 import { useComponentProps } from '../composables/useComponentProps'
-import { validateSchema, getAtPath, setAtPath } from '../utils/form'
+import { validateSchema, getAtPath, setAtPath, scrollToErrorEl } from '../utils/form'
 import { FormValidationException } from '../types/form'
 
 type I = InferInput<S>
@@ -93,6 +97,7 @@ const _props = withDefaults(defineProps<FormProps<S, T, N>>(), {
     return ['input', 'blur', 'change'] as FormInputEvents[]
   },
   validateOnInputDelay: 300,
+  focusOnError: true,
   transform: () => true as T,
   loadingAuto: true
 })
@@ -278,6 +283,10 @@ async function onSubmitWrapper(payload: Event) {
   } catch (error) {
     if (!(error instanceof FormValidationException)) {
       throw error
+    }
+
+    if (props.focusOnError) {
+      scrollToErrorEl(error.errors)
     }
 
     const errorEvent: FormErrorEvent = {

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -61,7 +61,8 @@ export type FormProps<S extends FormSchema, T extends boolean = true, N extends 
    */
   loadingAuto?: boolean
   /**
-   * when `true`, form component will be auto focus on first Element
+   * When `true`, the form automatically focuses the first field with an error on failed submission.
+   * @defaultValue `true`
    */
   focusOnError?: boolean
   class?: any

--- a/src/runtime/utils/form.ts
+++ b/src/runtime/utils/form.ts
@@ -115,16 +115,12 @@ export function setAtPath<T extends object>(
   return data
 }
 
-let timeOut: NodeJS.Timeout | null = null
 export function scrollToErrorEl(errors: FormErrorWithId[]) {
   const error = errors[0]
   if (error) {
     const el = document.getElementById(error.id!)
     if (el) {
-      if (timeOut) clearTimeout(timeOut)
-      timeOut = setTimeout(() => {
-        el.focus()
-      }, 0)
+      el.focus()
     }
   }
 }

--- a/src/runtime/utils/form.ts
+++ b/src/runtime/utils/form.ts
@@ -1,6 +1,6 @@
 import type { StandardSchemaV1 } from '@standard-schema/spec'
 import type { Struct } from 'superstruct'
-import type { FormSchema, ValidateReturnSchema } from '../types/form'
+import type { FormErrorWithId, FormSchema, ValidateReturnSchema } from '../types/form'
 
 export function isSuperStructSchema(schema: any): schema is Struct<any, any> {
   return (
@@ -113,4 +113,18 @@ export function setAtPath<T extends object>(
   current[lastKey] = value
 
   return data
+}
+
+export function scrollToErrorEl(errors: FormErrorWithId[]) {
+  const error = errors[0]
+  if (error) {
+    const el = document.getElementById(error.id!)
+    let timeOut
+    if (el) {
+      if (timeOut) clearTimeout(timeOut)
+      timeOut = setTimeout(() => {
+        el.focus()
+      }, 0)
+    }
+  }
 }

--- a/src/runtime/utils/form.ts
+++ b/src/runtime/utils/form.ts
@@ -115,11 +115,11 @@ export function setAtPath<T extends object>(
   return data
 }
 
+let timeOut: NodeJS.Timeout | null = null
 export function scrollToErrorEl(errors: FormErrorWithId[]) {
   const error = errors[0]
   if (error) {
     const el = document.getElementById(error.id!)
-    let timeOut
     if (el) {
       if (timeOut) clearTimeout(timeOut)
       timeOut = setTimeout(() => {

--- a/test/components/Form.spec.ts
+++ b/test/components/Form.spec.ts
@@ -275,6 +275,24 @@ describe('Form', () => {
       expect(passwordField.text()).toBe('Invalid input: expected string, received undefined')
     })
 
+    it('focuses on first error element on submit error', async () => {
+      const emailInputMock = { focus: vi.fn() }
+      const passwordInputMock = { focus: vi.fn() }
+      const getElementByIdSpy = vi.spyOn(document, 'getElementById').mockImplementation((id) => {
+        if (id === 'email') return emailInputMock as any
+        if (id === 'password') return passwordInputMock as any
+        return null
+      })
+
+      await form.submit()
+      await new Promise(resolve => setTimeout(resolve, 0))
+
+      expect(emailInputMock.focus).toHaveBeenCalledTimes(1)
+      expect(passwordInputMock.focus).toHaveBeenCalledTimes(0)
+
+      getElementByIdSpy.mockRestore()
+    })
+
     it('validate on submit works', async () => {
       state.email = 'bob@dylan.com'
       state.password = 'strongpassword'

--- a/test/components/Form.spec.ts
+++ b/test/components/Form.spec.ts
@@ -285,7 +285,7 @@ describe('Form', () => {
       })
 
       await form.submit()
-      await new Promise(resolve => setTimeout(resolve, 0))
+      await flushPromises()
 
       expect(emailInputMock.focus).toHaveBeenCalledTimes(1)
       expect(passwordInputMock.focus).toHaveBeenCalledTimes(0)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Resolves https://github.com/nuxt/ui/issues/4612

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change



<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR just a proposal that match with form behavior base on

https://www.w3.org/WAI/WCAG22/Understanding/error-identification.html

in client-validation form when `field` is `error` the browser automaticly focus to the first `field`. currently `NuxtUI` doesn't do that we need to manage by it self using `@error` prop. this PR make the `Form` will automatically focus to the error field

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
