### PR TITLE
feat(Modal/Slideover): add `leave` and `enter` events

### DIFF
--- a/src/runtime/components/Modal.vue
+++ b/src/runtime/components/Modal.vue
@@ -61,7 +61,9 @@ export interface ModalProps extends DialogRootProps {
 }
 
 export interface ModalEmits extends DialogRootEmits {
+  'leave': []
   'after:leave': []
+  'enter': []
   'after:enter': []
   'close:prevent': []
 }
@@ -149,7 +151,9 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.modal || {})
         data-slot="content"
         :class="ui.content({ class: [!slots.default && props.class, props.ui?.content] })"
         v-bind="contentProps"
+        @enter="emits('enter')"
         @after-enter="emits('after:enter')"
+        @leave="emits('leave')"
         @after-leave="emits('after:leave')"
         v-on="contentEvents"
       >

--- a/src/runtime/components/Slideover.vue
+++ b/src/runtime/components/Slideover.vue
@@ -61,7 +61,9 @@ export interface SlideoverProps extends DialogRootProps {
 }
 
 export interface SlideoverEmits extends DialogRootEmits {
+  'leave': []
   'after:leave': []
+  'enter': []
   'after:enter': []
   'close:prevent': []
 }
@@ -155,7 +157,9 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.slideover ||
           data-slot="content"
           :class="ui.content({ class: [!slots.default && props.class, props.ui?.content] })"
           v-bind="contentProps"
+          @enter="emits('enter')"
           @after-enter="emits('after:enter')"
+          @leave="emits('leave')"
           @after-leave="emits('after:leave')"
           v-on="contentEvents"
         >


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

partially related to the confusion of https://github.com/nuxt/ui/issues/6594 😅 

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Pass the `enter`/`leave` event from DialogContent to modal/slideover

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
