### PR TITLE
fix(AuthForm): track password visibility per field

### DIFF
--- a/src/runtime/components/AuthForm.vue
+++ b/src/runtime/components/AuthForm.vue
@@ -105,7 +105,7 @@ export type AuthFormSlots<T extends object = object, F extends AuthFormField = A
 </script>
 
 <script setup lang="ts" generic="T extends FormSchema, F extends AuthFormField">
-import { reactive, ref, computed, useTemplateRef } from 'vue'
+import { reactive, shallowReactive, computed, useTemplateRef } from 'vue'
 import { Primitive } from 'reka-ui'
 import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
@@ -154,8 +154,15 @@ const appConfig = useAppConfig() as AuthForm['AppConfig']
 const ui = computed(() => tv({ extend: tv(theme), ...(appConfig.ui?.authForm || {}) })())
 
 const formRef = useTemplateRef('formRef')
-const passwordVisibility = ref(false)
-const passwordRef = useTemplateRef('passwordRef')
+const passwordVisibility = reactive<Record<string, boolean>>(
+  (_props.fields as TypedAuthFormField[] || []).reduce<Record<string, boolean>>((acc, field) => {
+    if (field.type === 'password' && field.name) {
+      acc[field.name as string] = false
+    }
+    return acc
+  }, {})
+)
+const passwordRefs = shallowReactive<Record<string, { inputRef?: HTMLInputElement | null } | null>>({})
 
 function pickFieldProps(field: F) {
   const fields = ['name', 'errorPattern', 'help', 'error', 'hint', 'size', 'required', 'eagerValidation', 'validateOnInputDelay'] as (keyof F)[]
@@ -282,23 +289,23 @@ defineExpose({
             />
             <UInput
               v-else-if="field.type === 'password'"
-              ref="passwordRef"
+              :ref="(el: any) => { passwordRefs[field.name] = el }"
               v-model="state[field.name]"
               data-slot="password"
               :class="ui.password({ class: props.ui?.password })"
               v-bind="(omitFieldProps(field) as AuthFormInputField<'password'>)"
-              :type="passwordVisibility ? 'text' : 'password'"
+              :type="passwordVisibility[field.name] ? 'text' : 'password'"
             >
               <template #trailing>
                 <UButton
                   color="neutral"
                   variant="link"
                   size="sm"
-                  :icon="passwordVisibility ? appConfig.ui.icons.eyeOff : appConfig.ui.icons.eye"
-                  :aria-label="passwordVisibility ? t('authForm.hidePassword') : t('authForm.showPassword')"
-                  :aria-pressed="passwordVisibility"
-                  :aria-controls="passwordRef?.[0]?.inputRef?.id"
-                  @click="passwordVisibility = !passwordVisibility"
+                  :icon="passwordVisibility[field.name] ? appConfig.ui.icons.eyeOff : appConfig.ui.icons.eye"
+                  :aria-label="passwordVisibility[field.name] ? t('authForm.hidePassword') : t('authForm.showPassword')"
+                  :aria-pressed="!!passwordVisibility[field.name]"
+                  :aria-controls="passwordRefs[field.name]?.inputRef?.id"
+                  @click="passwordVisibility[field.name] = !passwordVisibility[field.name]"
                 />
               </template>
             </UInput>

--- a/test/components/AuthForm.spec.ts
+++ b/test/components/AuthForm.spec.ts
@@ -45,6 +45,36 @@ describe('AuthForm', () => {
     ['with footer slot', { props, slots: { footer: () => 'Footer' } }]
   ])
 
+  it('toggles password fields visibility independently', async () => {
+    const passwordFields = [{
+      name: 'password',
+      label: 'Password',
+      type: 'password' as const
+    }, {
+      name: 'password_confirmation',
+      label: 'Password confirmation',
+      type: 'password' as const
+    }] satisfies AuthFormProps['fields']
+
+    const wrapper = await mountSuspended(AuthForm, {
+      props: { fields: passwordFields }
+    })
+
+    const inputs = () => wrapper.findAll('input')
+    const toggles = wrapper.findAll('button[aria-label="Show password"]')
+    expect(toggles).toHaveLength(2)
+
+    // `aria-controls` points to its own input, not a shared one
+    expect(toggles[0]!.attributes('aria-controls')).toBe(inputs()[0]!.attributes('id'))
+    expect(toggles[1]!.attributes('aria-controls')).toBe(inputs()[1]!.attributes('id'))
+    expect(toggles[0]!.attributes('aria-controls')).not.toBe(toggles[1]!.attributes('aria-controls'))
+
+    // Revealing the first field does not reveal the second
+    await toggles[0]!.trigger('click')
+    expect(inputs()[0]!.attributes('type')).toBe('text')
+    expect(inputs()[1]!.attributes('type')).toBe('password')
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(AuthForm, {
       props: {


### PR DESCRIPTION
## Description

Resolves #6634

When a `UAuthForm` contained more than one `password` field, the reveal/hide buttons all shared a single `passwordVisibility` boolean, so clicking one reveal button revealed every password field at once.

`passwordVisibility` is now a reactive record keyed by field name (seeded to `false` for each password field), so each field toggles independently.

While fixing this I also noticed the trailing button's `aria-controls` used `passwordRef?.[0]?.inputRef?.id`, hardcoding index `0` so every button pointed at the first password input. Input refs are now tracked per field name too, so each button references its own input.

## Testing

Added a test that mounts a form with two password fields and asserts that:
- revealing the first field does not reveal the second
- each toggle's `aria-controls` points to its own distinct input

All AuthForm tests pass, lint and `vue-tsc` are clean, and existing render snapshots are unchanged.