### PR TITLE
feat(NavigationMenu): support chip on horizontal children

### DIFF
--- a/docs/content/docs/2.components/navigation-menu.md
+++ b/docs/content/docs/2.components/navigation-menu.md
@@ -125,7 +125,7 @@ Use the `items` prop as an array of objects with the following properties:
 - `onSelect?: (e: Event) => void`{lang="ts-type"}
 - `children?: NavigationMenuChildItem[]`{lang="ts-type"}
 - `class?: any`{lang="ts-type"}
-- `ui?: { linkLeadingAvatarSize?: ClassNameValue, linkLeadingAvatar?: ClassNameValue, linkLeadingIcon?: ClassNameValue, linkLeadingChipSize?: ClassNameValue, linkLabel?: ClassNameValue, linkLabelExternalIcon?: ClassNameValue, linkTrailing?: ClassNameValue, linkTrailingBadgeSize?: ClassNameValue, linkTrailingBadge?: ClassNameValue, linkTrailingIcon?: ClassNameValue, label?: ClassNameValue, link?: ClassNameValue, content?: ClassNameValue, childList?: ClassNameValue, childLabel?: ClassNameValue, childItem?: ClassNameValue, childLink?: ClassNameValue, childLinkIcon?: ClassNameValue, childLinkWrapper?: ClassNameValue, childLinkLabel?: ClassNameValue, childLinkLabelExternalIcon?: ClassNameValue, childLinkDescription?: ClassNameValue }`{lang="ts-type"}
+- `ui?: { linkLeadingAvatarSize?: ClassNameValue, linkLeadingAvatar?: ClassNameValue, linkLeadingIcon?: ClassNameValue, linkLeadingChipSize?: ClassNameValue, linkLabel?: ClassNameValue, linkLabelExternalIcon?: ClassNameValue, linkTrailing?: ClassNameValue, linkTrailingBadgeSize?: ClassNameValue, linkTrailingBadge?: ClassNameValue, linkTrailingIcon?: ClassNameValue, label?: ClassNameValue, link?: ClassNameValue, content?: ClassNameValue, childList?: ClassNameValue, childLabel?: ClassNameValue, childItem?: ClassNameValue, childLink?: ClassNameValue, childLinkIcon?: ClassNameValue, childLinkLeadingChipSize?: ClassNameValue, childLinkWrapper?: ClassNameValue, childLinkLabel?: ClassNameValue, childLinkLabelExternalIcon?: ClassNameValue, childLinkDescription?: ClassNameValue }`{lang="ts-type"}
 
 You can pass any property from the [Link](/docs/components/link#props) component such as `to`, `target`, etc.
 
@@ -1229,7 +1229,7 @@ You can use the `#content` slot to customize the content of the popover in the `
 
 ### With chip in items :badge{label="4.5+" class="align-text-top"}
 
-Use the `chip` property to display a [Chip](/docs/components/chip) around the icon of the items, you can pass any of its props.
+Use the `chip` property to display a [Chip](/docs/components/chip) around the icon of the items, you can pass any of its props. This also works on the children of an item.
 
 ::component-code
 ---
@@ -1266,6 +1266,40 @@ props:
       - label: Help
         icon: i-lucide-circle-help
         disabled: true
+---
+::
+
+In `horizontal` orientation, the `chip` property also works on the children displayed inside the content panel.
+
+::component-code
+---
+collapse: true
+ignore:
+  - items
+  - class
+external:
+  - items
+externalTypes:
+  - NavigationMenuItem[][]
+props:
+  orientation: 'horizontal'
+  items:
+    - label: Components
+      icon: i-lucide-box
+      children:
+        - label: Link
+          icon: i-lucide-link
+          description: Use NuxtLink with superpowers.
+          to: /docs/components/link
+          chip:
+            color: success
+        - label: Modal
+          icon: i-lucide-square
+          description: Display a modal dialog overlay for important content.
+          to: /docs/components/modal
+          chip:
+            color: info
+            text: 3
 ---
 ::
 

--- a/playgrounds/nuxt/app/pages/components/navigation-menu.vue
+++ b/playgrounds/nuxt/app/pages/components/navigation-menu.vue
@@ -31,7 +31,8 @@ const items = [
     children: [{
       label: 'Introduction',
       description: 'Fully styled and customizable components for Nuxt.',
-      icon: 'i-lucide-house'
+      icon: 'i-lucide-house',
+      chip: { color: 'success', text: 3 }
     }, {
       label: 'Installation',
       description: 'Learn how to install and configure Nuxt UI in your application.',

--- a/src/runtime/components/NavigationMenu.vue
+++ b/src/runtime/components/NavigationMenu.vue
@@ -66,7 +66,7 @@ export interface NavigationMenuItem extends Omit<LinkProps, 'type' | 'raw' | 'cu
   open?: boolean
   onSelect?: (e: Event) => void
   class?: any
-  ui?: Pick<NavigationMenu['slots'], 'item' | 'linkLeadingAvatarSize' | 'linkLeadingAvatar' | 'linkLeadingIcon' | 'linkLeadingChipSize' | 'linkLabel' | 'linkLabelExternalIcon' | 'linkTrailing' | 'linkTrailingBadgeSize' | 'linkTrailingBadge' | 'linkTrailingIcon' | 'label' | 'link' | 'content' | 'childList' | 'childLabel' | 'childItem' | 'childLink' | 'childLinkIcon' | 'childLinkWrapper' | 'childLinkLabel' | 'childLinkLabelExternalIcon' | 'childLinkDescription'>
+  ui?: Pick<NavigationMenu['slots'], 'item' | 'linkLeadingAvatarSize' | 'linkLeadingAvatar' | 'linkLeadingIcon' | 'linkLeadingChipSize' | 'linkLabel' | 'linkLabelExternalIcon' | 'linkTrailing' | 'linkTrailingBadgeSize' | 'linkTrailingBadge' | 'linkTrailingIcon' | 'label' | 'link' | 'content' | 'childList' | 'childLabel' | 'childItem' | 'childLink' | 'childLinkIcon' | 'childLinkLeadingChipSize' | 'childLinkWrapper' | 'childLinkLabel' | 'childLinkLabelExternalIcon' | 'childLinkDescription'>
   [key: string]: any
 }
 
@@ -465,7 +465,16 @@ function onLinkTrailingClick(e: Event, item: NavigationMenuItem) {
                 <ULink v-slot="{ active: childActive, ...childSlotProps }" v-bind="pickLinkProps(childItem)" custom>
                   <NavigationMenuLink as-child :active="childActive" @select="childItem.onSelect">
                     <ULinkBase v-bind="childSlotProps" data-slot="childLink" :class="ui.childLink({ class: [props.ui?.childLink, item.ui?.childLink, childItem.class], active: childActive })">
-                      <UIcon v-if="childItem.icon" :name="childItem.icon" data-slot="childLinkIcon" :class="ui.childLinkIcon({ class: [props.ui?.childLinkIcon, item.ui?.childLinkIcon], active: childActive })" />
+                      <UChip
+                        v-if="childItem.icon && childItem.chip"
+                        :size="((item.ui?.childLinkLeadingChipSize || props.ui?.childLinkLeadingChipSize || ui.childLinkLeadingChipSize()) as ChipProps['size'])"
+                        inset
+                        v-bind="typeof childItem.chip === 'object' ? childItem.chip : {}"
+                        data-slot="childLinkLeadingChip"
+                      >
+                        <UIcon :name="childItem.icon" data-slot="childLinkIcon" :class="ui.childLinkIcon({ class: [props.ui?.childLinkIcon, item.ui?.childLinkIcon], active: childActive })" />
+                      </UChip>
+                      <UIcon v-else-if="childItem.icon" :name="childItem.icon" data-slot="childLinkIcon" :class="ui.childLinkIcon({ class: [props.ui?.childLinkIcon, item.ui?.childLinkIcon], active: childActive })" />
 
                       <div data-slot="childLinkWrapper" :class="ui.childLinkWrapper({ class: [props.ui?.childLinkWrapper, item.ui?.childLinkWrapper] })">
                         <p data-slot="childLinkLabel" :class="ui.childLinkLabel({ class: [props.ui?.childLinkLabel, item.ui?.childLinkLabel], active: childActive })">

--- a/src/theme/navigation-menu.ts
+++ b/src/theme/navigation-menu.ts
@@ -23,6 +23,7 @@ export default (options: Required<ModuleOptions>) => ({
     childLink: 'group relative size-full flex items-start text-start text-sm before:absolute before:z-[-1] before:rounded-md focus:outline-none focus-visible:outline-none focus-visible:before:outline-3',
     childLinkWrapper: 'min-w-0',
     childLinkIcon: 'size-5 shrink-0',
+    childLinkLeadingChipSize: 'sm',
     childLinkLabel: 'truncate',
     childLinkLabelExternalIcon: 'inline-block size-3 align-top text-dimmed',
     childLinkDescription: 'text-muted',


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `chip` property only rendered on parent items and on children in `vertical`
orientation. Children displayed inside the `horizontal` content panel ignored it.

This wraps the child icon in a `UChip` when `chip` is set, matching the existing
behavior of parent items. A `childLinkLeadingChipSize` slot is added to control
the chip size, and the docs (new horizontal example) and playground are updated.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
