### PR TITLE
fix(Form): use FormState type to support nullable/custom initial state values

### DIFF
--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -2,7 +2,7 @@
 import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/form'
-import type { FormSchema, FormError, FormInputEvents, FormErrorEvent, FormSubmitEvent, FormEvent, Form, FormErrorWithId, InferInput, InferOutput, FormData } from '../types/form'
+import type { FormSchema, FormError, FormInputEvents, FormErrorEvent, FormSubmitEvent, FormEvent, Form, FormErrorWithId, InferInput, InferOutput, FormData, FormState } from '../types/form'
 import type { FormHTMLAttributes } from '../types/html'
 import type { ComponentConfig } from '../types/tv'
 
@@ -13,13 +13,13 @@ export type FormProps<S extends FormSchema, T extends boolean = true, N extends 
   /** Schema to validate the form state. Supports Standard Schema objects, Yup, Joi, and Superstructs. */
   schema?: S
   /** An object representing the current state of the form. */
-  state?: N extends false ? Partial<InferInput<S>> : never
+  state?: N extends false ? FormState<S> : never
   /**
    * Custom validation function to validate the form state.
    * @param state - The current state of the form.
    * @returns A promise that resolves to an array of FormError objects, or an array of FormError objects directly.
    */
-  validate?: (state: Partial<InferInput<S>>) => Promise<FormError[]> | FormError[]
+  validate?: (state: FormState<S>) => Promise<FormError[]> | FormError[]
 
   /**
    * The list of input events that trigger the form validation.

--- a/src/runtime/types/form.ts
+++ b/src/runtime/types/form.ts
@@ -34,6 +34,10 @@ export type InferOutput<Schema> = Schema extends StandardSchemaV1 ? StandardSche
   : Schema extends SuperstructSchema<infer O, any> ? O
     : never
 
+export type FormState<S extends FormSchema> = {
+  [K in keyof InferInput<S>]?: InferInput<S>[K] | unknown
+}
+
 export type FormData<S extends FormSchema, T extends boolean = true> = T extends true ? InferOutput<S> : InferInput<S>
 
 export type FormInputEvents = 'input' | 'blur' | 'change' | 'focus'

--- a/src/runtime/types/form.ts
+++ b/src/runtime/types/form.ts
@@ -35,7 +35,7 @@ export type InferOutput<Schema> = Schema extends StandardSchemaV1 ? StandardSche
     : never
 
 export type FormState<S extends FormSchema> = {
-  [K in keyof InferInput<S>]?: InferInput<S>[K] | unknown
+  [K in keyof InferInput<S>]?: any
 }
 
 export type FormData<S extends FormSchema, T extends boolean = true> = T extends true ? InferOutput<S> : InferInput<S>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue
Resolves https://github.com/nuxt/ui/issues/5204, https://github.com/nuxt/ui/issues/6309

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

## 📝 Description

The `state` strictly inferred all field types directly from the schema (based on `InferInput<S>`). 
While this seemed ideal, it caused significant friction because HTML/DOM inputs naturally handle unvalidated string states (like binding `""` to an `<input type="number">`). Developers were forced to either cast their reactive state to `any` or write overly complex schemas (e.g., `z.number().or(z.string()).pipe(...)`) just to satisfy TypeScript before the data was actually submitted and coerced.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
