### PR TITLE
fix(Link): fall back to original path when `localePath` fails

### DIFF
--- a/src/runtime/components/Link.vue
+++ b/src/runtime/components/Link.vue
@@ -181,7 +181,9 @@ const to = computed(() => {
     return path
   }
 
-  return localePath(path, typeof props.locale === 'string' ? props.locale : undefined)
+  const localizedPath = localePath(path, typeof props.locale === 'string' ? props.locale : undefined)
+
+  return localizedPath || path
 })
 
 const isInternalLink = computed(() => {

--- a/test/components/nuxt/LinkLocale.spec.ts
+++ b/test/components/nuxt/LinkLocale.spec.ts
@@ -1,0 +1,43 @@
+import { h, onUnmounted } from 'vue'
+import { describe, expect, it } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { useNuxtApp } from '#imports'
+import Link from '../../../src/runtime/components/Link.vue'
+import Button from '../../../src/runtime/components/Button.vue'
+
+function createLocalePathFallbackFixture(component: typeof Link | typeof Button) {
+  return {
+    setup() {
+      const nuxtApp = useNuxtApp() as ReturnType<typeof useNuxtApp>
+      const originalLocalePath = nuxtApp.$localePath
+
+      nuxtApp.$localePath = () => ''
+
+      onUnmounted(() => {
+        nuxtApp.$localePath = originalLocalePath
+      })
+
+      return () => h(component, { to: '/dashboard' }, () => 'Dashboard')
+    }
+  }
+}
+
+describe('Link locale fallback', () => {
+  it('falls back to the original internal path when localePath returns an empty string', async () => {
+    const wrapper = await mountSuspended(createLocalePathFallbackFixture(Link))
+
+    const link = wrapper.get('a')
+
+    expect(link.attributes('href')).toBe('/dashboard')
+    expect(link.text()).toContain('Dashboard')
+  })
+
+  it('keeps button links navigable when localePath cannot resolve the route', async () => {
+    const wrapper = await mountSuspended(createLocalePathFallbackFixture(Button))
+
+    const link = wrapper.get('a')
+
+    expect(link.attributes('href')).toBe('/dashboard')
+    expect(link.text()).toContain('Dashboard')
+  })
+})


### PR DESCRIPTION
## Summary

This fixes a regression where `ULink` and `UButton` can stop rendering navigable links when `@nuxtjs/i18n` is installed and `$localePath()` fails to resolve an internal path.

In that case, `Link.vue` currently resolves `to` to an empty string, which makes the component fall back to its button branch instead of preserving the original internal route.

This patch keeps the existing auto-localization behavior, but falls back to the original `path` when `localePath()` returns an empty string.

## Repro

With `@nuxtjs/i18n` installed:

```vue
<UButton to="/dashboard">Broken</UButton>
<ULink to="/dashboard">Broken</ULink>
<NuxtLink to="/dashboard">Works</NuxtLink>
<UButton to="/dashboard" :locale="false">Works</UButton>
```

The regression appears in the auto-localization path added in:
- `feat(Link): auto-localize internal links when @nuxtjs/i18n is installed` (`92cfda0f`)

## Changes

- keep using `$localePath()` for internal links
- if it returns a falsy value, fall back to the original internal `path`
- add a Nuxt regression test covering both `ULink` and `UButton`

## Validation

- `pnpm vitest --project nuxt test/components/nuxt/LinkLocale.spec.ts`
- `pnpm vitest test/components/Link.spec.ts test/components/Button.spec.ts test/components/nuxt/LinkLocale.spec.ts`
- `pnpm eslint src/runtime/components/Link.vue test/components/nuxt/LinkLocale.spec.ts`
