### PR TITLE
feat(vite): add `root` option to override `.nuxt-ui` directory location

### DIFF
--- a/docs/content/docs/1.getting-started/2.installation/2.vue.md
+++ b/docs/content/docs/1.getting-started/2.installation/2.vue.md
@@ -887,6 +887,32 @@ export default defineConfig({
 By default, only `@nuxt/ui` is scanned. Use this option when your external packages contain Vue components that use Nuxt UI.
 ::
 
+### `root` :badge{label="4.9+" class="align-text-top"}
+
+Use the `root` option to override the directory where Nuxt UI generates its `.nuxt-ui` directory (containing the theme templates). By default it uses Vite's `root`, but in setups like [`electron-vite`](https://electron-vite.org/) the renderer's `root` points to a sub-directory (e.g. `src/renderer`), so the templates land in `src/renderer/node_modules/.nuxt-ui` where Tailwind doesn't scan them, causing theme classes like `bg-default`, `ring-default` and `divide-default` to be missing.
+
+```ts [electron.vite.config.ts] {12}
+import { defineConfig } from 'electron-vite'
+import vue from '@vitejs/plugin-vue'
+import ui from '@nuxt/ui/vite'
+
+export default defineConfig({
+  renderer: {
+    root: 'src/renderer',
+    plugins: [
+      vue(),
+      ui({
+        root: __dirname
+      })
+    ]
+  }
+})
+```
+
+::note
+Point `root` at your project root so the generated `.nuxt-ui` directory ends up in a `node_modules` that Tailwind scans.
+::
+
 ## Continuous releases
 
 Nuxt UI uses [pkg.pr.new](https://github.com/stackblitz-labs/pkg.pr.new) for continuous preview releases, providing developers with instant access to the latest features and bug fixes without waiting for official releases.

--- a/src/plugins/templates.ts
+++ b/src/plugins/templates.ts
@@ -40,7 +40,9 @@ export default function TemplatePlugin(options: NuxtUIOptions, appConfig: Record
         // Alias targets must be absolute: Vite 8 warns on relative targets and
         // resolvers like @tailwindcss/vite reject them, which silently drops
         // every theme class from the generated CSS.
-        const alias = await writeTemplates(path.resolve(config.root || '.'))
+        // `options.root` lets setups like `electron-vite` override the location
+        // when `config.root` points to a sub-directory Tailwind doesn't scan.
+        const alias = await writeTemplates(path.resolve(options.root || config.root || '.'))
 
         return {
           resolve: {

--- a/src/unplugin.ts
+++ b/src/unplugin.ts
@@ -78,6 +78,14 @@ export interface NuxtUIOptions extends Omit<ModuleOptions, 'fonts' | 'colorMode'
    * @see https://ui.nuxt.com/docs/getting-started/installation/vue#scanpackages
    */
   scanPackages?: string[]
+  /**
+   * Root directory where the `.nuxt-ui` directory (generated theme templates) is created.
+   * Useful for setups like `electron-vite` where `config.root` points to a sub-directory
+   * (e.g. `src/renderer`) that Tailwind doesn't scan.
+   * @defaultValue `config.root`
+   * @see https://ui.nuxt.com/docs/getting-started/installation/vue#root
+   */
+  root?: string
 }
 
 export const runtimeDir = normalize(fileURLToPath(new URL('./runtime', import.meta.url)))


### PR DESCRIPTION
## Description

Adds a `root` option to the `@nuxt/ui/vite` plugin to override the directory where the `.nuxt-ui` directory (generated theme templates) is created.

By default the plugin uses Vite's `config.root`. In setups like [`electron-vite`](https://electron-vite.org/) the renderer's `root` points to a sub-directory (e.g. `src/renderer`), so the templates land in `src/renderer/node_modules/.nuxt-ui` where Tailwind doesn't scan them, causing theme classes like `bg-default`, `ring-default` and `divide-default` to be missing.

```ts
// electron.vite.config.ts
export default defineConfig({
  renderer: {
    root: 'src/renderer',
    plugins: [vue(), ui({ root: __dirname })]
  }
})
```

Closes #6589