### PR TITLE
fix(ContentNavigation): key items by identity to prevent leading icon flash

### DIFF
--- a/src/runtime/components/content/ContentNavigation.vue
+++ b/src/runtime/components/content/ContentNavigation.vue
@@ -203,7 +203,7 @@ const defaultValue = computed(() => {
 
   <Primitive :as="props.as" v-bind="$attrs" :as-child="props.level! > 0" data-slot="root" :class="ui.root({ class: [props.ui?.root, props.class] })">
     <AccordionRoot as="ul" :disabled="disabled" v-bind="rootProps" :default-value="defaultValue" :class="props.level! > 0 ? ui.listWithChildren({ class: props.ui?.listWithChildren }) : ui.list({ class: props.ui?.list })">
-      <template v-for="(link, index) in props.navigation" :key="index">
+      <template v-for="(link, index) in props.navigation" :key="`${index}-${link.path}`">
         <AccordionItem
           v-if="link.children?.length"
           as="li"

--- a/test/components/content/ContentNavigation.spec.ts
+++ b/test/components/content/ContentNavigation.spec.ts
@@ -1,4 +1,5 @@
-import { describe } from 'vitest'
+import { describe, it, expect } from 'vitest'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
 import ContentNavigation from '../../../src/runtime/components/content/ContentNavigation.vue'
 import { renderEach } from '../../component-render'
 import theme from '#build/ui/content/content-navigation'
@@ -68,4 +69,32 @@ describe('ContentNavigation', () => {
     ['with link-title slot', { props, slots: { 'link-title': () => 'Link title slot' } }],
     ['with link-trailing slot', { props, slots: { 'link-trailing': () => 'Link trailing slot' } }]
   ])
+
+  // Regression: navigating between routes (swapping `navigation`) must not morph the leading icon
+  // in place, otherwise the reused element flashes a solid gray box for one frame while the new
+  // icon's mask is injected. The fix keys items by identity so changed items remount.
+  it('replaces leading icon nodes when navigation changes (no flash)', async () => {
+    const navA = [
+      { title: 'Alpha', path: '/alpha', icon: 'i-lucide-folder' },
+      { title: 'Beta', path: '/beta', icon: 'i-lucide-file' }
+    ]
+    const navB = [
+      { title: 'Gamma', path: '/gamma', icon: 'i-lucide-bot' },
+      { title: 'Delta', path: '/delta', icon: 'i-lucide-cog' }
+    ]
+
+    const wrapper = await mountSuspended(ContentNavigation, { props: { navigation: navA } })
+
+    const before = wrapper.find('[data-slot="linkLeadingIcon"]').element
+    expect(before).toBeTruthy()
+
+    await wrapper.setProps({ navigation: navB })
+    await wrapper.vm.$nextTick()
+
+    const after = wrapper.find('[data-slot="linkLeadingIcon"]').element
+    expect(after).toBeTruthy()
+
+    // Different DOM node => the item was remounted rather than patched in place.
+    expect(after).not.toBe(before)
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

<!-- No linked issue; reproduces on nuxt.com docs sidebar. -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In a vertical `UContentNavigation`, navigating client side between two routes made the leading icon at a given list position flash as a solid gray square for one frame. It's positional, not icon specific: the item in a slot flashes regardless of which icon it holds. This reproduces on nuxt.com (its sidebar renders `<UContentNavigation>` with no `:key`); our own docs only hide it because `docs/app/layouts/docs.vue` puts `:key="navigationKey"` on the component and force remounts the whole sidebar.

The recursive `v-for` was keyed by index, so when `navigation` changed Vue patched the old item into the new item at the same slot in place rather than unmounting and mounting. The leading `UIcon` element got reused with only its class swapped, and in `@nuxt/icon`'s CSS mode (`mask-image: var(--svg); background-color: currentColor`) the new icon's `--svg` rule isn't injected yet for that frame, so the element paints as a solid `currentColor` box. Freshly mounted icons never show this.

The fix keys items by `${index}-${link.path}`. The index prefix keeps keys unique within each level (sibling groups can legitimately share a `path`, e.g. our docs gives ~13 top level groups the same `/docs/components`), while the `path` suffix makes the key change when a slot holds a different page, so changed items remount with a fresh icon instead of morphing. Unchanged items keep their key, so their `active` state transitions stay smooth.

I intentionally left `AccordionItem :value` and `defaultValue` index based. The reka-ui accordion is uncontrolled (it seeds its internal value from `defaultValue` only at mount), so a `path` based value would go stale on client navigation and collapse open sections, and it would also make siblings that share a `path` toggle together. The `:key` is a vnode key that's never rendered to HTML, so existing snapshots are unaffected.

Added a regression test that mounts the component with no external `:key`, swaps `:navigation`, and asserts the `[data-slot="linkLeadingIcon"]` DOM node at a slot is replaced rather than reused. It fails on the old index keyed code and passes with the fix.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
