### PR TITLE
fix(module): remove inline script in SPA mode for strict CSP

### DIFF
--- a/src/runtime/plugins/colors.ts
+++ b/src/runtime/plugins/colors.ts
@@ -1,7 +1,7 @@
 import { computed } from 'vue'
 import colors from 'tailwindcss/colors'
 import type { UseHeadInput } from '@unhead/vue/types'
-import { defineNuxtPlugin, useAppConfig, useNuxtApp, useHead } from '#imports'
+import { defineNuxtPlugin, injectHead, useAppConfig, useNuxtApp, useHead } from '#imports'
 
 const shades = [50, 100, 200, 300, 400, 500, 600, 700, 800, 900, 950] as const
 
@@ -18,6 +18,10 @@ function generateShades(key: string, value: string, prefix?: string) {
 }
 function generateColor(key: string, shade: number) {
   return `--ui-${key}: var(--ui-color-${key}-${shade});`
+}
+
+function removeTemporaryColorsStyle() {
+  document.querySelector('[data-nuxt-ui-colors]')?.remove()
 }
 
 export default defineNuxtPlugin(() => {
@@ -58,9 +62,7 @@ export default defineNuxtPlugin(() => {
     style.setAttribute('data-nuxt-ui-colors', '')
     document.head.appendChild(style)
 
-    headData.script = [{
-      innerHTML: 'document.head.removeChild(document.querySelector(\'[data-nuxt-ui-colors]\'))'
-    }]
+    injectHead().hooks.hookOnce('dom:rendered', removeTemporaryColorsStyle)
   }
 
   useHead(headData)

--- a/src/runtime/vue/stubs/base.ts
+++ b/src/runtime/vue/stubs/base.ts
@@ -5,7 +5,7 @@ import { useColorMode as useColorModeVueUse } from '@vueuse/core'
 import appConfig from '#build/app.config'
 import type { NuxtApp } from '#app'
 
-export { useHead } from '@unhead/vue'
+export { injectHead, useHead } from '@unhead/vue'
 
 export { useAppConfig } from '../composables/useAppConfig'
 export { defineShortcuts } from '../../composables/defineShortcuts'


### PR DESCRIPTION
Replace the temporary style cleanup script with a dom:rendered hook to comply with script-src 'self' without unsafe-inline.

<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

## Summary

- Remove the inline `<script>` injected by the `colors` plugin in Vue SPA mode (`@nuxt/ui/vite` + `@nuxt/ui/vue-plugin`), which violated strict CSP policies (`script-src 'self'` without `unsafe-inline`)
- Clean up the temporary anti-FOUC `<style data-nuxt-ui-colors>` via Unhead's `dom:rendered` hook instead
- Export `injectHead` from the Vue SPA stub so the plugin can access the head instance

## Linked issues
Resolves #4976
Related to #3394 (CSP / inline styles) but does not address `style-src` nonce support.

## Type of change
- [x] Bug fix

## Test plan
- [ ] Run `pnpm run dev:vue` and verify `style#nuxt-ui-colors` is present in `<head>`
- [ ] Verify `[data-nuxt-ui-colors]` is removed after page load
- [ ] Add a strict CSP meta (`script-src 'self'`) in the Vue playground and confirm no CSP violation in the console
- [ ] Confirm Nuxt SSR behavior is unchanged (SPA block does not run when `serverRendered` is true)
