### PR TITLE
feat(FormField): add error and help icons

### DIFF
--- a/docs/content/docs/2.components/form-field.md
+++ b/docs/content/docs/2.components/form-field.md
@@ -116,9 +116,9 @@ slots:
 :u-input{placeholder="Enter your email" class="w-full"}
 ::
 
-### Help icon :badge{label="Soon" class="align-text-top"}
+### Help icon
 
-Use the `help-icon` prop to display an icon next to the help message. Use the `#help-leading` slot to customize the icon.
+Use the `help-icon` prop to display an icon next to the help message.
 
 ::component-code
 ---
@@ -161,9 +161,9 @@ slots:
 :u-input{placeholder="Enter your email" class="w-full"}
 ::
 
-### Error icon :badge{label="Soon" class="align-text-top"}
+### Error icon
 
-Use the `error-icon` prop to display an icon next to the error message. Use the `#error-leading` slot to customize the icon.
+Use the `error-icon` prop to display an icon next to the error message.
 
 ::component-code
 ---
@@ -181,10 +181,6 @@ slots:
 ---
 
 :u-input{placeholder="Enter your email" class="w-full"}
-::
-
-::tip{to="/docs/getting-started/theme/design-system#colors"}
-This sets the `color` to `error` on the form control. You can change it globally in your `app.config.ts`.
 ::
 
 ### Error pattern

--- a/docs/content/docs/2.components/form-field.md
+++ b/docs/content/docs/2.components/form-field.md
@@ -116,6 +116,28 @@ slots:
 :u-input{placeholder="Enter your email" class="w-full"}
 ::
 
+### Help icon :badge{label="Soon" class="align-text-top"}
+
+Use the `help-icon` prop to display an icon next to the help message. Use the `#help-leading` slot to customize the icon.
+
+::component-code
+---
+prettier: true
+ignore:
+  - label
+props:
+  label: Email
+  help: Please enter a valid email address.
+  helpIcon: i-lucide-info
+slots:
+  default: |
+
+    <UInput placeholder="Enter your email" class="w-full" />
+---
+
+:u-input{placeholder="Enter your email" class="w-full"}
+::
+
 ### Error
 
 Use the `error` prop to display an error message below the form control. When used together with the `help` prop, the `error` prop takes precedence.
@@ -130,6 +152,28 @@ ignore:
 props:
   label: Email
   error: Please enter a valid email address.
+slots:
+  default: |
+
+    <UInput placeholder="Enter your email" class="w-full" />
+---
+
+:u-input{placeholder="Enter your email" class="w-full"}
+::
+
+### Error icon :badge{label="Soon" class="align-text-top"}
+
+Use the `error-icon` prop to display an icon next to the error message. Use the `#error-leading` slot to customize the icon.
+
+::component-code
+---
+prettier: true
+ignore:
+  - label
+props:
+  label: Email
+  error: Please enter a valid email address.
+  errorIcon: i-lucide-circle-alert
 slots:
   default: |
 

--- a/playgrounds/nuxt/app/pages/components/form-field.vue
+++ b/playgrounds/nuxt/app/pages/components/form-field.vue
@@ -14,8 +14,10 @@ const feedbacks = [
   { required: true },
   { description: 'This is a description' },
   { error: 'This is an error' },
+  { error: 'This is an error', errorIcon: 'i-lucide-circle-alert' },
   { hint: 'This is a hint' },
-  { help: 'Help! I need somebody!' }
+  { help: 'Help! I need somebody!' },
+  { help: 'Help! I need somebody!', helpIcon: 'i-lucide-info' }
 ]
 </script>
 

--- a/src/runtime/components/FormField.vue
+++ b/src/runtime/components/FormField.vue
@@ -151,7 +151,7 @@ provide(formFieldInjectionKey, computed(() => ({
     <div :class="[(props.label || !!slots.label || props.description || !!slots.description) && ui.container({ class: props.ui?.container })]">
       <slot :error="error" />
       <div v-if="props.error !== false && ((typeof error === 'string' && error) || !!slots.error)" :id="`${ariaId}-error`" data-slot="error" :class="ui.error({ class: props.ui?.error })">
-        <span v-if="props.errorIcon || !!slots.errorLeading" data-slot="errorLeading" :class="ui.errorLeading({ class: props.ui?.errorLeading })" aria-hidden="true">
+        <span v-if="props.errorIcon || !!slots.errorLeading" data-slot="errorLeading" :class="ui.errorLeading({ class: props.ui?.errorLeading })">
           <slot name="errorLeading" :error="error" :ui="ui">
             <UIcon v-if="props.errorIcon" :name="props.errorIcon" data-slot="errorIcon" :class="ui.errorIcon({ class: props.ui?.errorIcon })" />
           </slot>
@@ -161,7 +161,7 @@ provide(formFieldInjectionKey, computed(() => ({
         </slot>
       </div>
       <div v-else-if="props.help || !!slots.help" :id="`${ariaId}-help`" data-slot="help" :class="ui.help({ class: props.ui?.help })">
-        <span v-if="props.helpIcon || !!slots.helpLeading" data-slot="helpLeading" :class="ui.helpLeading({ class: props.ui?.helpLeading })" aria-hidden="true">
+        <span v-if="props.helpIcon || !!slots.helpLeading" data-slot="helpLeading" :class="ui.helpLeading({ class: props.ui?.helpLeading })">
           <slot name="helpLeading" :help="props.help" :ui="ui">
             <UIcon v-if="props.helpIcon" :name="props.helpIcon" data-slot="helpIcon" :class="ui.helpIcon({ class: props.ui?.helpIcon })" />
           </slot>

--- a/src/runtime/components/FormField.vue
+++ b/src/runtime/components/FormField.vue
@@ -2,6 +2,7 @@
 import type { Ref, VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/form-field'
+import type { IconProps } from '../types'
 import type { ComponentConfig } from '../types/tv'
 
 type FormField = ComponentConfig<typeof theme, AppConfig, 'formField'>
@@ -19,7 +20,17 @@ export interface FormFieldProps {
   label?: string
   description?: string
   help?: string
+  /**
+   * The icon displayed next to the help message.
+   * @IconifyIcon
+   */
+  helpIcon?: IconProps['name']
   error?: boolean | string
+  /**
+   * The icon displayed next to the error message.
+   * @IconifyIcon
+   */
+  errorIcon?: IconProps['name']
   hint?: string
   /**
    * @defaultValue 'md'
@@ -47,7 +58,9 @@ export interface FormFieldSlots {
   hint?(props: { hint: string | undefined }): VNode[]
   description?(props: { description: string | undefined }): VNode[]
   help?(props: { help: string | undefined }): VNode[]
+  helpLeading?(props: { help: string | undefined, ui: FormField['ui'] }): VNode[]
   error?(props: { error: string | true | undefined }): VNode[]
+  errorLeading?(props: { error: string | true | undefined, ui: FormField['ui'] }): VNode[]
   default?(props: { error: string | true | undefined }): VNode[]
 }
 </script>
@@ -60,6 +73,7 @@ import { useComponentProps } from '../composables/useComponentProps'
 import { formFieldInjectionKey, inputIdInjectionKey, formErrorsInjectionKey, formInputsInjectionKey } from '../composables/useFormField'
 import { tv } from '../utils/tv'
 import type { FormError, FormFieldInjectedOptions } from '../types/form'
+import UIcon from './Icon.vue'
 
 const _props = withDefaults(defineProps<FormFieldProps>(), {
   error: undefined,
@@ -137,11 +151,21 @@ provide(formFieldInjectionKey, computed(() => ({
     <div :class="[(props.label || !!slots.label || props.description || !!slots.description) && ui.container({ class: props.ui?.container })]">
       <slot :error="error" />
       <div v-if="props.error !== false && ((typeof error === 'string' && error) || !!slots.error)" :id="`${ariaId}-error`" data-slot="error" :class="ui.error({ class: props.ui?.error })">
+        <span v-if="props.errorIcon || !!slots.errorLeading" data-slot="errorLeading" :class="ui.errorLeading({ class: props.ui?.errorLeading })" aria-hidden="true">
+          <slot name="errorLeading" :error="error" :ui="ui">
+            <UIcon v-if="props.errorIcon" :name="props.errorIcon" data-slot="errorIcon" :class="ui.errorIcon({ class: props.ui?.errorIcon })" />
+          </slot>
+        </span>
         <slot name="error" :error="error">
           {{ error }}
         </slot>
       </div>
       <div v-else-if="props.help || !!slots.help" :id="`${ariaId}-help`" data-slot="help" :class="ui.help({ class: props.ui?.help })">
+        <span v-if="props.helpIcon || !!slots.helpLeading" data-slot="helpLeading" :class="ui.helpLeading({ class: props.ui?.helpLeading })" aria-hidden="true">
+          <slot name="helpLeading" :help="props.help" :ui="ui">
+            <UIcon v-if="props.helpIcon" :name="props.helpIcon" data-slot="helpIcon" :class="ui.helpIcon({ class: props.ui?.helpIcon })" />
+          </slot>
+        </span>
         <slot name="help" :help="props.help">
           {{ props.help }}
         </slot>

--- a/src/theme/form-field.ts
+++ b/src/theme/form-field.ts
@@ -6,9 +6,13 @@ export default {
     label: 'block font-medium text-default',
     container: 'relative',
     description: 'text-muted',
-    error: 'mt-2 text-error',
+    error: 'mt-2 flex items-start gap-1.5 text-error',
+    errorLeading: 'inline-flex shrink-0 items-center h-lh',
+    errorIcon: 'size-4',
     hint: 'text-muted',
-    help: 'mt-2 text-muted'
+    help: 'mt-2 flex items-start gap-1.5 text-muted',
+    helpLeading: 'inline-flex shrink-0 items-center h-lh',
+    helpIcon: 'size-4'
   },
   variants: {
     size: {

--- a/test/components/FormField.spec.ts
+++ b/test/components/FormField.spec.ts
@@ -68,7 +68,9 @@ describe('FormField', () => {
     ['with label and description', { props: { label: 'Username', description: 'Enter your username' } }],
     ['with required', { props: { label: 'Username', required: true } }],
     ['with help', { props: { help: 'Username must be unique' } }],
+    ['with help icon', { props: { help: 'Username must be unique', helpIcon: 'i-lucide-info' } }],
     ['with error', { props: { error: 'Username is already taken' } }],
+    ['with error icon', { props: { error: 'Username is already taken', errorIcon: 'i-lucide-circle-alert' } }],
     ['with hint', { props: { hint: 'Use letters, numbers, and special characters' } }],
     ...sizes.map((size: string) => [`with size ${size}`, { props: { label: 'Username', description: 'Enter your username', size } }]),
     ...orientations.map((orientation: string) => [`with orientation ${orientation}`, { props: { label: 'Username', description: 'Enter your username', orientation } }]),
@@ -81,7 +83,9 @@ describe('FormField', () => {
     ['with description slot', { slots: { description: () => 'Description slot' } }],
     ['with error slot', { slots: { error: () => 'Error slot' } }],
     ['with hint slot', { slots: { hint: () => 'Hint slot' } }],
-    ['with help slot', { slots: { help: () => 'Help slot' } }]
+    ['with help slot', { slots: { help: () => 'Help slot' } }],
+    ['with help leading slot', { props: { help: 'Username must be unique' }, slots: { helpLeading: () => 'Help icon slot' } }],
+    ['with error leading slot', { props: { error: 'Username is already taken' }, slots: { errorLeading: () => 'Error icon slot' } }]
   ])
 
   it('passes accessibility tests', async () => {

--- a/test/components/__snapshots__/AuthForm-vue.spec.ts.snap
+++ b/test/components/__snapshots__/AuthForm-vue.spec.ts.snap
@@ -19,7 +19,9 @@ exports[`AuthForm > renders with as correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -65,7 +67,9 @@ exports[`AuthForm > renders with class correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -115,7 +119,9 @@ exports[`AuthForm > renders with description correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -165,7 +171,9 @@ exports[`AuthForm > renders with description slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -211,7 +219,9 @@ exports[`AuthForm > renders with disabled correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -257,7 +267,9 @@ exports[`AuthForm > renders with fields correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -303,7 +315,9 @@ exports[`AuthForm > renders with footer slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -349,7 +363,9 @@ exports[`AuthForm > renders with header slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -399,7 +415,9 @@ exports[`AuthForm > renders with icon correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -449,7 +467,9 @@ exports[`AuthForm > renders with leading slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -495,7 +515,9 @@ exports[`AuthForm > renders with loading correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -549,7 +571,9 @@ exports[`AuthForm > renders with providers correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -595,7 +619,9 @@ exports[`AuthForm > renders with providers slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -641,7 +667,9 @@ exports[`AuthForm > renders with separator correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -687,7 +715,9 @@ exports[`AuthForm > renders with submit correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -733,7 +763,9 @@ exports[`AuthForm > renders with submit slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -780,7 +812,9 @@ exports[`AuthForm > renders with title correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -830,7 +864,9 @@ exports[`AuthForm > renders with title slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -876,7 +912,9 @@ exports[`AuthForm > renders with ui correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -922,7 +960,9 @@ exports[`AuthForm > renders with validation slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">

--- a/test/components/__snapshots__/AuthForm.spec.ts.snap
+++ b/test/components/__snapshots__/AuthForm.spec.ts.snap
@@ -19,7 +19,9 @@ exports[`AuthForm > renders with as correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -67,7 +69,9 @@ exports[`AuthForm > renders with class correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -119,7 +123,9 @@ exports[`AuthForm > renders with description correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -171,7 +177,9 @@ exports[`AuthForm > renders with description slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -219,7 +227,9 @@ exports[`AuthForm > renders with disabled correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -267,7 +277,9 @@ exports[`AuthForm > renders with fields correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -315,7 +327,9 @@ exports[`AuthForm > renders with footer slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -363,7 +377,9 @@ exports[`AuthForm > renders with header slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -415,7 +431,9 @@ exports[`AuthForm > renders with icon correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -467,7 +485,9 @@ exports[`AuthForm > renders with leading slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -515,7 +535,9 @@ exports[`AuthForm > renders with loading correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -571,7 +593,9 @@ exports[`AuthForm > renders with providers correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -619,7 +643,9 @@ exports[`AuthForm > renders with providers slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -667,7 +693,9 @@ exports[`AuthForm > renders with separator correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -715,7 +743,9 @@ exports[`AuthForm > renders with submit correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -763,7 +793,9 @@ exports[`AuthForm > renders with submit slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -812,7 +844,9 @@ exports[`AuthForm > renders with title correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -864,7 +898,9 @@ exports[`AuthForm > renders with title slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -912,7 +948,9 @@ exports[`AuthForm > renders with ui correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">
@@ -960,7 +998,9 @@ exports[`AuthForm > renders with validation slot correctly 1`] = `
             <!--v-if-->
             <!--v-if-->
           </div>
-          <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Invalid email format</div>
+          <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+            <!--v-if-->Invalid email format
+          </div>
         </div>
       </div>
       <div data-orientation="vertical" data-slot="root" class="text-sm">

--- a/test/components/__snapshots__/Form-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Form-vue.spec.ts.snap
@@ -25,7 +25,9 @@ exports[`Form > custom validation works > with error 1`] = `
         <!--v-if-->
         <!--v-if-->
       </div>
-      <div id="v-1-error" data-slot="error" class="mt-2 text-error">Must be at least 8 characters</div>
+      <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+        <!--v-if-->Must be at least 8 characters
+      </div>
     </div>
   </div>
 </form>"
@@ -87,7 +89,9 @@ exports[`Form > joi validation works > with error 1`] = `
         <!--v-if-->
         <!--v-if-->
       </div>
-      <div id="v-1-error" data-slot="error" class="mt-2 text-error">Must be at least 8 characters</div>
+      <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+        <!--v-if-->Must be at least 8 characters
+      </div>
     </div>
   </div>
 </form>"
@@ -165,7 +169,9 @@ exports[`Form > superstruct validation works > with error 1`] = `
         <!--v-if-->
         <!--v-if-->
       </div>
-      <div id="v-1-error" data-slot="error" class="mt-2 text-error">Must be at least 8 characters</div>
+      <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+        <!--v-if-->Must be at least 8 characters
+      </div>
     </div>
   </div>
 </form>"
@@ -227,7 +233,9 @@ exports[`Form > valibot validation works > with error 1`] = `
         <!--v-if-->
         <!--v-if-->
       </div>
-      <div id="v-1-error" data-slot="error" class="mt-2 text-error">Must be at least 8 characters</div>
+      <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+        <!--v-if-->Must be at least 8 characters
+      </div>
     </div>
   </div>
 </form>"
@@ -289,7 +297,9 @@ exports[`Form > yup validation works > with error 1`] = `
         <!--v-if-->
         <!--v-if-->
       </div>
-      <div id="v-1-error" data-slot="error" class="mt-2 text-error">Must be at least 8 characters</div>
+      <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+        <!--v-if-->Must be at least 8 characters
+      </div>
     </div>
   </div>
 </form>"
@@ -351,7 +361,9 @@ exports[`Form > zod validation works > with error 1`] = `
         <!--v-if-->
         <!--v-if-->
       </div>
-      <div id="v-1-error" data-slot="error" class="mt-2 text-error">Must be at least 8 characters</div>
+      <div id="v-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+        <!--v-if-->Must be at least 8 characters
+      </div>
     </div>
   </div>
 </form>"

--- a/test/components/__snapshots__/Form.spec.ts.snap
+++ b/test/components/__snapshots__/Form.spec.ts.snap
@@ -25,7 +25,9 @@ exports[`Form > custom validation works > with error 1`] = `
         <!--v-if-->
         <!--v-if-->
       </div>
-      <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Must be at least 8 characters</div>
+      <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+        <!--v-if-->Must be at least 8 characters
+      </div>
     </div>
   </div>
 </form>"
@@ -87,7 +89,9 @@ exports[`Form > joi validation works > with error 1`] = `
         <!--v-if-->
         <!--v-if-->
       </div>
-      <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Must be at least 8 characters</div>
+      <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+        <!--v-if-->Must be at least 8 characters
+      </div>
     </div>
   </div>
 </form>"
@@ -165,7 +169,9 @@ exports[`Form > superstruct validation works > with error 1`] = `
         <!--v-if-->
         <!--v-if-->
       </div>
-      <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Must be at least 8 characters</div>
+      <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+        <!--v-if-->Must be at least 8 characters
+      </div>
     </div>
   </div>
 </form>"
@@ -227,7 +233,9 @@ exports[`Form > valibot validation works > with error 1`] = `
         <!--v-if-->
         <!--v-if-->
       </div>
-      <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Must be at least 8 characters</div>
+      <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+        <!--v-if-->Must be at least 8 characters
+      </div>
     </div>
   </div>
 </form>"
@@ -289,7 +297,9 @@ exports[`Form > yup validation works > with error 1`] = `
         <!--v-if-->
         <!--v-if-->
       </div>
-      <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Must be at least 8 characters</div>
+      <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+        <!--v-if-->Must be at least 8 characters
+      </div>
     </div>
   </div>
 </form>"
@@ -351,7 +361,9 @@ exports[`Form > zod validation works > with error 1`] = `
         <!--v-if-->
         <!--v-if-->
       </div>
-      <div id="v-0-0-1-error" data-slot="error" class="mt-2 text-error">Must be at least 8 characters</div>
+      <div id="v-0-0-1-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+        <!--v-if-->Must be at least 8 characters
+      </div>
     </div>
   </div>
 </form>"

--- a/test/components/__snapshots__/FormField-vue.spec.ts.snap
+++ b/test/components/__snapshots__/FormField-vue.spec.ts.snap
@@ -55,7 +55,33 @@ exports[`FormField > renders with error correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-error" data-slot="error" class="mt-2 text-error">Username is already taken</div>
+    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+      <!--v-if-->Username is already taken
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`FormField > renders with error icon correctly 1`] = `
+"<div data-orientation="vertical" data-slot="root" class="text-sm">
+  <div data-slot="wrapper" class="">
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <div class="">
+    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error"><span data-slot="errorLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="errorIcon" class="size-4"></svg></span>Username is already taken</div>
+  </div>
+</div>"
+`;
+
+exports[`FormField > renders with error leading slot correctly 1`] = `
+"<div data-orientation="vertical" data-slot="root" class="text-sm">
+  <div data-slot="wrapper" class="">
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <div class="">
+    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error"><span data-slot="errorLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true">Error icon slot</span>Username is already taken</div>
   </div>
 </div>"
 `;
@@ -67,7 +93,9 @@ exports[`FormField > renders with error slot correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-error" data-slot="error" class="mt-2 text-error">Error slot</div>
+    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+      <!--v-if-->Error slot
+    </div>
   </div>
 </div>"
 `;
@@ -79,7 +107,33 @@ exports[`FormField > renders with help correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-help" data-slot="help" class="mt-2 text-muted">Username must be unique</div>
+    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted">
+      <!--v-if-->Username must be unique
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`FormField > renders with help icon correctly 1`] = `
+"<div data-orientation="vertical" data-slot="root" class="text-sm">
+  <div data-slot="wrapper" class="">
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <div class="">
+    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted"><span data-slot="helpLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="helpIcon" class="size-4"></svg></span>Username must be unique</div>
+  </div>
+</div>"
+`;
+
+exports[`FormField > renders with help leading slot correctly 1`] = `
+"<div data-orientation="vertical" data-slot="root" class="text-sm">
+  <div data-slot="wrapper" class="">
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <div class="">
+    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted"><span data-slot="helpLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true">Help icon slot</span>Username must be unique</div>
   </div>
 </div>"
 `;
@@ -91,7 +145,9 @@ exports[`FormField > renders with help slot correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-help" data-slot="help" class="mt-2 text-muted">Help slot</div>
+    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted">
+      <!--v-if-->Help slot
+    </div>
   </div>
 </div>"
 `;

--- a/test/components/__snapshots__/FormField-vue.spec.ts.snap
+++ b/test/components/__snapshots__/FormField-vue.spec.ts.snap
@@ -69,7 +69,7 @@ exports[`FormField > renders with error icon correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error"><span data-slot="errorLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="errorIcon" class="size-4"></svg></span>Username is already taken</div>
+    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error"><span data-slot="errorLeading" class="inline-flex shrink-0 items-center h-lh"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="errorIcon" class="size-4"></svg></span>Username is already taken</div>
   </div>
 </div>"
 `;
@@ -81,7 +81,7 @@ exports[`FormField > renders with error leading slot correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error"><span data-slot="errorLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true">Error icon slot</span>Username is already taken</div>
+    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error"><span data-slot="errorLeading" class="inline-flex shrink-0 items-center h-lh">Error icon slot</span>Username is already taken</div>
   </div>
 </div>"
 `;
@@ -121,7 +121,7 @@ exports[`FormField > renders with help icon correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted"><span data-slot="helpLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="helpIcon" class="size-4"></svg></span>Username must be unique</div>
+    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted"><span data-slot="helpLeading" class="inline-flex shrink-0 items-center h-lh"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="helpIcon" class="size-4"></svg></span>Username must be unique</div>
   </div>
 </div>"
 `;
@@ -133,7 +133,7 @@ exports[`FormField > renders with help leading slot correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted"><span data-slot="helpLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true">Help icon slot</span>Username must be unique</div>
+    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted"><span data-slot="helpLeading" class="inline-flex shrink-0 items-center h-lh">Help icon slot</span>Username must be unique</div>
   </div>
 </div>"
 `;

--- a/test/components/__snapshots__/FormField.spec.ts.snap
+++ b/test/components/__snapshots__/FormField.spec.ts.snap
@@ -55,7 +55,33 @@ exports[`FormField > renders with error correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-error" data-slot="error" class="mt-2 text-error">Username is already taken</div>
+    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+      <!--v-if-->Username is already taken
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`FormField > renders with error icon correctly 1`] = `
+"<div data-orientation="vertical" data-slot="root" class="text-sm">
+  <div data-slot="wrapper" class="">
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <div class="">
+    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error"><span data-slot="errorLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true"><span class="iconify i-lucide:circle-alert size-4" aria-hidden="true" data-slot="errorIcon"></span></span>Username is already taken</div>
+  </div>
+</div>"
+`;
+
+exports[`FormField > renders with error leading slot correctly 1`] = `
+"<div data-orientation="vertical" data-slot="root" class="text-sm">
+  <div data-slot="wrapper" class="">
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <div class="">
+    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error"><span data-slot="errorLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true">Error icon slot</span>Username is already taken</div>
   </div>
 </div>"
 `;
@@ -67,7 +93,9 @@ exports[`FormField > renders with error slot correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-error" data-slot="error" class="mt-2 text-error">Error slot</div>
+    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error">
+      <!--v-if-->Error slot
+    </div>
   </div>
 </div>"
 `;
@@ -79,7 +107,33 @@ exports[`FormField > renders with help correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-help" data-slot="help" class="mt-2 text-muted">Username must be unique</div>
+    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted">
+      <!--v-if-->Username must be unique
+    </div>
+  </div>
+</div>"
+`;
+
+exports[`FormField > renders with help icon correctly 1`] = `
+"<div data-orientation="vertical" data-slot="root" class="text-sm">
+  <div data-slot="wrapper" class="">
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <div class="">
+    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted"><span data-slot="helpLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true"><span class="iconify i-lucide:info size-4" aria-hidden="true" data-slot="helpIcon"></span></span>Username must be unique</div>
+  </div>
+</div>"
+`;
+
+exports[`FormField > renders with help leading slot correctly 1`] = `
+"<div data-orientation="vertical" data-slot="root" class="text-sm">
+  <div data-slot="wrapper" class="">
+    <!--v-if-->
+    <!--v-if-->
+  </div>
+  <div class="">
+    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted"><span data-slot="helpLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true">Help icon slot</span>Username must be unique</div>
   </div>
 </div>"
 `;
@@ -91,7 +145,9 @@ exports[`FormField > renders with help slot correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-help" data-slot="help" class="mt-2 text-muted">Help slot</div>
+    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted">
+      <!--v-if-->Help slot
+    </div>
   </div>
 </div>"
 `;

--- a/test/components/__snapshots__/FormField.spec.ts.snap
+++ b/test/components/__snapshots__/FormField.spec.ts.snap
@@ -69,7 +69,7 @@ exports[`FormField > renders with error icon correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error"><span data-slot="errorLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true"><span class="iconify i-lucide:circle-alert size-4" aria-hidden="true" data-slot="errorIcon"></span></span>Username is already taken</div>
+    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error"><span data-slot="errorLeading" class="inline-flex shrink-0 items-center h-lh"><span class="iconify i-lucide:circle-alert size-4" aria-hidden="true" data-slot="errorIcon"></span></span>Username is already taken</div>
   </div>
 </div>"
 `;
@@ -81,7 +81,7 @@ exports[`FormField > renders with error leading slot correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error"><span data-slot="errorLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true">Error icon slot</span>Username is already taken</div>
+    <div id="v-0-0-error" data-slot="error" class="mt-2 flex items-start gap-1.5 text-error"><span data-slot="errorLeading" class="inline-flex shrink-0 items-center h-lh">Error icon slot</span>Username is already taken</div>
   </div>
 </div>"
 `;
@@ -121,7 +121,7 @@ exports[`FormField > renders with help icon correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted"><span data-slot="helpLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true"><span class="iconify i-lucide:info size-4" aria-hidden="true" data-slot="helpIcon"></span></span>Username must be unique</div>
+    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted"><span data-slot="helpLeading" class="inline-flex shrink-0 items-center h-lh"><span class="iconify i-lucide:info size-4" aria-hidden="true" data-slot="helpIcon"></span></span>Username must be unique</div>
   </div>
 </div>"
 `;
@@ -133,7 +133,7 @@ exports[`FormField > renders with help leading slot correctly 1`] = `
     <!--v-if-->
   </div>
   <div class="">
-    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted"><span data-slot="helpLeading" class="inline-flex shrink-0 items-center h-lh" aria-hidden="true">Help icon slot</span>Username must be unique</div>
+    <div id="v-0-0-help" data-slot="help" class="mt-2 flex items-start gap-1.5 text-muted"><span data-slot="helpLeading" class="inline-flex shrink-0 items-center h-lh">Help icon slot</span>Username must be unique</div>
   </div>
 </div>"
 `;


### PR DESCRIPTION
### 🔗 Linked issue

No linked issue.

### ❓ Type of change

- [x] ✨ New feature (a non-breaking change that adds functionality)

### 📚 Description

Adds optional `error-icon` and `help-icon` props to `FormField`, along with `#error-leading` and `#help-leading` slots for custom rendering.

Icons are opt-in and marked `aria-hidden` since the adjacent text already conveys the message. Theme slots handle layout and styling.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
- [x] The component is available in the playground.
- [x] I have added tests to cover this component.

<img width="536" height="774" alt="Screenshot 2026-06-18 at 10 00 58" src="https://github.com/user-attachments/assets/45980169-581b-49e0-82fb-fc2a62e8c67b" />
