### PR TITLE
feat(ScrollArea): add `getScrollElement` virtualize option

### DIFF
--- a/docs/app/components/content/examples/scroll-area/ScrollAreaExternalScrollExample.vue
+++ b/docs/app/components/content/examples/scroll-area/ScrollAreaExternalScrollExample.vue
@@ -1,0 +1,163 @@
+<script setup lang="ts">
+type User = {
+  id: number
+  firstName: string
+  lastName: string
+  email: string
+  image: string
+}
+
+const { data: users } = useLazyFetch('https://dummyjson.com/users?limit=100&select=firstName,lastName,email,image', {
+  key: 'scroll-area-external-scroll-users',
+  transform: (data?: { users: User[] }) => data?.users ?? [],
+  default: () => [] as User[],
+  server: false
+})
+
+// The container owns the scroll; the list virtualizes against it so everything shares one scrollbar.
+const container = useTemplateRef('container')
+const title = useTemplateRef('title')
+const toolbar = useTemplateRef('toolbar')
+const scrollArea = useTemplateRef('scrollArea')
+
+const ITEM_SIZE = 88
+const getScrollElement = () => container.value
+
+// `scrollMargin` is the list's offset within the scroll element (border-box height of the title + toolbar above it).
+const { height: titleHeight } = useElementSize(title, undefined, { box: 'border-box' })
+const { height: toolbarHeight } = useElementSize(toolbar, undefined, { box: 'border-box' })
+const scrollMargin = computed(() => titleHeight.value + toolbarHeight.value)
+
+// Find: jump through the items whose name matches the query (like a find toolbar).
+const query = ref('')
+const matches = computed(() => {
+  const q = query.value.trim().toLowerCase()
+  if (!q) return []
+  return users.value.reduce<number[]>((acc, user, index) => {
+    if (`${user.firstName} ${user.lastName}`.toLowerCase().includes(q)) acc.push(index)
+    return acc
+  }, [])
+})
+const cursor = ref(0)
+const currentMatch = computed(() => matches.value[cursor.value] ?? -1)
+
+function scrollToMatch() {
+  if (currentMatch.value < 0) return
+  scrollArea.value?.virtualizer?.scrollToIndex(currentMatch.value, { align: 'center', behavior: 'smooth' })
+}
+
+function step(delta: number) {
+  if (!matches.value.length) return
+  cursor.value = (cursor.value + delta + matches.value.length) % matches.value.length
+  scrollToMatch()
+}
+
+function scrollToTop() {
+  container.value?.scrollTo({ top: 0, behavior: 'smooth' })
+}
+
+// Re-runs on a new query and when `users` resolves, so the first match centers as soon as results arrive.
+watch(matches, () => {
+  cursor.value = 0
+  scrollToMatch()
+})
+</script>
+
+<template>
+  <div
+    ref="container"
+    class="w-full h-128 overflow-y-auto"
+  >
+    <div
+      ref="title"
+      class="flex items-end justify-between gap-4 p-6 bg-elevated/50"
+    >
+      <div>
+        <h2 class="text-2xl font-bold text-highlighted">
+          Members
+        </h2>
+        <p class="text-muted">
+          This header and the virtualized list share one scrollbar.
+        </p>
+      </div>
+      <UBadge
+        color="neutral"
+        variant="subtle"
+        :label="`${users.length} members`"
+      />
+    </div>
+
+    <div
+      ref="toolbar"
+      class="sticky top-0 z-10 flex items-center px-6 py-3 border-y border-default bg-elevated/50 backdrop-blur"
+    >
+      <UFieldGroup>
+        <UInput
+          v-model="query"
+          placeholder="Find a member..."
+          icon="i-lucide-search"
+          aria-describedby="scroll-area-find-count"
+          class="w-64"
+          :ui="{ trailing: 'pointer-events-none' }"
+        >
+          <template #trailing>
+            <span
+              id="scroll-area-find-count"
+              class="text-xs text-muted tabular-nums"
+              aria-live="polite"
+              role="status"
+            >
+              {{ matches.length ? cursor + 1 : 0 }}/{{ matches.length }}
+            </span>
+          </template>
+        </UInput>
+        <UButton
+          icon="i-lucide-chevron-up"
+          color="neutral"
+          variant="outline"
+          aria-label="Previous match"
+          :disabled="!matches.length"
+          @click="step(-1)"
+        />
+        <UButton
+          icon="i-lucide-chevron-down"
+          color="neutral"
+          variant="outline"
+          aria-label="Next match"
+          :disabled="!matches.length"
+          @click="step(1)"
+        />
+      </UFieldGroup>
+
+      <div class="ms-auto">
+        <UButton
+          icon="i-lucide-arrow-up-to-line"
+          color="neutral"
+          variant="outline"
+          label="Top"
+          @click="scrollToTop"
+        />
+      </div>
+    </div>
+
+    <UScrollArea
+      ref="scrollArea"
+      v-slot="{ item, index }"
+      :items="users"
+      :virtualize="{ scrollMargin, getScrollElement, estimateSize: ITEM_SIZE, skipMeasurement: true }"
+    >
+      <UPageCard
+        orientation="horizontal"
+        class="rounded-none"
+        :class="[index === currentMatch && 'bg-primary/10']"
+      >
+        <UUser
+          :name="`${item.firstName} ${item.lastName}`"
+          :description="item.email"
+          :avatar="{ src: item.image, alt: item.firstName, loading: 'lazy' as const }"
+          size="lg"
+        />
+      </UPageCard>
+    </UScrollArea>
+  </div>
+</template>

--- a/docs/content/docs/2.components/scroll-area.md
+++ b/docs/content/docs/2.components/scroll-area.md
@@ -171,6 +171,10 @@ class: '!p-0'
 Because the container owns the scroll, the toolbar's find and "Top" buttons scroll it directly with `container.scrollTo`.
 ::
 
+::caution
+The `shadow` prop has no effect in this mode, since the root no longer owns the scroll. Apply your own fade to the scroll container instead.
+::
+
 ### With programmatic scroll
 
 You can use the exposed `virtualizer` to programmatically control scroll position.

--- a/docs/content/docs/2.components/scroll-area.md
+++ b/docs/content/docs/2.components/scroll-area.md
@@ -153,6 +153,24 @@ class: '!p-0'
 ---
 ::
 
+### With external scroll element :badge{label="Soon" class="align-text-top"}
+
+Pass a `getScrollElement` function in the `virtualize` prop to virtualize against an ancestor scroll container instead of the component's own viewport. Set `scrollMargin` to the list's offset from the scroll element's start (e.g. the height of the content above it).
+
+::component-example
+---
+prettier: true
+collapse: true
+overflowHidden: true
+name: 'scroll-area-external-scroll-example'
+class: '!p-0'
+---
+::
+
+::note
+Because the container owns the scroll, the toolbar's find and "Top" buttons scroll it directly with `container.scrollTo`.
+::
+
 ### With programmatic scroll
 
 You can use the exposed `virtualizer` to programmatically control scroll position.

--- a/src/runtime/components/ScrollArea.vue
+++ b/src/runtime/components/ScrollArea.vue
@@ -9,8 +9,14 @@ type ScrollArea = ComponentConfig<typeof theme, AppConfig, 'scrollArea'>
 
 export interface ScrollAreaVirtualizeOptions extends Partial<Omit<
   VirtualizerOptions<Element, Element>,
-  'count' | 'getScrollElement' | 'horizontal' | 'isRtl' | 'estimateSize' | 'lanes' | 'enabled'
+  'count' | 'horizontal' | 'isRtl' | 'estimateSize' | 'lanes' | 'enabled'
 >> {
+  /**
+   * Virtualize against an external scroll element instead of the component's own root.
+   * Pair with `scrollMargin` set to the content's offset from the scroll element's start.
+   * @defaultValue undefined
+   */
+  getScrollElement?: () => Element | null
   /**
    * Estimated size (in px) of each item along the scroll axis. Can be a number or a function.
    * @defaultValue 100
@@ -87,7 +93,7 @@ export interface ScrollAreaEmits {
 </script>
 
 <script setup lang="ts" generic="T extends ScrollAreaItem">
-import { computed, onMounted, onUnmounted, toRef, useTemplateRef, watch } from 'vue'
+import { computed, onUnmounted, toRef, useTemplateRef, watch } from 'vue'
 import { Primitive } from 'reka-ui'
 import { defu } from 'defu'
 import { useVirtualizer } from '@tanstack/vue-virtual'
@@ -130,6 +136,9 @@ const scrollShadowStyle = props.shadow
 const isRtl = computed(() => dir.value === 'rtl')
 const isHorizontal = computed(() => props.orientation === 'horizontal')
 const isVertical = computed(() => !isHorizontal.value)
+
+// When an external scroll element is provided, it owns the scroll
+const isExternalScroll = computed(() => typeof props.virtualize === 'object' && !!props.virtualize.getScrollElement)
 
 const virtualizerProps = toRef(() => {
   const options = typeof props.virtualize === 'boolean' ? {} : props.virtualize
@@ -179,7 +188,7 @@ const virtualizer = !!props.virtualize && useVirtualizer({
   get count() {
     return props.items?.length || 0
   },
-  getScrollElement: () => rootRef.value?.$el,
+  getScrollElement: () => isExternalScroll.value ? (virtualizerProps.value.getScrollElement?.() ?? null) : rootRef.value?.$el,
   get horizontal() {
     return isHorizontal.value
   },
@@ -202,6 +211,8 @@ function getVirtualItemStyle(virtualItem: VirtualItem): CSSProperties {
   const hasLanes = lanes.value !== undefined && lanes.value > 1
   const lane = virtualItem.lane
   const gap = virtualizerProps.value.gap ?? 0
+  // In external-scroll mode `start` includes `scrollMargin`; subtract it so items sit inline.
+  const offset = virtualItem.start - (isExternalScroll.value ? (virtualizerProps.value.scrollMargin ?? 0) : 0)
 
   // For cross-axis gaps: calculate size and position accounting for gaps between lanes
   // laneSize = (100% - (lanes - 1) * gap) / lanes
@@ -220,30 +231,33 @@ function getVirtualItemStyle(virtualItem: VirtualItem): CSSProperties {
     blockSize: isHorizontal.value ? (hasLanes ? laneSize : '100%') : undefined,
     inlineSize: isVertical.value ? (hasLanes ? laneSize : '100%') : undefined,
     transform: isHorizontal.value
-      ? `translateX(${isRtl.value ? -virtualItem.start : virtualItem.start}px)`
-      : `translateY(${virtualItem.start}px)`
+      ? `translateX(${isRtl.value ? -offset : offset}px)`
+      : `translateY(${offset}px)`
   }
 }
 
-// Recalculate layout on container resize (e.g. estimateSize depends on lane width)
+// Recalculate layout when the scroll viewport resizes (e.g. estimateSize depends on lane width).
+// The viewport is the external element when provided, otherwise the root; re-observe if it changes.
 let resizeObserver: ResizeObserver | null = null
 let rafId: number | null = null
 
-onMounted(() => {
-  if (virtualizer) {
-    const el = rootRef.value?.$el
-    if (el) {
-      resizeObserver = new ResizeObserver(() => {
-        if (rafId !== null) return
-        rafId = requestAnimationFrame(() => {
-          rafId = null
-          virtualizer.value.measure()
-        })
+watch(
+  () => (isExternalScroll.value && virtualizerProps.value.getScrollElement?.()) || rootRef.value?.$el,
+  (el) => {
+    resizeObserver?.disconnect()
+    resizeObserver = null
+    if (!virtualizer || !el) return
+    resizeObserver = new ResizeObserver(() => {
+      if (rafId !== null) return
+      rafId = requestAnimationFrame(() => {
+        rafId = null
+        virtualizer.value.measure()
       })
-      resizeObserver.observe(el)
-    }
-  }
-})
+    })
+    resizeObserver.observe(el)
+  },
+  { immediate: true }
+)
 
 onUnmounted(() => {
   if (rafId !== null) {
@@ -291,7 +305,7 @@ defineExpose({
     data-slot="root"
     :data-orientation="props.orientation"
     :class="ui.root({ class: [props.ui?.root, props.class] })"
-    :style="scrollShadowStyle"
+    :style="[scrollShadowStyle, isExternalScroll ? { overflow: 'visible' } : undefined]"
   >
     <template v-if="virtualizer">
       <div

--- a/src/runtime/components/ScrollArea.vue
+++ b/src/runtime/components/ScrollArea.vue
@@ -140,6 +140,9 @@ const isVertical = computed(() => !isHorizontal.value)
 // When an external scroll element is provided, it owns the scroll
 const isExternalScroll = computed(() => typeof props.virtualize === 'object' && !!props.virtualize.getScrollElement)
 
+// The scroll viewport: the external element when provided, otherwise the component's root.
+const getScrollElement = () => (isExternalScroll.value ? virtualizerProps.value.getScrollElement?.() : rootRef.value?.$el) ?? null
+
 const virtualizerProps = toRef(() => {
   const options = typeof props.virtualize === 'boolean' ? {} : props.virtualize
 
@@ -188,7 +191,7 @@ const virtualizer = !!props.virtualize && useVirtualizer({
   get count() {
     return props.items?.length || 0
   },
-  getScrollElement: () => isExternalScroll.value ? (virtualizerProps.value.getScrollElement?.() ?? null) : rootRef.value?.$el,
+  getScrollElement,
   get horizontal() {
     return isHorizontal.value
   },
@@ -237,12 +240,12 @@ function getVirtualItemStyle(virtualItem: VirtualItem): CSSProperties {
 }
 
 // Recalculate layout when the scroll viewport resizes (e.g. estimateSize depends on lane width).
-// The viewport is the external element when provided, otherwise the root; re-observe if it changes.
+// Re-observe if the scroll element changes.
 let resizeObserver: ResizeObserver | null = null
 let rafId: number | null = null
 
 watch(
-  () => (isExternalScroll.value && virtualizerProps.value.getScrollElement?.()) || rootRef.value?.$el,
+  getScrollElement,
   (el) => {
     resizeObserver?.disconnect()
     resizeObserver = null

--- a/test/components/ScrollArea.spec.ts
+++ b/test/components/ScrollArea.spec.ts
@@ -22,6 +22,7 @@ describe('ScrollArea', () => {
     ['with virtualize padding', { props: { ...props, virtualize: { paddingStart: 20, paddingEnd: 20 } } }],
     ['with virtualize lanes', { props: { ...props, virtualize: { lanes: 3 } } }],
     ['with virtualize scrollMargin', { props: { ...props, virtualize: { scrollMargin: 10 } } }],
+    ['with virtualize external scroll element', { props: { ...props, virtualize: { getScrollElement: () => document.body, scrollMargin: 20 } } }],
     ['with shadow', { props: { ...props, shadow: true } }],
     ['with as', { props: { ...props, as: 'section' } }],
     ['with class', { props: { ...props, class: 'absolute' } }],

--- a/test/components/__snapshots__/ScrollArea-vue.spec.ts.snap
+++ b/test/components/__snapshots__/ScrollArea-vue.spec.ts.snap
@@ -82,6 +82,12 @@ exports[`ScrollArea > renders with virtualize boolean correctly 1`] = `
 </div>"
 `;
 
+exports[`ScrollArea > renders with virtualize external scroll element correctly 1`] = `
+"<div data-slot="root" data-orientation="vertical" class="relative outline-primary/25 focus-visible:outline-3 overflow-y-auto overflow-x-hidden" style="overflow: visible;">
+  <div data-slot="viewport" class="relative flex flex-col" style="position: relative; inline-size: 100%; block-size: 300px;"></div>
+</div>"
+`;
+
 exports[`ScrollArea > renders with virtualize gap correctly 1`] = `
 "<div data-slot="root" data-orientation="vertical" class="relative outline-primary/25 focus-visible:outline-3 overflow-y-auto overflow-x-hidden">
   <div data-slot="viewport" class="relative flex flex-col" style="position: relative; inline-size: 100%; block-size: 320px;"></div>

--- a/test/components/__snapshots__/ScrollArea.spec.ts.snap
+++ b/test/components/__snapshots__/ScrollArea.spec.ts.snap
@@ -82,6 +82,12 @@ exports[`ScrollArea > renders with virtualize boolean correctly 1`] = `
 </div>"
 `;
 
+exports[`ScrollArea > renders with virtualize external scroll element correctly 1`] = `
+"<div data-slot="root" data-orientation="vertical" class="relative outline-primary/25 focus-visible:outline-3 overflow-y-auto overflow-x-hidden" style="overflow: visible;">
+  <div data-slot="viewport" class="relative flex flex-col" style="position: relative; inline-size: 100%; block-size: 300px;"></div>
+</div>"
+`;
+
 exports[`ScrollArea > renders with virtualize gap correctly 1`] = `
 "<div data-slot="root" data-orientation="vertical" class="relative outline-primary/25 focus-visible:outline-3 overflow-y-auto overflow-x-hidden">
   <div data-slot="viewport" class="relative flex flex-col" style="position: relative; inline-size: 100%; block-size: 320px;"></div>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6649

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Exposes `getScrollElement` through the `virtualize` prop (previously hardcoded to the component's root and excluded from the type), so a list can virtualize against an **ancestor** scroll container. This lets surrounding content and the virtualized list share a single scrollbar instead of nesting a second scroller.

In external mode the root no longer owns a scroll viewport, item positions account for `scrollMargin`, and the resize observer tracks the real scroll element. Gated behind external mode, so default behaviour is unchanged (snapshots: additions only). Adds a docs example and a test case.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
