### PR TITLE
feat(components): allow hiding `icon` with `false`

### DIFF
--- a/src/runtime/components/ChatPromptSubmit.vue
+++ b/src/runtime/components/ChatPromptSubmit.vue
@@ -10,11 +10,11 @@ type ChatPromptSubmit = ComponentConfig<typeof theme, AppConfig, 'chatPromptSubm
 export interface ChatPromptSubmitProps extends Omit<ButtonProps, LinkPropsKeys | 'icon' | 'color' | 'variant'> {
   status?: ChatStatus
   /**
-   * The icon displayed in the button when the status is `ready`.
+   * The icon displayed in the button when the status is `ready`. Set to `false` to hide the icon.
    * @defaultValue appConfig.ui.icons.arrowUp
    * @IconifyIcon
    */
-  icon?: IconProps['name']
+  icon?: IconProps['name'] | false
   /**
    * The color of the button when the status is `ready`.
    * @defaultValue 'primary'
@@ -119,7 +119,7 @@ const disabled = computed(() => props.status === 'ready' ? props.disabled : fals
 
 const statusButtonProps = computed(() => ({
   ready: {
-    icon: props.icon || appConfig.ui.icons.arrowUp,
+    icon: props.icon === false ? undefined : (props.icon ?? appConfig.ui.icons.arrowUp),
     color: props.color,
     variant: props.variant,
     type: 'submit' as const

--- a/src/runtime/components/CommandPalette.vue
+++ b/src/runtime/components/CommandPalette.vue
@@ -71,11 +71,11 @@ export interface CommandPaletteProps<G extends CommandPaletteGroup<T> = CommandP
    */
   size?: CommandPalette['variants']['size']
   /**
-   * The icon displayed in the input.
+   * The icon displayed in the input. Set to `false` to hide the icon.
    * @defaultValue appConfig.ui.icons.search
    * @IconifyIcon
    */
-  icon?: IconProps['name']
+  icon?: IconProps['name'] | false
   /**
    * The icon displayed on the right side of the input.
    * @defaultValue appConfig.ui.icons.search
@@ -593,7 +593,7 @@ function onSelect(e: Event, item: T) {
         :loading="props.loading"
         :loading-icon="props.loadingIcon"
         :trailing-icon="props.trailingIcon"
-        :icon="props.icon || appConfig.ui.icons.search"
+        :icon="props.icon === false ? undefined : (props.icon ?? appConfig.ui.icons.search)"
         v-bind="typeof props.input === 'object' ? props.input : {}"
         data-slot="input"
         :class="ui.input({ class: props.ui?.input })"

--- a/src/runtime/components/DashboardSearchButton.vue
+++ b/src/runtime/components/DashboardSearchButton.vue
@@ -8,11 +8,11 @@ type DashboardSearchButton = ComponentConfig<typeof theme, AppConfig, 'dashboard
 
 export interface DashboardSearchButtonProps extends Omit<ButtonProps, LinkPropsKeys | 'icon' | 'label' | 'color' | 'variant'> {
   /**
-   * The icon displayed in the button.
+   * The icon displayed in the button. Set to `false` to hide the icon.
    * @defaultValue appConfig.ui.icons.search
    * @IconifyIcon
    */
-  icon?: IconProps['name']
+  icon?: IconProps['name'] | false
   /**
    * The label displayed in the button.
    * @defaultValue t('dashboardSearchButton.label')
@@ -96,7 +96,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.dashboardSea
 <template>
   <DefineButtonTemplate>
     <UButton
-      :icon="props.icon || appConfig.ui.icons.search"
+      :icon="props.icon === false ? undefined : (props.icon ?? appConfig.ui.icons.search)"
       :label="props.label || t('dashboardSearchButton.label')"
       :variant="props.variant || (props.collapsed ? 'ghost' : 'outline')"
       v-bind="{

--- a/src/runtime/components/FileUpload.vue
+++ b/src/runtime/components/FileUpload.vue
@@ -18,11 +18,11 @@ export interface FileUploadProps<M extends boolean = false> extends /** @vue-ign
   id?: string
   name?: string
   /**
-   * The icon to display.
+   * The icon to display. Set to `false` to hide the icon.
    * @defaultValue appConfig.ui.icons.upload
    * @IconifyIcon
    */
-  icon?: IconProps['name']
+  icon?: IconProps['name'] | false
   label?: string
   description?: string
   /**
@@ -375,8 +375,10 @@ defineExpose({
 
         <div v-if="position === 'inside' ? (!props.preview || (multiple ? !(modelValue as File[])?.length : !modelValue)) : true" data-slot="wrapper" :class="ui.wrapper({ class: props.ui?.wrapper })">
           <slot name="leading" :ui="ui">
-            <UIcon v-if="variant === 'button'" :name="props.icon || appConfig.ui.icons.upload" data-slot="icon" :class="ui.icon({ class: props.ui?.icon })" />
-            <UAvatar v-else :icon="props.icon || appConfig.ui.icons.upload" :size="props.size" data-slot="avatar" :class="ui.avatar({ class: props.ui?.avatar })" />
+            <template v-if="props.icon !== false">
+              <UIcon v-if="variant === 'button'" :name="props.icon ?? appConfig.ui.icons.upload" data-slot="icon" :class="ui.icon({ class: props.ui?.icon })" />
+              <UAvatar v-else :icon="props.icon ?? appConfig.ui.icons.upload" :size="props.size" data-slot="avatar" :class="ui.avatar({ class: props.ui?.avatar })" />
+            </template>
           </slot>
 
           <template v-if="variant !== 'button'">

--- a/src/runtime/components/content/ContentSearchButton.vue
+++ b/src/runtime/components/content/ContentSearchButton.vue
@@ -8,11 +8,11 @@ type ContentSearchButton = ComponentConfig<typeof theme, AppConfig, 'contentSear
 
 export interface ContentSearchButtonProps extends Omit<ButtonProps, LinkPropsKeys | 'icon' | 'label' | 'color' | 'variant'> {
   /**
-   * The icon displayed in the button.
+   * The icon displayed in the button. Set to `false` to hide the icon.
    * @defaultValue appConfig.ui.icons.search
    * @IconifyIcon
    */
-  icon?: IconProps['name']
+  icon?: IconProps['name'] | false
   /**
    * The label displayed in the button.
    * @defaultValue t('contentSearchButton.label')
@@ -96,7 +96,7 @@ const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.contentSearc
 <template>
   <DefineButtonTemplate>
     <UButton
-      :icon="props.icon || appConfig.ui.icons.search"
+      :icon="props.icon === false ? undefined : (props.icon ?? appConfig.ui.icons.search)"
       :label="props.label || t('contentSearchButton.label')"
       :variant="props.variant || (props.collapsed ? 'ghost' : 'outline')"
       v-bind="{

--- a/test/components/ChatPromptSubmit.spec.ts
+++ b/test/components/ChatPromptSubmit.spec.ts
@@ -58,6 +58,14 @@ describe('ChatPromptSubmit', () => {
     expect(wrapper.find('button').attributes('disabled')).toBeUndefined()
   })
 
+  it('hides the icon when icon is false', async () => {
+    const withIcon = await mountSuspended(ChatPromptSubmit)
+    expect(withIcon.find('[data-slot="leadingIcon"]').exists()).toBe(true)
+
+    const withoutIcon = await mountSuspended(ChatPromptSubmit, { props: { icon: false } })
+    expect(withoutIcon.find('[data-slot="leadingIcon"]').exists()).toBe(false)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(ChatPromptSubmit, {
       props: {

--- a/test/components/CommandPalette.spec.ts
+++ b/test/components/CommandPalette.spec.ts
@@ -146,6 +146,14 @@ describe('CommandPalette', () => {
     ['with footer slot', { props, slots: { footer: () => 'Footer slot' } }]
   ])
 
+  it('hides the input icon when icon is false', async () => {
+    const withIcon = await mountSuspended(CommandPalette, { props })
+    expect(withIcon.find('[data-slot="leadingIcon"]').exists()).toBe(true)
+
+    const withoutIcon = await mountSuspended(CommandPalette, { props: { ...props, icon: false } })
+    expect(withoutIcon.find('[data-slot="leadingIcon"]').exists()).toBe(false)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(CommandPalette, {
       props: {

--- a/test/components/DashboardSearchButton.spec.ts
+++ b/test/components/DashboardSearchButton.spec.ts
@@ -14,6 +14,14 @@ describe('DashboardSearchButton', () => {
     ['with class', { props: { class: 'w-full' } }]
   ])
 
+  it('hides the icon when icon is false', async () => {
+    const withIcon = await mountSuspended(DashboardSearchButton)
+    expect(withIcon.find('[data-slot="leadingIcon"]').exists()).toBe(true)
+
+    const withoutIcon = await mountSuspended(DashboardSearchButton, { props: { icon: false } })
+    expect(withoutIcon.find('[data-slot="leadingIcon"]').exists()).toBe(false)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(DashboardSearchButton, {
       props: {

--- a/test/components/FileUpload.spec.ts
+++ b/test/components/FileUpload.spec.ts
@@ -92,6 +92,22 @@ describe('FileUpload', () => {
     ['with file-trailing slot', { props, slots: { 'file-trailing': () => 'File trailing slot' } }]
   ])
 
+  it('hides the icon when icon is false', async () => {
+    const withIcon = await mountSuspended(FileUpload)
+    expect(withIcon.find('[data-slot="icon"]').exists()).toBe(true)
+
+    const withoutIcon = await mountSuspended(FileUpload, { props: { icon: false } })
+    expect(withoutIcon.find('[data-slot="icon"]').exists()).toBe(false)
+  })
+
+  it('hides the icon when icon is false with variant button', async () => {
+    const withIcon = await mountSuspended(FileUpload, { props: { variant: 'button' } })
+    expect(withIcon.find('[data-slot="icon"]').exists()).toBe(true)
+
+    const withoutIcon = await mountSuspended(FileUpload, { props: { variant: 'button', icon: false } })
+    expect(withoutIcon.find('[data-slot="icon"]').exists()).toBe(false)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(FileUpload, {
       props: {

--- a/test/components/content/ContentSearchButton.spec.ts
+++ b/test/components/content/ContentSearchButton.spec.ts
@@ -1,4 +1,5 @@
-import { describe } from 'vitest'
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
 import ContentSearchButton from '../../../src/runtime/components/content/ContentSearchButton.vue'
 import { renderEach } from '../../component-render'
 
@@ -11,4 +12,12 @@ describe('DashboardSearchButton', () => {
     ['without collapsed', { props: { collapsed: false } }],
     ['with class', { props: { class: 'w-full' } }]
   ])
+
+  it('hides the icon when icon is false', async () => {
+    const withIcon = await mountSuspended(ContentSearchButton, { props: { collapsed: false } })
+    expect(withIcon.find('[data-slot="leadingIcon"]').exists()).toBe(true)
+
+    const withoutIcon = await mountSuspended(ContentSearchButton, { props: { collapsed: false, icon: false } })
+    expect(withoutIcon.find('[data-slot="leadingIcon"]').exists()).toBe(false)
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- N/A -->

### 📚 Description

Passing `:icon="false"` previously fell back to the default icon because the components resolved the icon with `props.icon || appConfig.ui.icons.*`, so any falsy value (`false`, `undefined`) was swallowed.

This makes `false` an explicit "no icon" signal across the components that expose a primary, decorative `icon` prop:

- `DashboardSearchButton`
- `ContentSearchButton`
- `CommandPalette` (input icon)
- `FileUpload` (button/area icon)
- `ChatPromptSubmit` (`ready` status icon)

The icon type is widened to `IconProps['name'] | false`, and the default is now applied with `??` so it only kicks in when `icon` is `undefined`. `FileUpload` additionally guards both render branches with `v-if`, since `UAvatar` renders its own fallback icon when given an empty value.

Structural icons (`closeIcon`, `clearIcon`, chevrons, the `Checkbox` check mark, select leading/trailing icons, etc.) are intentionally left untouched: their fallback is required for the component to function.