### PR TITLE
fix(module): avoid unhead v2-only `hookOnce` in colors plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,7 +95,6 @@ Load these based on your task. **Do not load all files at once** — only load w
 | Semantic colors | Use `text-default`, `bg-elevated`, etc. - never Tailwind palette |
 | Reka UI props | Use `reactivePick` + `useForwardProps(source, emits?)` from `composables/useForwardProps` to forward props (proxy-aware; reka-ui's `useForwardProps` / `useForwardPropsEmits` filter out `<UTheme :props>` defaults) |
 | Form components | Use `useFormField` and `useFieldGroup` composables |
-| Unhead compatibility | `@unhead/vue` is kept at **v2** to stay aligned with Nuxt, but the library also runs in Vue apps on unhead **v3**. Only use head APIs present in both: on v3 `injectHead().hooks` is a `HookableCore` (exposes `hook` / `removeHook` / `callHook` only, and is typed optional) — **not** the full v2 `Hookable`. Avoid v2-only methods like `hookOnce`; use `head.hooks?.hook(...)` and self-unhook for once semantics. |
 
 ## Component Creation Workflow
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -95,6 +95,7 @@ Load these based on your task. **Do not load all files at once** — only load w
 | Semantic colors | Use `text-default`, `bg-elevated`, etc. - never Tailwind palette |
 | Reka UI props | Use `reactivePick` + `useForwardProps(source, emits?)` from `composables/useForwardProps` to forward props (proxy-aware; reka-ui's `useForwardProps` / `useForwardPropsEmits` filter out `<UTheme :props>` defaults) |
 | Form components | Use `useFormField` and `useFieldGroup` composables |
+| Unhead compatibility | `@unhead/vue` is kept at **v2** to stay aligned with Nuxt, but the library also runs in Vue apps on unhead **v3**. Only use head APIs present in both: on v3 `injectHead().hooks` is a `HookableCore` (exposes `hook` / `removeHook` / `callHook` only, and is typed optional) — **not** the full v2 `Hookable`. Avoid v2-only methods like `hookOnce`; use `head.hooks?.hook(...)` and self-unhook for once semantics. |
 
 ## Component Creation Workflow
 

--- a/src/runtime/plugins/colors.ts
+++ b/src/runtime/plugins/colors.ts
@@ -62,7 +62,13 @@ export default defineNuxtPlugin(() => {
     style.setAttribute('data-nuxt-ui-colors', '')
     document.head.appendChild(style)
 
-    injectHead().hooks.hookOnce('dom:rendered', removeTemporaryColorsStyle)
+    // `hookOnce` is only available on unhead v2's `Hookable`. In v3 `hooks` is a `HookableCore`
+    // that exposes `hook` only, so self-unhook to keep the once semantics across both versions.
+    const head = injectHead()
+    const unhook = head.hooks?.hook('dom:rendered', () => {
+      removeTemporaryColorsStyle()
+      unhook?.()
+    })
   }
 
   useHead(headData)


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6642

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

#6577 cleaned up the temporary anti-FOUC `<style data-nuxt-ui-colors>` via `injectHead().hooks.hookOnce('dom:rendered', ...)`. `hookOnce` only exists on unhead v2's full `Hookable`. In unhead v3 the head's `hooks` is a `HookableCore` that exposes `hook`/`removeHook`/`callHook` only (and is typed optional), so the call throws `hooks.hookOnce is not a function` in Vue apps using unhead v3.

This avoids upgrading `@unhead/vue` (kept at v2 to stay aligned with Nuxt) by using `hook`, which is present on both v2 and v3, and self-unhooking to preserve the once semantics. The `dom:rendered` hook itself still exists and fires in both versions.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.