### PR TITLE
fix(ChatMessages): re-evaluate streaming indicator on each render

### DIFF
--- a/src/runtime/components/ChatMessages.vue
+++ b/src/runtime/components/ChatMessages.vue
@@ -108,13 +108,20 @@ const props = useComponentProps<ChatMessagesProps<T>>('chatMessages', _props)
 
 const getProxySlots = () => omit(slots, ['default', 'indicator', 'viewport'])
 
-const showIndicator = computed(() => {
+// This is intentionally a function (not a `computed`) so it is re-evaluated on
+// every render. `@ai-sdk/vue` stores messages in a `shallowRef` and grows them
+// via in-place mutation + `triggerRef`, so the array reference and the message
+// objects never change identity. A `computed` would cache its result on the
+// first `streaming` render (when the assistant message is still empty) and never
+// recompute as parts stream in, leaving the indicator stuck. Evaluating during
+// render ties the indicator to the same re-render that displays the streamed content.
+function showIndicator() {
   if (props.status === 'submitted') return true
   if (props.status !== 'streaming') return false
 
   const lastMessage = props.messages?.[props.messages.length - 1]
   return lastMessage?.role === 'assistant' && !lastMessage.parts?.length
-})
+}
 
 const appConfig = useAppConfig() as ChatMessages['AppConfig']
 
@@ -341,7 +348,7 @@ defineExpose({
     </slot>
 
     <UChatMessage
-      v-if="showIndicator"
+      v-if="showIndicator()"
       id="indicator"
       role="assistant"
       v-bind="{ ...assistantProps, actions: undefined, parts: [] }"

--- a/test/components/ChatMessages.spec.ts
+++ b/test/components/ChatMessages.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect } from 'vitest'
+import { defineComponent, h, nextTick, ref, shallowRef, triggerRef } from 'vue'
 import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { renderEach } from '../component-render'
@@ -74,6 +75,43 @@ describe('ChatMessages', () => {
       parts: messages[1]!.parts,
       message: messages[1]
     })
+  })
+
+  it('hides the streaming indicator once the assistant message produces parts', async () => {
+    // Reproduces the `@ai-sdk/vue` reactivity model: messages live in a `shallowRef`
+    // and grow via in-place mutation + `triggerRef`, so neither the array nor the
+    // message objects ever change identity. When the server assigns the assistant
+    // message id, an empty assistant message is flushed before any content, so the
+    // indicator must appear then disappear as soon as parts stream in.
+    const messages = shallowRef<any[]>([
+      { id: 'u1', role: 'user', parts: [{ type: 'text', text: 'hi' }] },
+      { id: 'a1', role: 'assistant', parts: [] }
+    ])
+    // A separate reactive value bound to a prop, used only to force ChatMessages to
+    // re-render on each tick, mimicking how streamed content forces re-renders in a
+    // real app (dynamic slots / non-static prop references).
+    const tick = ref(0)
+
+    const Parent = defineComponent({
+      setup() {
+        return () => h(ChatMessages, { messages: messages.value, status: 'streaming', spacingOffset: tick.value })
+      }
+    })
+
+    const wrapper = await mountSuspended(Parent)
+
+    // Empty assistant message -> indicator visible.
+    expect(wrapper.find('[data-slot="indicator"]').exists()).toBe(true)
+
+    // Stream the first part in place + triggerRef, and force a re-render.
+    messages.value[1]!.parts.push({ type: 'text', text: 'Hello' })
+    triggerRef(messages)
+    tick.value++
+    await nextTick()
+
+    // A cached `computed` would stay stuck on its first `streaming` result here;
+    // the indicator must now be gone.
+    expect(wrapper.find('[data-slot="indicator"]').exists()).toBe(false)
   })
 
   it('forwards `message` to the actions slot', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When the server assigns an id to the assistant message (`toUIMessageStream({ generateMessageId })`, common when persisting messages), the `UChatMessages` loading indicator stayed visible below the streaming answer for the whole response instead of disappearing once the first content arrived.

The cause was a stale `computed`. With AI SDK v7, `@ai-sdk/vue` stores messages in a `shallowRef` and grows them via in place mutation plus `triggerRef`, so the array reference and the message objects never change identity. `showIndicator` reads `lastMessage.parts?.length`, but that nested read is never tracked, so the `computed` cached its result on the first `streaming` render (when a server assigned id has already materialised an empty assistant message) and only recomputed once the status flipped to `ready` at the end.

The fix turns `showIndicator` into a plain function evaluated on every render, which ties it to the same re-render that displays the streamed content. This is a v7 only regression: on v6 `@ai-sdk/vue` uses a deep reactive `ref` and swaps the array on push, so the `computed` tracked correctly there, and the function stays correct under both models.

Added a regression test that reproduces the reactivity model (`shallowRef` plus in place mutation plus `triggerRef`) and fails against the previous `computed`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.