### PR TITLE
fix(Button): allow inline event handlers with non-void return types

### DIFF
--- a/src/runtime/components/BlogPost.vue
+++ b/src/runtime/components/BlogPost.vue
@@ -41,7 +41,7 @@ export interface BlogPostProps {
   variant?: BlogPost['variants']['variant']
   to?: LinkProps['to']
   target?: LinkProps['target']
-  onClick?: (event: MouseEvent) => void | Promise<void>
+  onClick?: (event: MouseEvent) => void
   class?: any
   ui?: BlogPost['slots']
 }

--- a/src/runtime/components/Button.vue
+++ b/src/runtime/components/Button.vue
@@ -31,7 +31,7 @@ export interface ButtonProps extends UseComponentIconsProps, Omit<LinkProps, 'ra
   block?: boolean
   /** Set loading state automatically based on the `@click` promise state */
   loadingAuto?: boolean
-  onClick?: ((event: MouseEvent) => void | Promise<void>) | Array<((event: MouseEvent) => void | Promise<void>)>
+  onClick?: ((event: MouseEvent) => void) | Array<((event: MouseEvent) => void)>
   class?: any
   ui?: Button['slots']
 }

--- a/src/runtime/components/ChangelogVersion.vue
+++ b/src/runtime/components/ChangelogVersion.vue
@@ -37,7 +37,7 @@ export interface ChangelogVersionProps {
   indicator?: boolean
   to?: LinkProps['to']
   target?: LinkProps['target']
-  onClick?: (event: MouseEvent) => void | Promise<void>
+  onClick?: (event: MouseEvent) => void
   class?: any
   ui?: ChangelogVersion['slots']
 }

--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -62,7 +62,7 @@ export type FormProps<S extends FormSchema, T extends boolean = true, N extends 
   loadingAuto?: boolean
   class?: any
   ui?: { base?: any }
-  onSubmit?: ((event: FormSubmitEvent<FormData<S, T>>) => void | Promise<void>) | (() => void | Promise<void>)
+  onSubmit?: ((event: FormSubmitEvent<FormData<S, T>>) => void) | (() => void)
 } & /** @vue-ignore */ Omit<FormHTMLAttributes, 'name'>
 
 export interface FormEmits<S extends FormSchema, T extends boolean = true> {

--- a/src/runtime/components/LinkBase.vue
+++ b/src/runtime/components/LinkBase.vue
@@ -5,7 +5,7 @@ export interface LinkBaseProps {
   as?: string
   type?: string
   disabled?: boolean
-  onClick?: ((e: MouseEvent) => void | Promise<void>) | Array<((e: MouseEvent) => void | Promise<void>)>
+  onClick?: ((e: MouseEvent) => void) | Array<((e: MouseEvent) => void)>
   href?: string | null
   navigate?: (e: MouseEvent) => void
   target?: LinkProps['target']

--- a/src/runtime/components/PageCard.vue
+++ b/src/runtime/components/PageCard.vue
@@ -53,7 +53,7 @@ export interface PageCardProps {
   variant?: PageCard['variants']['variant']
   to?: LinkProps['to']
   target?: LinkProps['target']
-  onClick?: (event: MouseEvent) => void | Promise<void>
+  onClick?: (event: MouseEvent) => void
   class?: any
   ui?: PageCard['slots']
 }

--- a/src/runtime/components/PageFeature.vue
+++ b/src/runtime/components/PageFeature.vue
@@ -28,7 +28,7 @@ export interface PageFeatureProps {
   orientation?: PageFeature['variants']['orientation']
   to?: LinkProps['to']
   target?: LinkProps['target']
-  onClick?: (event: MouseEvent) => void | Promise<void>
+  onClick?: (event: MouseEvent) => void
   class?: any
   ui?: PageFeature['slots']
 }

--- a/src/runtime/components/User.vue
+++ b/src/runtime/components/User.vue
@@ -30,7 +30,7 @@ export interface UserProps {
   orientation?: User['variants']['orientation']
   to?: LinkProps['to']
   target?: LinkProps['target']
-  onClick?: (event: MouseEvent) => void | Promise<void>
+  onClick?: (event: MouseEvent) => void
   class?: any
   ui?: User['slots']
 }

--- a/src/runtime/vue/overrides/inertia/LinkBase.vue
+++ b/src/runtime/vue/overrides/inertia/LinkBase.vue
@@ -5,7 +5,7 @@ export interface LinkBaseProps {
   as?: string
   type?: string
   disabled?: boolean
-  onClick?: ((e: MouseEvent) => void | Promise<void>) | Array<((e: MouseEvent) => void | Promise<void>)>
+  onClick?: ((e: MouseEvent) => void) | Array<((e: MouseEvent) => void)>
   href?: string
   target?: LinkProps['target']
   rel?: LinkProps['rel']


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6660

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since `vue-tsc@3.3.6` ([this change](https://github.com/vuejs/language-tools/commit/9b6fb7fc787f8c5fafa7a315e79431eb8d466a45)) started checking the return type of inline event handlers, idiomatic templates like `<UButton @click="open = true" />` began failing with:

```
Type '(event: MouseEvent) => boolean' is not assignable to type '(event: MouseEvent) => void | Promise<void>'.
```

TypeScript has a special leniency where a function returning any value is assignable to `() => void` (the return value is ignored), which is why `@click="count++"` works on a native `<button>`. That leniency does not apply when `void` is part of a union, so `void | Promise<void>` was rejecting these handlers.

Dropping `| Promise<void>` from the handler prop types resolves it while staying fully backward compatible:

- Async handlers still type-check, since `Promise<void>` is assignable to `void`.
- `loadingAuto` is unaffected, as the returned value is awaited at runtime regardless of the declared type.
- It only widens the public prop types, so no consumer code breaks.

Applied to `onClick` on `Button`, `LinkBase`, `BlogPost`, `ChangelogVersion`, `PageCard`, `PageFeature`, `User`, and `onSubmit` on `Form`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
