### PR TITLE
fix(templates): resolve vite root to an absolute path for #build aliases

### DIFF
--- a/src/plugins/templates.ts
+++ b/src/plugins/templates.ts
@@ -35,7 +35,12 @@ export default function TemplatePlugin(options: NuxtUIOptions, appConfig: Record
     enforce: 'pre',
     vite: {
       async config(config) {
-        const alias = await writeTemplates(config.root || process.cwd())
+        // `config.root` is not resolved yet when `config` hooks run, so a
+        // CLI-provided root (e.g. `vite some/dir`) can still be relative here.
+        // Alias targets must be absolute: Vite 8 warns on relative targets and
+        // resolvers like @tailwindcss/vite reject them, which silently drops
+        // every theme class from the generated CSS.
+        const alias = await writeTemplates(path.resolve(config.root || '.'))
 
         return {
           resolve: {


### PR DESCRIPTION
### 🔗 Linked issue

_None — happy to open one if preferred._

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

#### Where we noticed this

While upgrading [nuxt-studio](https://github.com/nuxt-content/studio) to Vite 8, all Nuxt UI theme classes (e.g. `text-[8px]/3` from the Badge theme) silently disappeared from the generated Tailwind CSS. Studio runs its embedded Vue app with a relative CLI root (`vite src/app` from the repo root), which turned out to be the trigger.

#### Root cause

`TemplatePlugin` builds the `#build/*` alias map inside a Vite `config` hook:

```ts
const alias = await writeTemplates(config.root || process.cwd())
```

At that point `config.root` is **not resolved yet**. In Vite's `resolveConfig`, plugin `config` hooks run *before* the root is normalized ([`packages/vite/src/node/config.ts`](https://github.com/vitejs/vite/blob/main/packages/vite/src/node/config.ts)):

```ts
config = await runConfigHook(config, userPlugins, configEnv)
// ...
const resolvedRoot = normalizePath(config.root ? path.resolve(config.root) : process.cwd())
```

So a CLI-provided root like `vite playgrounds/vue` reaches the hook as the literal relative string, and every `#build/*` alias target ends up relative (`playgrounds/vue/node_modules/.nuxt-ui/ui.css`).

Vite tolerates the relative alias for its own pipeline (with a warning: *"rewrote #build/ui.css to … but was not an absolute path … will lead to duplicated modules"*), but `@tailwindcss/vite`'s custom resolver only accepts absolute results. The consequences differ by Vite major — reproducible with this repo's own vue playground:

- **Vite 7**: `vite build playgrounds/vue` from the repo root hard-fails with `[@tailwindcss/vite:generate:build] Can't resolve '#build/ui.css' in '…/dist/runtime'`
- **Vite 8**: the build succeeds, but Tailwind never inlines `ui.css` and therefore never registers its `@source "./ui"` directive — every utility that only exists in the generated component themes is silently dropped from the CSS

#### Why `path.resolve(config.root || '.')`

The fix mirrors exactly what Vite itself does a few lines later (`path.resolve(config.root)` falls back to `process.cwd()`), so the alias map is guaranteed to match Vite's eventual `resolvedRoot`. For absolute roots it's a no-op, and the behavior is identical on Vite 7 and Vite 8.

Verified on both majors: with the fix, `vite build playgrounds/vue` from the repo root builds cleanly and the output CSS contains the theme-only utilities (e.g. `.text-\[8px\]\/3`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)