### PR TITLE
fix(defineShortcuts): ignore key events during IME composition

### DIFF
--- a/src/runtime/composables/defineShortcuts.ts
+++ b/src/runtime/composables/defineShortcuts.ts
@@ -108,6 +108,13 @@ export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: Shor
   const shiftableCodes = shiftableKeys.map(k => convertKeyToCode(k))
 
   const onKeyDown = (e: KeyboardEvent) => {
+    // Ignore keydowns dispatched during IME composition (for example picking a
+    // Japanese or Chinese candidate), otherwise the composed keystrokes can match
+    // and fire a shortcut. Same condition as the useIMEGuard composable.
+    if (e.isComposing || e.keyCode === 229) {
+      return
+    }
+
     // Input autocomplete triggers a keydown event
     if (!e.key) {
       return

--- a/test/composables/defineShortcuts.spec.ts
+++ b/test/composables/defineShortcuts.spec.ts
@@ -456,4 +456,32 @@ describe('defineShortcuts', () => {
       expect(handler).not.toHaveBeenCalled()
     })
   })
+
+  describe('IME composition', () => {
+    it('does NOT trigger a shortcut while composing', async () => {
+      const handler = vi.fn()
+      await registerShortcuts({ a: handler })
+
+      fireKeydown('a', { isComposing: true })
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('does NOT accumulate chained input while composing', async () => {
+      const handler = vi.fn()
+      await registerShortcuts({ 'g-i': handler })
+
+      fireKeydown('g', { isComposing: true })
+      fireKeydown('i', { isComposing: true })
+      expect(handler).not.toHaveBeenCalled()
+    })
+
+    it('triggers once composition has ended', async () => {
+      const handler = vi.fn()
+      await registerShortcuts({ a: handler })
+
+      fireKeydown('a', { isComposing: true })
+      fireKeydown('a')
+      expect(handler).toHaveBeenCalledOnce()
+    })
+  })
 })


### PR DESCRIPTION
`defineShortcuts` attaches a `keydown` listener to `window` and matches every event against the registered shortcuts. It does not check whether an IME composition is in progress, so the keystrokes used to compose CJK text are treated as shortcut input.

While composing (Japanese, Chinese, and so on):

- A shortcut registered with `usingInput` stays active while an input is focused, so it fires on the keys that build up a candidate, including the Enter that confirms it.
- Each composition keydown is also pushed into `chainedInputs`, so composing romaji such as "gi" can match a chained shortcut like `g-i`.

The repo already handles this in `useIMEGuard` (used by `ChatPrompt`), which bails on `event.isComposing || event.keyCode === 229`. This change applies the same condition at the top of the `keydown` handler, so shortcuts are skipped during composition and work normally once it ends. The `keyCode === 229` fallback is kept to match `useIMEGuard`, since `isComposing` is not reliable during composition in every browser.

Tests in `test/composables/defineShortcuts.spec.ts` cover a single-key shortcut and a chained shortcut staying quiet while `isComposing` is set, plus a normal press still firing after composition ends. Removing the guard makes the first two fail.
