### PR TITLE
fix(LocaleSelect): add missing keys in emoji mapping

### DIFF
--- a/src/runtime/components/locale/LocaleSelect.vue
+++ b/src/runtime/components/locale/LocaleSelect.vue
@@ -36,10 +36,12 @@ function getEmojiFlag(locale: string): string {
     el: 'gr', // Greek -> Greece
     en: 'us', // English -> United States (default)
     et: 'ee', // Estonian -> Estonia
+    eu: 'es', // Basque -> Spain
     gl: 'es', // Galician -> Spain
     he: 'il', // Hebrew -> Israel
     hi: 'in', // Hindi -> India
     hy: 'am', // Armenian -> Armenia
+    is: 'is', // Icelandic -> Iceland
     ja: 'jp', // Japanese -> Japan
     ka: 'ge', // Georgian -> Georgia
     kk: 'kz', // Kazakh -> Kazakhstan
@@ -47,6 +49,7 @@ function getEmojiFlag(locale: string): string {
     ko: 'kr', // Korean -> South Korea
     ky: 'kg', // Kyrgyz -> Kyrgyzstan
     lb: 'lu', // Luxembourgish -> Luxembourg
+    lo: 'la', // Lao -> Laos
     ms: 'my', // Malay -> Malaysia
     nb: 'no', // Norwegian Bokmål -> Norway
     sl: 'si', // Slovenian -> Slovenia

--- a/src/runtime/components/locale/LocaleSelect.vue
+++ b/src/runtime/components/locale/LocaleSelect.vue
@@ -27,6 +27,7 @@ const modelValue = defineModel<string>({ required: true })
 function getEmojiFlag(locale: string): string {
   const languageToCountry: Record<string, string> = {
     ar: 'sa', // Arabic -> Saudi Arabia
+    be: 'by', // Belarusian -> Belarus
     bn: 'bd', // Bengali -> Bangladesh
     ca: 'es', // Catalan -> Spain
     ckb: 'iq', // Central Kurdish -> Iraq


### PR DESCRIPTION

| before | after |
|--------|--------|
| <img width="594" height="530" alt="CleanShot 2026-06-22 at 13 38 10@2x" src="https://github.com/user-attachments/assets/98af22d5-4416-45fa-a743-81ba32521a1c" /> | <img width="730" height="604" alt="CleanShot 2026-06-22 at 13 44 22@2x" src="https://github.com/user-attachments/assets/9a289967-3318-498a-8e99-4c72fa7baab0" /> | 


