### PR TITLE
feat(ScrollArea): add `shadow` prop

### DIFF
--- a/docs/app/components/content/examples/scroll-area/ScrollAreaShadowExample.vue
+++ b/docs/app/components/content/examples/scroll-area/ScrollAreaShadowExample.vue
@@ -1,0 +1,13 @@
+<template>
+  <div class="max-w-sm bg-elevated/50 rounded-lg">
+    <UScrollArea
+      shadow
+      class="p-4 h-72"
+      :ui="{ viewport: 'gap-4' }"
+    >
+      <p v-for="i in 6" :key="i">
+        Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nullam pulvinar risus non risus hendrerit venenatis. Pellentesque sit amet hendrerit risus, sed porttitor quam. Morbi accumsan cursus enim, sed ultricies sapien.
+      </p>
+    </UScrollArea>
+  </div>
+</template>

--- a/docs/content/docs/2.components/scroll-area.md
+++ b/docs/content/docs/2.components/scroll-area.md
@@ -91,6 +91,21 @@ options:
 ---
 ::
 
+### Shadow :badge{label="Soon" class="align-text-top"}
+
+Use the `shadow` prop to display fade shadows on the scrollable edges, indicating that more content is available in the scroll direction. The fade automatically follows the `orientation` and only appears when the content overflows.
+
+::component-example
+---
+collapse: true
+name: 'scroll-area-shadow-example'
+---
+::
+
+::tip
+Pass an object to the `shadow` prop to configure the fade size, e.g. `:shadow="{ size: 48 }"`.
+::
+
 ## Examples
 
 ### As masonry layout

--- a/src/runtime/components/ScrollArea.vue
+++ b/src/runtime/components/ScrollArea.vue
@@ -59,6 +59,12 @@ export interface ScrollAreaProps<T extends ScrollAreaItem = ScrollAreaItem> {
    * @defaultValue false
    */
   virtualize?: boolean | ScrollAreaVirtualizeOptions
+  /**
+   * Display fade shadows on the scrollable edges to indicate more content.
+   * Pass an object to configure the shadow size (in px).
+   * @defaultValue false
+   */
+  shadow?: boolean | { size?: number }
   class?: any
   ui?: ScrollArea['slots']
 }
@@ -89,10 +95,12 @@ import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
 import { tv } from '../utils/tv'
 import { useLocale } from '../composables/useLocale'
+import { useScrollShadow } from '../composables/useScrollShadow'
 
 const _props = withDefaults(defineProps<ScrollAreaProps<T>>(), {
   orientation: 'vertical',
-  virtualize: false
+  virtualize: false,
+  shadow: false
 })
 defineSlots<ScrollAreaSlots<T>>()
 const emits = defineEmits<ScrollAreaEmits>()
@@ -108,6 +116,16 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.scrollArea |
 }))
 
 const rootRef = useTemplateRef<ComponentPublicInstance>('rootRef')
+
+const scrollShadowStyle = props.shadow
+  ? useScrollShadow(
+    computed(() => rootRef.value?.$el as HTMLElement | undefined),
+    {
+      orientation: () => props.orientation ?? 'vertical',
+      size: typeof props.shadow === 'object' ? props.shadow.size : undefined
+    }
+  ).style
+  : undefined
 
 const isRtl = computed(() => dir.value === 'rtl')
 const isHorizontal = computed(() => props.orientation === 'horizontal')
@@ -273,6 +291,7 @@ defineExpose({
     data-slot="root"
     :data-orientation="props.orientation"
     :class="ui.root({ class: [props.ui?.root, props.class] })"
+    :style="scrollShadowStyle"
   >
     <template v-if="virtualizer">
       <div

--- a/test/components/ScrollArea.spec.ts
+++ b/test/components/ScrollArea.spec.ts
@@ -22,6 +22,7 @@ describe('ScrollArea', () => {
     ['with virtualize padding', { props: { ...props, virtualize: { paddingStart: 20, paddingEnd: 20 } } }],
     ['with virtualize lanes', { props: { ...props, virtualize: { lanes: 3 } } }],
     ['with virtualize scrollMargin', { props: { ...props, virtualize: { scrollMargin: 10 } } }],
+    ['with shadow', { props: { ...props, shadow: true } }],
     ['with as', { props: { ...props, as: 'section' } }],
     ['with class', { props: { ...props, class: 'absolute' } }],
     ['with ui', { props: { ...props, ui: { viewport: 'gap-4' } } }],

--- a/test/components/__snapshots__/ScrollArea-vue.spec.ts.snap
+++ b/test/components/__snapshots__/ScrollArea-vue.spec.ts.snap
@@ -56,6 +56,16 @@ exports[`ScrollArea > renders with orientation vertical correctly 1`] = `
 </div>"
 `;
 
+exports[`ScrollArea > renders with shadow correctly 1`] = `
+"<div data-slot="root" data-orientation="vertical" class="relative overflow-y-auto overflow-x-hidden">
+  <div data-slot="viewport" class="relative flex flex-col">
+    <div data-slot="item" class=""></div>
+    <div data-slot="item" class=""></div>
+    <div data-slot="item" class=""></div>
+  </div>
+</div>"
+`;
+
 exports[`ScrollArea > renders with ui correctly 1`] = `
 "<div data-slot="root" data-orientation="vertical" class="relative overflow-y-auto overflow-x-hidden">
   <div data-slot="viewport" class="relative flex flex-col gap-4">

--- a/test/components/__snapshots__/ScrollArea.spec.ts.snap
+++ b/test/components/__snapshots__/ScrollArea.spec.ts.snap
@@ -56,6 +56,16 @@ exports[`ScrollArea > renders with orientation vertical correctly 1`] = `
 </div>"
 `;
 
+exports[`ScrollArea > renders with shadow correctly 1`] = `
+"<div data-slot="root" data-orientation="vertical" class="relative overflow-y-auto overflow-x-hidden">
+  <div data-slot="viewport" class="relative flex flex-col">
+    <div data-slot="item" class=""></div>
+    <div data-slot="item" class=""></div>
+    <div data-slot="item" class=""></div>
+  </div>
+</div>"
+`;
+
 exports[`ScrollArea > renders with ui correctly 1`] = `
 "<div data-slot="root" data-orientation="vertical" class="relative overflow-y-auto overflow-x-hidden">
   <div data-slot="viewport" class="relative flex flex-col gap-4">


### PR DESCRIPTION
### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds a `shadow` prop to `UScrollArea` that applies fade shadows on scrollable edges via the existing `useScrollShadow` composable. Pass `true` for defaults or an object (`{ size: 48 }`) to customize fade size. Shadows follow `orientation` and only show when content overflows.

Includes a docs example and snapshot test coverage.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.