### PR TITLE
feat(Table): add `getScrollElement` virtualize option

### DIFF
--- a/docs/app/components/content/examples/scroll-area/ScrollAreaExternalScrollExample.vue
+++ b/docs/app/components/content/examples/scroll-area/ScrollAreaExternalScrollExample.vue
@@ -180,7 +180,7 @@ watch(matches, () => {
         :orientation="orientation"
         :items="users"
         :class="isHorizontal && 'h-48 shrink-0'"
-        :virtualize="{ scrollMargin, getScrollElement, estimateSize: itemSize, skipMeasurement: true }"
+        :virtualize="{ scrollMargin, getScrollElement, estimateSize: itemSize, skipMeasurement: isHorizontal }"
       >
         <UPageCard
           class="rounded-none h-full"

--- a/docs/app/components/content/examples/scroll-area/ScrollAreaExternalScrollExample.vue
+++ b/docs/app/components/content/examples/scroll-area/ScrollAreaExternalScrollExample.vue
@@ -1,4 +1,10 @@
 <script setup lang="ts">
+const props = withDefaults(defineProps<{
+  orientation?: 'vertical' | 'horizontal'
+}>(), {
+  orientation: 'horizontal'
+})
+
 type User = {
   id: number
   firstName: string
@@ -14,19 +20,22 @@ const { data: users } = useLazyFetch('https://dummyjson.com/users?limit=100&sele
   server: false
 })
 
+const isHorizontal = computed(() => props.orientation === 'horizontal')
+
 // The container owns the scroll; the list virtualizes against it so everything shares one scrollbar.
 const container = useTemplateRef('container')
 const title = useTemplateRef('title')
 const toolbar = useTemplateRef('toolbar')
 const scrollArea = useTemplateRef('scrollArea')
 
-const ITEM_SIZE = 88
+// Item size along the scroll axis: card width when horizontal, row height when vertical.
+const itemSize = computed(() => isHorizontal.value ? 256 : 88)
 const getScrollElement = () => container.value
 
-// `scrollMargin` is the list's offset within the scroll element (border-box height of the title + toolbar above it).
+// `scrollMargin` is the list's offset along the scroll axis: the title + toolbar height when vertical, none when horizontal.
 const { height: titleHeight } = useElementSize(title, undefined, { box: 'border-box' })
 const { height: toolbarHeight } = useElementSize(toolbar, undefined, { box: 'border-box' })
-const scrollMargin = computed(() => titleHeight.value + toolbarHeight.value)
+const scrollMargin = computed(() => isHorizontal.value ? 0 : titleHeight.value + toolbarHeight.value)
 
 // Find: jump through the items whose name matches the query (like a find toolbar).
 const query = ref('')
@@ -52,8 +61,8 @@ function step(delta: number) {
   scrollToMatch()
 }
 
-function scrollToTop() {
-  container.value?.scrollTo({ top: 0, behavior: 'smooth' })
+function scrollToStart() {
+  container.value?.scrollTo(isHorizontal.value ? { left: 0, behavior: 'smooth' } : { top: 0, behavior: 'smooth' })
 }
 
 // Re-runs on a new query and when `users` resolves, so the first match centers as soon as results arrive.
@@ -66,11 +75,12 @@ watch(matches, () => {
 <template>
   <div
     ref="container"
-    class="w-full h-128 overflow-y-auto"
+    :class="isHorizontal ? 'w-full overflow-x-auto' : 'w-full h-128 overflow-y-auto'"
   >
     <div
       ref="title"
-      class="flex items-end justify-between gap-4 p-6 bg-elevated/50"
+      class="z-10 flex items-end justify-between gap-4 p-6 bg-elevated/50"
+      :class="isHorizontal && 'sticky left-0'"
     >
       <div>
         <h2 class="text-2xl font-bold text-highlighted">
@@ -89,7 +99,8 @@ watch(matches, () => {
 
     <div
       ref="toolbar"
-      class="sticky top-0 z-10 flex items-center px-6 py-3 border-y border-default bg-elevated/50 backdrop-blur"
+      class="z-10 flex items-center px-6 py-3 border-y border-default bg-elevated/50 backdrop-blur"
+      :class="isHorizontal ? 'sticky left-0' : 'sticky top-0'"
     >
       <UFieldGroup>
         <UInput
@@ -112,7 +123,7 @@ watch(matches, () => {
           </template>
         </UInput>
         <UButton
-          icon="i-lucide-chevron-up"
+          :icon="isHorizontal ? 'i-lucide-chevron-left' : 'i-lucide-chevron-up'"
           color="neutral"
           variant="outline"
           aria-label="Previous match"
@@ -120,7 +131,7 @@ watch(matches, () => {
           @click="step(-1)"
         />
         <UButton
-          icon="i-lucide-chevron-down"
+          :icon="isHorizontal ? 'i-lucide-chevron-right' : 'i-lucide-chevron-down'"
           color="neutral"
           variant="outline"
           aria-label="Next match"
@@ -131,11 +142,11 @@ watch(matches, () => {
 
       <div class="ms-auto">
         <UButton
-          icon="i-lucide-arrow-up-to-line"
+          :icon="isHorizontal ? 'i-lucide-arrow-left-to-line' : 'i-lucide-arrow-up-to-line'"
           color="neutral"
           variant="outline"
-          label="Top"
-          @click="scrollToTop"
+          :label="isHorizontal ? 'Start' : 'Top'"
+          @click="scrollToStart"
         />
       </div>
     </div>
@@ -143,20 +154,34 @@ watch(matches, () => {
     <UScrollArea
       ref="scrollArea"
       v-slot="{ item, index }"
+      :orientation="orientation"
       :items="users"
-      :virtualize="{ scrollMargin, getScrollElement, estimateSize: ITEM_SIZE, skipMeasurement: true }"
+      :class="isHorizontal && 'h-44'"
+      :virtualize="{ scrollMargin, getScrollElement, estimateSize: itemSize, skipMeasurement: true }"
     >
       <UPageCard
-        orientation="horizontal"
-        class="rounded-none"
-        :class="[index === currentMatch && 'bg-primary/10']"
+        class="rounded-none h-full"
+        :class="[isHorizontal && 'w-64', index === currentMatch && 'bg-primary/10']"
       >
-        <UUser
-          :name="`${item.firstName} ${item.lastName}`"
-          :description="item.email"
-          :avatar="{ src: item.image, alt: item.firstName, loading: 'lazy' as const }"
-          size="lg"
-        />
+        <div
+          class="flex gap-3 h-full min-w-0"
+          :class="isHorizontal ? 'flex-col items-center justify-center text-center' : 'items-center'"
+        >
+          <UAvatar
+            :src="item.image"
+            :alt="item.firstName"
+            :size="isHorizontal ? '2xl' : 'lg'"
+            loading="lazy"
+          />
+          <div class="min-w-0">
+            <p class="font-medium text-highlighted truncate">
+              {{ item.firstName }} {{ item.lastName }}
+            </p>
+            <p class="text-sm text-muted truncate">
+              {{ item.email }}
+            </p>
+          </div>
+        </div>
       </UPageCard>
     </UScrollArea>
   </div>

--- a/docs/app/components/content/examples/scroll-area/ScrollAreaExternalScrollExample.vue
+++ b/docs/app/components/content/examples/scroll-area/ScrollAreaExternalScrollExample.vue
@@ -2,7 +2,7 @@
 const props = withDefaults(defineProps<{
   orientation?: 'vertical' | 'horizontal'
 }>(), {
-  orientation: 'horizontal'
+  orientation: 'vertical'
 })
 
 type User = {
@@ -22,7 +22,7 @@ const { data: users } = useLazyFetch('https://dummyjson.com/users?limit=100&sele
 
 const isHorizontal = computed(() => props.orientation === 'horizontal')
 
-// The container owns the scroll; the list virtualizes against it so everything shares one scrollbar.
+// The container owns the scroll; the list virtualizes against it so the header and cards share one scrollbar.
 const container = useTemplateRef('container')
 const title = useTemplateRef('title')
 const toolbar = useTemplateRef('toolbar')
@@ -32,10 +32,10 @@ const scrollArea = useTemplateRef('scrollArea')
 const itemSize = computed(() => isHorizontal.value ? 256 : 88)
 const getScrollElement = () => container.value
 
-// `scrollMargin` is the list's offset along the scroll axis: the title + toolbar height when vertical, none when horizontal.
-const { height: titleHeight } = useElementSize(title, undefined, { box: 'border-box' })
+// `scrollMargin` is the title's offset along the scroll axis: its width when it sits left of the cards, its height when it sits above them.
+const { width: titleWidth, height: titleHeight } = useElementSize(title, undefined, { box: 'border-box' })
 const { height: toolbarHeight } = useElementSize(toolbar, undefined, { box: 'border-box' })
-const scrollMargin = computed(() => isHorizontal.value ? 0 : titleHeight.value + toolbarHeight.value)
+const scrollMargin = computed(() => isHorizontal.value ? titleWidth.value : toolbarHeight.value + titleHeight.value)
 
 // Find: jump through the items whose name matches the query (like a find toolbar).
 const query = ref('')
@@ -77,17 +77,18 @@ watch(matches, () => {
     ref="container"
     :class="isHorizontal ? 'w-full overflow-x-auto' : 'w-full h-128 overflow-y-auto'"
   >
+    <!-- Vertical: the header sits above the toolbar and scrolls away as you scroll down. -->
     <div
+      v-if="!isHorizontal"
       ref="title"
-      class="z-10 flex items-end justify-between gap-4 p-6 bg-elevated/50"
-      :class="isHorizontal && 'sticky left-0'"
+      class="flex items-end justify-between gap-4 p-6 bg-elevated/50"
     >
       <div>
         <h2 class="text-2xl font-bold text-highlighted">
           Members
         </h2>
         <p class="text-muted">
-          This header and the virtualized list share one scrollbar.
+          This header scrolls away with the cards, sharing one scrollbar.
         </p>
       </div>
       <UBadge
@@ -140,49 +141,72 @@ watch(matches, () => {
         />
       </UFieldGroup>
 
-      <div class="ms-auto">
-        <UButton
-          :icon="isHorizontal ? 'i-lucide-arrow-left-to-line' : 'i-lucide-arrow-up-to-line'"
-          color="neutral"
-          variant="outline"
-          :label="isHorizontal ? 'Start' : 'Top'"
-          @click="scrollToStart"
-        />
-      </div>
+      <UButton
+        :icon="isHorizontal ? 'i-lucide-arrow-left-to-line' : 'i-lucide-arrow-up-to-line'"
+        color="neutral"
+        variant="outline"
+        class="ms-auto"
+        :label="isHorizontal ? 'Start' : 'Top'"
+        @click="scrollToStart"
+      />
     </div>
 
-    <UScrollArea
-      ref="scrollArea"
-      v-slot="{ item, index }"
-      :orientation="orientation"
-      :items="users"
-      :class="isHorizontal && 'h-44'"
-      :virtualize="{ scrollMargin, getScrollElement, estimateSize: itemSize, skipMeasurement: true }"
-    >
-      <UPageCard
-        class="rounded-none h-full"
-        :class="[isHorizontal && 'w-64', index === currentMatch && 'bg-primary/10']"
+    <!-- Horizontal: the header sits left of the cards (in the row) so it scrolls away with them. -->
+    <div :class="isHorizontal && 'flex'">
+      <div
+        v-if="isHorizontal"
+        ref="title"
+        class="w-72 shrink-0 flex flex-col justify-center gap-4 p-6 bg-elevated/50 border-r border-default"
       >
-        <div
-          class="flex gap-3 h-full min-w-0"
-          :class="isHorizontal ? 'flex-col items-center justify-center text-center' : 'items-center'"
-        >
-          <UAvatar
-            :src="item.image"
-            :alt="item.firstName"
-            :size="isHorizontal ? '2xl' : 'lg'"
-            loading="lazy"
-          />
-          <div class="min-w-0">
-            <p class="font-medium text-highlighted truncate">
-              {{ item.firstName }} {{ item.lastName }}
-            </p>
-            <p class="text-sm text-muted truncate">
-              {{ item.email }}
-            </p>
-          </div>
+        <div>
+          <h2 class="text-2xl font-bold text-highlighted">
+            Members
+          </h2>
+          <p class="text-muted">
+            This header scrolls away with the cards, sharing one scrollbar.
+          </p>
         </div>
-      </UPageCard>
-    </UScrollArea>
+        <UBadge
+          color="neutral"
+          variant="subtle"
+          class="self-start"
+          :label="`${users.length} members`"
+        />
+      </div>
+
+      <UScrollArea
+        ref="scrollArea"
+        v-slot="{ item, index }"
+        :orientation="orientation"
+        :items="users"
+        :class="isHorizontal && 'h-48 shrink-0'"
+        :virtualize="{ scrollMargin, getScrollElement, estimateSize: itemSize, skipMeasurement: true }"
+      >
+        <UPageCard
+          class="rounded-none h-full"
+          :class="[isHorizontal && 'w-64', index === currentMatch && 'bg-primary/10']"
+        >
+          <div
+            class="flex gap-3 h-full min-w-0"
+            :class="isHorizontal ? 'flex-col items-center justify-center text-center' : 'items-center'"
+          >
+            <UAvatar
+              :src="item.image"
+              :alt="item.firstName"
+              :size="isHorizontal ? '2xl' : 'lg'"
+              loading="lazy"
+            />
+            <div class="min-w-0">
+              <p class="font-medium text-highlighted truncate">
+                {{ item.firstName }} {{ item.lastName }}
+              </p>
+              <p class="text-sm text-muted truncate">
+                {{ item.email }}
+              </p>
+            </div>
+          </div>
+        </UPageCard>
+      </UScrollArea>
+    </div>
   </div>
 </template>

--- a/docs/app/components/content/examples/table/TableExternalScrollExample.vue
+++ b/docs/app/components/content/examples/table/TableExternalScrollExample.vue
@@ -76,7 +76,7 @@ const columns: TableColumn<Payment>[] = [{
 <template>
   <div
     ref="container"
-    class="w-full h-96 overflow-y-auto"
+    class="w-full h-96 overflow-auto"
   >
     <div
       ref="title"

--- a/docs/app/components/content/examples/table/TableExternalScrollExample.vue
+++ b/docs/app/components/content/examples/table/TableExternalScrollExample.vue
@@ -7,18 +7,29 @@ const UBadge = resolveComponent('UBadge')
 type Payment = {
   id: string
   date: string
-  status: 'paid' | 'failed' | 'refunded'
+  customer: string
   email: string
+  method: string
+  status: 'paid' | 'failed' | 'refunded'
   amount: number
 }
 
-const data = ref<Payment[]>(Array(1000).fill(0).map((_, i) => ({
-  id: `4600-${i}`,
-  date: '2024-03-11T15:30:00',
-  status: 'paid',
-  email: 'james.anderson@example.com',
-  amount: 594
-})))
+const names = ['James Anderson', 'Mary Johnson', 'Robert Williams', 'Patricia Brown', 'Michael Davis']
+const methods = ['Visa', 'Mastercard', 'PayPal', 'Amex']
+const statuses = ['paid', 'failed', 'refunded'] as const
+
+const data = ref<Payment[]>(Array.from({ length: 1000 }, (_, i) => {
+  const customer = names[i % names.length]!
+  return {
+    id: `4600-${i}`,
+    date: '2024-03-11T15:30:00',
+    customer,
+    email: `${customer.toLowerCase().replace(' ', '.')}@example.com`,
+    method: methods[i % methods.length]!,
+    status: statuses[i % statuses.length]!,
+    amount: 100 + ((i * 37) % 900)
+  }
+}))
 
 // The container owns the scroll; the table virtualizes against it so the header and rows share one scrollbar.
 const container = useTemplateRef('container')
@@ -43,6 +54,15 @@ const columns: TableColumn<Payment>[] = [{
     hour12: false
   })
 }, {
+  accessorKey: 'customer',
+  header: 'Customer'
+}, {
+  accessorKey: 'email',
+  header: 'Email'
+}, {
+  accessorKey: 'method',
+  header: 'Method'
+}, {
   accessorKey: 'status',
   header: 'Status',
   cell: ({ row }) => {
@@ -54,9 +74,6 @@ const columns: TableColumn<Payment>[] = [{
 
     return h(UBadge, { class: 'capitalize', variant: 'subtle', color }, () => row.getValue('status'))
   }
-}, {
-  accessorKey: 'email',
-  header: 'Email'
 }, {
   accessorKey: 'amount',
   header: 'Amount',
@@ -80,14 +97,14 @@ const columns: TableColumn<Payment>[] = [{
   >
     <div
       ref="title"
-      class="flex items-end justify-between gap-4 p-6 bg-elevated/50"
+      class="sticky left-0 z-10 flex items-end justify-between gap-4 p-6 bg-elevated/50"
     >
       <div>
         <h2 class="text-2xl font-bold text-highlighted">
           Payments
         </h2>
         <p class="text-muted">
-          This header and the virtualized table share one scrollbar.
+          The title stays put while the wide table scrolls both axes under one scrollbar.
         </p>
       </div>
       <UBadge
@@ -102,6 +119,7 @@ const columns: TableColumn<Payment>[] = [{
       :data="data"
       :columns="columns"
       :virtualize="{ scrollMargin: titleHeight, getScrollElement }"
+      :ui="{ base: 'min-w-[1200px]' }"
     />
   </div>
 </template>

--- a/docs/app/components/content/examples/table/TableExternalScrollExample.vue
+++ b/docs/app/components/content/examples/table/TableExternalScrollExample.vue
@@ -1,0 +1,107 @@
+<script setup lang="ts">
+import { h, resolveComponent } from 'vue'
+import type { TableColumn } from '@nuxt/ui'
+
+const UBadge = resolveComponent('UBadge')
+
+type Payment = {
+  id: string
+  date: string
+  status: 'paid' | 'failed' | 'refunded'
+  email: string
+  amount: number
+}
+
+const data = ref<Payment[]>(Array(1000).fill(0).map((_, i) => ({
+  id: `4600-${i}`,
+  date: '2024-03-11T15:30:00',
+  status: 'paid',
+  email: 'james.anderson@example.com',
+  amount: 594
+})))
+
+// The container owns the scroll; the table virtualizes against it so the header and rows share one scrollbar.
+const container = useTemplateRef('container')
+const title = useTemplateRef('title')
+const getScrollElement = () => container.value
+
+// `scrollMargin` is the table's offset within the scroll element (border-box height of the title above it).
+const { height: titleHeight } = useElementSize(title, undefined, { box: 'border-box' })
+
+const columns: TableColumn<Payment>[] = [{
+  accessorKey: 'id',
+  header: '#',
+  cell: ({ row }) => `#${row.getValue('id')}`
+}, {
+  accessorKey: 'date',
+  header: 'Date',
+  cell: ({ row }) => new Date(row.getValue('date')).toLocaleString('en-US', {
+    day: 'numeric',
+    month: 'short',
+    hour: '2-digit',
+    minute: '2-digit',
+    hour12: false
+  })
+}, {
+  accessorKey: 'status',
+  header: 'Status',
+  cell: ({ row }) => {
+    const color = ({
+      paid: 'success' as const,
+      failed: 'error' as const,
+      refunded: 'neutral' as const
+    })[row.getValue('status') as string]
+
+    return h(UBadge, { class: 'capitalize', variant: 'subtle', color }, () => row.getValue('status'))
+  }
+}, {
+  accessorKey: 'email',
+  header: 'Email'
+}, {
+  accessorKey: 'amount',
+  header: 'Amount',
+  meta: {
+    class: {
+      th: 'text-right',
+      td: 'text-right font-medium'
+    }
+  },
+  cell: ({ row }) => new Intl.NumberFormat('en-US', {
+    style: 'currency',
+    currency: 'EUR'
+  }).format(Number.parseFloat(row.getValue('amount')))
+}]
+</script>
+
+<template>
+  <div
+    ref="container"
+    class="w-full h-96 overflow-y-auto"
+  >
+    <div
+      ref="title"
+      class="flex items-end justify-between gap-4 p-6 bg-elevated/50"
+    >
+      <div>
+        <h2 class="text-2xl font-bold text-highlighted">
+          Payments
+        </h2>
+        <p class="text-muted">
+          This header and the virtualized table share one scrollbar.
+        </p>
+      </div>
+      <UBadge
+        color="neutral"
+        variant="subtle"
+        :label="`${data.length} rows`"
+      />
+    </div>
+
+    <UTable
+      sticky
+      :data="data"
+      :columns="columns"
+      :virtualize="{ scrollMargin: titleHeight, getScrollElement }"
+    />
+  </div>
+</template>

--- a/docs/content/docs/2.components/scroll-area.md
+++ b/docs/content/docs/2.components/scroll-area.md
@@ -164,6 +164,13 @@ collapse: true
 overflowHidden: true
 name: 'scroll-area-external-scroll-example'
 class: '!p-0'
+options:
+  - name: orientation
+    label: orientation
+    default: horizontal
+    items:
+      - vertical
+      - horizontal
 ---
 ::
 

--- a/docs/content/docs/2.components/scroll-area.md
+++ b/docs/content/docs/2.components/scroll-area.md
@@ -167,7 +167,7 @@ class: '!p-0'
 options:
   - name: orientation
     label: orientation
-    default: horizontal
+    default: vertical
     items:
       - vertical
       - horizontal

--- a/docs/content/docs/2.components/table.md
+++ b/docs/content/docs/2.components/table.md
@@ -688,6 +688,24 @@ class: '!p-0'
 A height constraint is required on the table for virtualization to work properly (e.g., `class="h-[400px]"`).
 ::
 
+### With external scroll element :badge{label="Soon" class="align-text-top"}
+
+Pass a `getScrollElement` function in the `virtualize` prop to virtualize against an ancestor scroll container instead of the table's own root. Set `scrollMargin` to the table's offset from the scroll element's start (e.g. the height of the content above it), so a header and the table body share a single scrollbar.
+
+::component-example
+---
+prettier: true
+collapse: true
+overflowHidden: true
+name: 'table-external-scroll-example'
+class: '!p-0'
+---
+::
+
+::note
+In this mode the root's `overflow` becomes `visible`, so a `sticky` header anchors to the external scroll container rather than the table root.
+::
+
 ### With tree data
 
 You can use the `get-sub-rows` prop to display hierarchical (tree) data in the table.

--- a/docs/content/docs/2.components/table.md
+++ b/docs/content/docs/2.components/table.md
@@ -703,7 +703,7 @@ class: '!p-0'
 ::
 
 ::note
-In this mode the root's `overflow` becomes `visible`, so a `sticky` header anchors to the external scroll container rather than the table root.
+In this mode the table root's `overflow` is `visible` and the external container owns scrolling on both axes, so give it `overflow-auto` (not just `overflow-y-auto`) to keep wide tables horizontally scrollable. A `sticky` header then anchors to that container.
 ::
 
 ### With tree data

--- a/src/runtime/components/ScrollArea.vue
+++ b/src/runtime/components/ScrollArea.vue
@@ -215,8 +215,8 @@ function getVirtualItemStyle(virtualItem: VirtualItem): CSSProperties {
   const hasLanes = lanes.value !== undefined && lanes.value > 1
   const lane = virtualItem.lane
   const gap = virtualizerProps.value.gap ?? 0
-  // In external-scroll mode `start` includes `scrollMargin`; subtract it so items sit inline.
-  const offset = virtualItem.start - (isExternalScroll.value ? (virtualizerProps.value.scrollMargin ?? 0) : 0)
+  // `start` includes `scrollMargin`; subtract it so items sit inline (0 unless set).
+  const offset = virtualItem.start - (virtualizerProps.value.scrollMargin ?? 0)
 
   // For cross-axis gaps: calculate size and position accounting for gaps between lanes
   // laneSize = (100% - (lanes - 1) * gap) / lanes

--- a/src/runtime/components/ScrollArea.vue
+++ b/src/runtime/components/ScrollArea.vue
@@ -116,9 +116,13 @@ const props = useComponentProps<ScrollAreaProps<T>>('scrollArea', _props)
 const { dir } = useLocale()
 const appConfig = useAppConfig() as ScrollArea['AppConfig']
 
+// When an external scroll element is provided, it owns the scroll (the root grows inline).
+const isExternalScroll = computed(() => typeof props.virtualize === 'object' && !!props.virtualize.getScrollElement)
+
 // eslint-disable-next-line vue/no-dupe-keys
 const ui = computed(() => tv({ extend: theme, ...(appConfig.ui?.scrollArea || {}) })({
-  orientation: props.orientation
+  orientation: props.orientation,
+  externalScroll: isExternalScroll.value
 }))
 
 const rootRef = useTemplateRef<ComponentPublicInstance>('rootRef')
@@ -136,9 +140,6 @@ const scrollShadowStyle = props.shadow
 const isRtl = computed(() => dir.value === 'rtl')
 const isHorizontal = computed(() => props.orientation === 'horizontal')
 const isVertical = computed(() => !isHorizontal.value)
-
-// When an external scroll element is provided, it owns the scroll
-const isExternalScroll = computed(() => typeof props.virtualize === 'object' && !!props.virtualize.getScrollElement)
 
 // The scroll viewport: the external element when provided, otherwise the component's root.
 const getScrollElement = () => (isExternalScroll.value ? virtualizerProps.value.getScrollElement?.() : rootRef.value?.$el) ?? null
@@ -308,7 +309,7 @@ defineExpose({
     data-slot="root"
     :data-orientation="props.orientation"
     :class="ui.root({ class: [props.ui?.root, props.class] })"
-    :style="[scrollShadowStyle, isExternalScroll ? { overflow: 'visible' } : undefined]"
+    :style="scrollShadowStyle"
   >
     <template v-if="virtualizer">
       <div

--- a/src/runtime/components/ScrollArea.vue
+++ b/src/runtime/components/ScrollArea.vue
@@ -216,7 +216,7 @@ function getVirtualItemStyle(virtualItem: VirtualItem): CSSProperties {
   const lane = virtualItem.lane
   const gap = virtualizerProps.value.gap ?? 0
   // `start` includes `scrollMargin`; subtract it so items sit inline (0 unless set).
-  const offset = virtualItem.start - (virtualizerProps.value.scrollMargin ?? 0)
+  const offset = virtualItem.start - virtualizerProps.value.scrollMargin
 
   // For cross-axis gaps: calculate size and position accounting for gaps between lanes
   // laneSize = (100% - (lanes - 1) * gap) / lanes

--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -440,8 +440,8 @@ const virtualizerProps = toRef(() => defu(typeof props.virtualize === 'boolean' 
 }))
 
 const getScrollElement = () => (isExternalScroll.value ? virtualizerProps.value.getScrollElement?.() : rootRef.value?.$el) ?? null
-// Offset applied to the spacer rows: `scrollMargin` is the table's offset within an external scroll element.
-const scrollMargin = computed(() => isExternalScroll.value ? (virtualizerProps.value.scrollMargin ?? 0) : 0)
+// Offset applied to the spacer rows: `scrollMargin` is the table's offset within the scroll element (0 unless set).
+const scrollMargin = computed(() => virtualizerProps.value.scrollMargin ?? 0)
 
 const virtualizer = !!props.virtualize && useVirtualizer({
   ...virtualizerProps.value,

--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -287,12 +287,16 @@ function processColumns(columns: TableColumn<T>[]): TableColumn<T>[] {
   })
 }
 
+// When an external scroll element is provided, it owns the scroll (the root grows inline).
+const isExternalScroll = computed(() => typeof props.virtualize === 'object' && !!props.virtualize.getScrollElement)
+
 // eslint-disable-next-line vue/no-dupe-keys
 const ui = computed(() => tv({ extend: theme, ...(appConfig.ui?.table || {}) })({
   sticky: props.sticky,
   loading: props.loading,
   loadingColor: props.loadingColor,
-  loadingAnimation: props.loadingAnimation
+  loadingAnimation: props.loadingAnimation,
+  externalScroll: isExternalScroll.value
 }))
 
 const [DefineTableTemplate, ReuseTableTemplate] = createReusableTemplate()
@@ -435,8 +439,6 @@ const virtualizerProps = toRef(() => defu(typeof props.virtualize === 'boolean' 
   overscan: 12
 }))
 
-// When an external scroll element is provided, it owns the scroll (the root grows inline).
-const isExternalScroll = computed(() => typeof props.virtualize === 'object' && !!props.virtualize.getScrollElement)
 const getScrollElement = () => (isExternalScroll.value ? virtualizerProps.value.getScrollElement?.() : rootRef.value?.$el) ?? null
 // Offset applied to the spacer rows: `scrollMargin` is the table's offset within an external scroll element.
 const scrollMargin = computed(() => isExternalScroll.value ? (virtualizerProps.value.scrollMargin ?? 0) : 0)
@@ -715,14 +717,7 @@ defineExpose({
     </table>
   </DefineTableTemplate>
 
-  <Primitive
-    ref="rootRef"
-    :as="props.as"
-    v-bind="$attrs"
-    data-slot="root"
-    :class="ui.root({ class: [props.ui?.root, props.class] })"
-    :style="isExternalScroll ? { overflow: 'visible' } : undefined"
-  >
+  <Primitive ref="rootRef" :as="props.as" v-bind="$attrs" data-slot="root" :class="ui.root({ class: [props.ui?.root, props.class] })">
     <ReuseTableTemplate />
   </Primitive>
 </template>

--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -103,7 +103,13 @@ export interface TableProps<T extends TableData = TableData> extends TableOption
    * @see https://tanstack.com/virtual/latest/docs/api/virtualizer#options
    * @defaultValue false
    */
-  virtualize?: boolean | (Partial<Omit<VirtualizerOptions<Element, Element>, 'getScrollElement' | 'count' | 'estimateSize' | 'overscan'>> & {
+  virtualize?: boolean | (Partial<Omit<VirtualizerOptions<Element, Element>, 'count' | 'estimateSize' | 'overscan'>> & {
+    /**
+     * Virtualize against an external scroll element instead of the table's own root.
+     * Pair with `scrollMargin` set to the table's offset from the scroll element's start.
+     * @defaultValue undefined
+     */
+    getScrollElement?: () => Element | null
     /**
      * Number of items rendered outside the visible area
      * @defaultValue 12
@@ -429,12 +435,21 @@ const virtualizerProps = toRef(() => defu(typeof props.virtualize === 'boolean' 
   overscan: 12
 }))
 
+// When an external scroll element is provided, it owns the scroll (the root grows inline).
+const isExternalScroll = computed(() => typeof props.virtualize === 'object' && !!props.virtualize.getScrollElement)
+const getScrollElement = () => (isExternalScroll.value ? virtualizerProps.value.getScrollElement?.() : rootRef.value?.$el) ?? null
+// Offset applied to the spacer rows: `scrollMargin` is the table's offset within an external scroll element.
+const scrollMargin = computed(() => isExternalScroll.value ? (virtualizerProps.value.scrollMargin ?? 0) : 0)
+
 const virtualizer = !!props.virtualize && useVirtualizer({
   ...virtualizerProps.value,
   get count() {
     return centerRows.value.length
   },
-  getScrollElement: () => rootRef.value?.$el,
+  get scrollMargin() {
+    return scrollMargin.value
+  },
+  getScrollElement,
   estimateSize: (index: number) => {
     const estimate = virtualizerProps.value.estimateSize
     return typeof estimate === 'function' ? estimate(index) : estimate
@@ -443,11 +458,12 @@ const virtualizer = !!props.virtualize && useVirtualizer({
 
 const virtualItems = computed(() => virtualizer ? virtualizer.value.getVirtualItems() : [])
 
-const virtualPaddingTop = computed(() => virtualItems.value[0]?.start ?? 0)
+// `start`/`end` include `scrollMargin`; exclude it from the spacers so the rows sit inline below preceding content.
+const virtualPaddingTop = computed(() => (virtualItems.value[0]?.start ?? 0) - scrollMargin.value)
 
 const virtualPaddingBottom = computed(() => {
   if (!virtualizer || !virtualItems.value.length) return 0
-  return virtualizer.value.getTotalSize() - (virtualItems.value[virtualItems.value.length - 1]?.end ?? 0)
+  return virtualizer.value.getTotalSize() - (virtualItems.value[virtualItems.value.length - 1]?.end ?? 0) + scrollMargin.value
 })
 
 function valueUpdater<T extends Updater<any>>(updaterOrValue: T, ref: Ref) {
@@ -699,7 +715,14 @@ defineExpose({
     </table>
   </DefineTableTemplate>
 
-  <Primitive ref="rootRef" :as="props.as" v-bind="$attrs" data-slot="root" :class="ui.root({ class: [props.ui?.root, props.class] })">
+  <Primitive
+    ref="rootRef"
+    :as="props.as"
+    v-bind="$attrs"
+    data-slot="root"
+    :class="ui.root({ class: [props.ui?.root, props.class] })"
+    :style="isExternalScroll ? { overflow: 'visible' } : undefined"
+  >
     <ReuseTableTemplate />
   </Primitive>
 </template>

--- a/src/theme/scroll-area.ts
+++ b/src/theme/scroll-area.ts
@@ -16,6 +16,11 @@ export default {
         viewport: 'flex-row',
         item: ''
       }
+    },
+    externalScroll: {
+      true: {
+        root: 'overflow-visible'
+      }
     }
   }
 }

--- a/src/theme/table.ts
+++ b/src/theme/table.ts
@@ -39,6 +39,11 @@ export default (options: Required<ModuleOptions>) => ({
         thead: 'after:absolute after:z-1 after:h-px'
       }
     },
+    externalScroll: {
+      true: {
+        root: 'overflow-visible'
+      }
+    },
     loadingAnimation: {
       'carousel': '',
       'carousel-inverse': '',

--- a/test/components/Table.spec.ts
+++ b/test/components/Table.spec.ts
@@ -180,6 +180,7 @@ describe('Table', () => {
     ['with meta field on columns', { props: { ...props, columns: columns.map(c => ({ ...c, meta: { class: { th: 'custom-heading-class', td: 'custom-cell-class' }, style: { th: { backgroundColor: 'black' }, td: { backgroundColor: 'lightgray' } } } })) } }],
     ['with virtualize', { props: { ...props, virtualize: true } }],
     ['with virtualize and sticky', { props: { ...props, columns, virtualize: true, sticky: true } }],
+    ['with virtualize external scroll element', { props: { ...props, virtualize: { getScrollElement: () => document.body, scrollMargin: 20 } } }],
     ['with row pinning', { props: { ...props, rowPinning: { top: ['2'], bottom: ['3'] } } }],
     ['with row pinning and virtualization', { props: { ...props, virtualize: true, rowPinning: { top: ['2'], bottom: ['3'] } } }],
     ['with as', { props: { ...props, as: 'section' } }],

--- a/test/components/__snapshots__/ScrollArea-vue.spec.ts.snap
+++ b/test/components/__snapshots__/ScrollArea-vue.spec.ts.snap
@@ -83,7 +83,7 @@ exports[`ScrollArea > renders with virtualize boolean correctly 1`] = `
 `;
 
 exports[`ScrollArea > renders with virtualize external scroll element correctly 1`] = `
-"<div data-slot="root" data-orientation="vertical" class="relative outline-primary/25 focus-visible:outline-3 overflow-y-auto overflow-x-hidden" style="overflow: visible;">
+"<div data-slot="root" data-orientation="vertical" class="relative outline-primary/25 focus-visible:outline-3 overflow-visible">
   <div data-slot="viewport" class="relative flex flex-col" style="position: relative; inline-size: 100%; block-size: 300px;"></div>
 </div>"
 `;

--- a/test/components/__snapshots__/ScrollArea.spec.ts.snap
+++ b/test/components/__snapshots__/ScrollArea.spec.ts.snap
@@ -83,7 +83,7 @@ exports[`ScrollArea > renders with virtualize boolean correctly 1`] = `
 `;
 
 exports[`ScrollArea > renders with virtualize external scroll element correctly 1`] = `
-"<div data-slot="root" data-orientation="vertical" class="relative outline-primary/25 focus-visible:outline-3 overflow-y-auto overflow-x-hidden" style="overflow: visible;">
+"<div data-slot="root" data-orientation="vertical" class="relative outline-primary/25 focus-visible:outline-3 overflow-visible">
   <div data-slot="viewport" class="relative flex flex-col" style="position: relative; inline-size: 100%; block-size: 300px;"></div>
 </div>"
 `;

--- a/test/components/__snapshots__/Table-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Table-vue.spec.ts.snap
@@ -2064,6 +2064,28 @@ exports[`Table > renders with virtualize correctly 1`] = `
 </div>"
 `;
 
+exports[`Table > renders with virtualize external scroll element correctly 1`] = `
+"<div data-slot="root" class="relative overflow-auto outline-primary/25 focus-visible:outline-3" style="overflow: visible;">
+  <table data-slot="base" class="min-w-full overflow-clip">
+    <!--v-if-->
+    <thead data-slot="thead" class="relative">
+      <tr data-slot="tr" class="data-[selected=true]:bg-elevated/50">
+        <th data-pinned="false" scope="col" data-slot="th" class="px-4 py-3.5 text-sm text-highlighted text-left rtl:text-right font-semibold [&amp;:has([role=checkbox])]:pe-0">Id</th>
+        <th data-pinned="false" scope="col" data-slot="th" class="px-4 py-3.5 text-sm text-highlighted text-left rtl:text-right font-semibold [&amp;:has([role=checkbox])]:pe-0">Amount</th>
+        <th data-pinned="false" scope="col" data-slot="th" class="px-4 py-3.5 text-sm text-highlighted text-left rtl:text-right font-semibold [&amp;:has([role=checkbox])]:pe-0">Status</th>
+        <th data-pinned="false" scope="col" data-slot="th" class="px-4 py-3.5 text-sm text-highlighted text-left rtl:text-right font-semibold [&amp;:has([role=checkbox])]:pe-0">Email</th>
+      </tr>
+      <tr data-slot="separator" class="absolute z-1 left-0 w-full h-px bg-(--ui-border-accented)"></tr>
+    </thead>
+    <tbody data-slot="tbody" class="isolate [&amp;>tr]:data-[selectable=true]:hover:bg-elevated/50 [&amp;>tr]:data-[selectable=true]:outline-primary/25 [&amp;>tr]:data-[selectable=true]:focus-visible:outline-3 divide-y divide-default">
+      <!--v-if-->
+      <!--v-if-->
+    </tbody>
+    <!--v-if-->
+  </table>
+</div>"
+`;
+
 exports[`Table > renders without data correctly 1`] = `
 "<div data-slot="root" class="relative overflow-auto outline-primary/25 focus-visible:outline-3">
   <table data-slot="base" class="min-w-full overflow-clip">

--- a/test/components/__snapshots__/Table-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Table-vue.spec.ts.snap
@@ -2065,7 +2065,7 @@ exports[`Table > renders with virtualize correctly 1`] = `
 `;
 
 exports[`Table > renders with virtualize external scroll element correctly 1`] = `
-"<div data-slot="root" class="relative overflow-auto outline-primary/25 focus-visible:outline-3" style="overflow: visible;">
+"<div data-slot="root" class="relative outline-primary/25 focus-visible:outline-3 overflow-visible">
   <table data-slot="base" class="min-w-full overflow-clip">
     <!--v-if-->
     <thead data-slot="thead" class="relative">

--- a/test/components/__snapshots__/Table.spec.ts.snap
+++ b/test/components/__snapshots__/Table.spec.ts.snap
@@ -2064,6 +2064,28 @@ exports[`Table > renders with virtualize correctly 1`] = `
 </div>"
 `;
 
+exports[`Table > renders with virtualize external scroll element correctly 1`] = `
+"<div data-slot="root" class="relative overflow-auto outline-primary/25 focus-visible:outline-3" style="overflow: visible;">
+  <table data-slot="base" class="min-w-full overflow-clip">
+    <!--v-if-->
+    <thead data-slot="thead" class="relative">
+      <tr data-slot="tr" class="data-[selected=true]:bg-elevated/50">
+        <th data-pinned="false" scope="col" data-slot="th" class="px-4 py-3.5 text-sm text-highlighted text-left rtl:text-right font-semibold [&amp;:has([role=checkbox])]:pe-0">Id</th>
+        <th data-pinned="false" scope="col" data-slot="th" class="px-4 py-3.5 text-sm text-highlighted text-left rtl:text-right font-semibold [&amp;:has([role=checkbox])]:pe-0">Amount</th>
+        <th data-pinned="false" scope="col" data-slot="th" class="px-4 py-3.5 text-sm text-highlighted text-left rtl:text-right font-semibold [&amp;:has([role=checkbox])]:pe-0">Status</th>
+        <th data-pinned="false" scope="col" data-slot="th" class="px-4 py-3.5 text-sm text-highlighted text-left rtl:text-right font-semibold [&amp;:has([role=checkbox])]:pe-0">Email</th>
+      </tr>
+      <tr data-slot="separator" class="absolute z-1 left-0 w-full h-px bg-(--ui-border-accented)"></tr>
+    </thead>
+    <tbody data-slot="tbody" class="isolate [&amp;>tr]:data-[selectable=true]:hover:bg-elevated/50 [&amp;>tr]:data-[selectable=true]:outline-primary/25 [&amp;>tr]:data-[selectable=true]:focus-visible:outline-3 divide-y divide-default">
+      <!--v-if-->
+      <!--v-if-->
+    </tbody>
+    <!--v-if-->
+  </table>
+</div>"
+`;
+
 exports[`Table > renders without data correctly 1`] = `
 "<div data-slot="root" class="relative overflow-auto outline-primary/25 focus-visible:outline-3">
   <table data-slot="base" class="min-w-full overflow-clip">

--- a/test/components/__snapshots__/Table.spec.ts.snap
+++ b/test/components/__snapshots__/Table.spec.ts.snap
@@ -2065,7 +2065,7 @@ exports[`Table > renders with virtualize correctly 1`] = `
 `;
 
 exports[`Table > renders with virtualize external scroll element correctly 1`] = `
-"<div data-slot="root" class="relative overflow-auto outline-primary/25 focus-visible:outline-3" style="overflow: visible;">
+"<div data-slot="root" class="relative outline-primary/25 focus-visible:outline-3 overflow-visible">
   <table data-slot="base" class="min-w-full overflow-clip">
     <!--v-if-->
     <thead data-slot="thead" class="relative">


### PR DESCRIPTION
Follow-up to #6650 (which added this to `ScrollArea`), suggested by @benjamincanac in that thread.

Allow passing `getScrollElement` through the `virtualize` prop so a virtualized table can scroll against an ancestor container instead of its own root. This lets a page header (or other surrounding content) and the table body share a single scrollbar rather than nesting a second scroller. Pair it with `scrollMargin` set to the table's offset from the scroll element's start.

Same public API change as #6650. Because `Table` uses padding-row spacers instead of `ScrollArea`'s absolute transforms, the offset handling differs in implementation: the top spacer subtracts `scrollMargin` and the bottom spacer adds it back, so the rows sit inline below the preceding content. When an external element is provided the root drops its own `overflow`, since it no longer owns the scroll.

Resolves #6656.

### Changes
- Expose `getScrollElement` in the `virtualize` prop options type
- Account for `scrollMargin` in the virtual padding spacers
- Drop the root scroll viewport in external mode
- Add a docs example and a "With external scroll element" section