### PR TITLE
fix(Link): apply `rel` prop to internal links

### DIFF
--- a/src/runtime/components/Link.vue
+++ b/src/runtime/components/Link.vue
@@ -195,17 +195,25 @@ const isInternalLink = computed(() => {
   return true
 })
 
-const externalRel = computed(() => {
-  if (props.noRel) return null
-  if (props.rel) return props.rel
-  return 'noopener noreferrer'
-})
+// NuxtLink strips `rel` from its slot props when rendered with `custom`, so
+// the prop is applied here for every branch instead of read from the slot.
+const rel = computed(() => {
+  // If noRel is explicitly set, return null
+  if (props.noRel) {
+    return null
+  }
 
-// NuxtLink only forwards `rel` to the underlying RouterLink when it is not
-// rendered with `custom`, so internal links must apply the prop themselves.
-const internalRel = computed(() => {
-  if (props.noRel) return null
-  return props.rel || null
+  // If rel is explicitly set, use it
+  if (props.rel !== undefined) {
+    return props.rel || null
+  }
+
+  // Default to "noopener noreferrer" for external links
+  if (!isInternalLink.value) {
+    return 'noopener noreferrer'
+  }
+
+  return null
 })
 
 function isLinkActive({ route: linkRoute, isActive, isExactActive }: any = {}) {
@@ -261,7 +269,7 @@ function resolveLinkClass({ route, isActive, isExactActive }: any = {}) {
           disabled,
           href,
           navigate,
-          rel: (rest as NuxtLinkDefaultSlotProps).rel ?? internalRel,
+          rel,
           target: (rest as NuxtLinkDefaultSlotProps).target,
           isExternal: (rest as NuxtLinkDefaultSlotProps).isExternal,
           active: isLinkActive({ route: linkRoute, isActive, isExactActive })
@@ -278,7 +286,7 @@ function resolveLinkClass({ route, isActive, isExactActive }: any = {}) {
         disabled,
         href,
         navigate,
-        rel: (rest as NuxtLinkDefaultSlotProps).rel ?? internalRel,
+        rel,
         target: (rest as NuxtLinkDefaultSlotProps).target,
         isExternal: (rest as NuxtLinkDefaultSlotProps).isExternal
       }"
@@ -295,7 +303,7 @@ function resolveLinkClass({ route, isActive, isExactActive }: any = {}) {
         as,
         type,
         disabled,
-        ...(to ? { href: String(to), target: props.target, rel: externalRel, isExternal: true } : {}),
+        ...(to ? { href: String(to), target: props.target, rel, isExternal: true } : {}),
         active: active ?? false
       }"
     />
@@ -307,7 +315,7 @@ function resolveLinkClass({ route, isActive, isExactActive }: any = {}) {
       as,
       type,
       disabled,
-      ...(to ? { href: String(to), target: props.target, rel: externalRel, isExternal: true } : {})
+      ...(to ? { href: String(to), target: props.target, rel, isExternal: true } : {})
     }"
     :class="resolveLinkClass()"
   >

--- a/src/runtime/components/Link.vue
+++ b/src/runtime/components/Link.vue
@@ -201,6 +201,13 @@ const externalRel = computed(() => {
   return 'noopener noreferrer'
 })
 
+// NuxtLink only forwards `rel` to the underlying RouterLink when it is not
+// rendered with `custom`, so internal links must apply the prop themselves.
+const internalRel = computed(() => {
+  if (props.noRel) return null
+  return props.rel || null
+})
+
 function isLinkActive({ route: linkRoute, isActive, isExactActive }: any = {}) {
   if (props.active !== undefined) {
     return props.active
@@ -254,7 +261,7 @@ function resolveLinkClass({ route, isActive, isExactActive }: any = {}) {
           disabled,
           href,
           navigate,
-          rel: (rest as NuxtLinkDefaultSlotProps).rel,
+          rel: (rest as NuxtLinkDefaultSlotProps).rel ?? internalRel,
           target: (rest as NuxtLinkDefaultSlotProps).target,
           isExternal: (rest as NuxtLinkDefaultSlotProps).isExternal,
           active: isLinkActive({ route: linkRoute, isActive, isExactActive })
@@ -271,7 +278,7 @@ function resolveLinkClass({ route, isActive, isExactActive }: any = {}) {
         disabled,
         href,
         navigate,
-        rel: (rest as NuxtLinkDefaultSlotProps).rel,
+        rel: (rest as NuxtLinkDefaultSlotProps).rel ?? internalRel,
         target: (rest as NuxtLinkDefaultSlotProps).target,
         isExternal: (rest as NuxtLinkDefaultSlotProps).isExternal
       }"

--- a/src/runtime/components/Link.vue
+++ b/src/runtime/components/Link.vue
@@ -208,8 +208,8 @@ const rel = computed(() => {
     return props.rel || null
   }
 
-  // Default to "noopener noreferrer" for external links
-  if (!isInternalLink.value) {
+  // Default to "noopener noreferrer" for external links or links with target
+  if (!isInternalLink.value || (props.target && props.target !== '_self')) {
     return 'noopener noreferrer'
   }
 

--- a/src/runtime/vue/overrides/inertia/Link.vue
+++ b/src/runtime/vue/overrides/inertia/Link.vue
@@ -94,7 +94,7 @@ const page = usePage()
 
 const appConfig = useAppConfig() as Link['AppConfig']
 
-const routerLinkProps = useForwardProps(reactiveOmit(props, 'as', 'type', 'disabled', 'active', 'exact', 'activeClass', 'inactiveClass', 'to', 'href', 'raw', 'custom', 'class', 'noRel'))
+const routerLinkProps = useForwardProps(reactiveOmit(props, 'as', 'type', 'disabled', 'active', 'exact', 'activeClass', 'inactiveClass', 'to', 'href', 'raw', 'custom', 'class', 'target', 'rel', 'noRel'))
 
 const ui = computed(() => tv({
   extend: theme,

--- a/src/runtime/vue/overrides/none/Link.vue
+++ b/src/runtime/vue/overrides/none/Link.vue
@@ -122,6 +122,8 @@ const isExternal = computed(() => {
   return hasProtocol(href.value, { acceptRelative: true })
 })
 
+const hasTarget = computed(() => !!props.target && props.target !== '_self')
+
 const isLinkActive = computed(() => {
   if (props.active !== undefined) {
     return props.active
@@ -140,16 +142,19 @@ const linkClass = computed(() => {
   return ui.value({ class: props.class, active, disabled: props.disabled })
 })
 
-const linkRel = computed(() => {
+const rel = computed(() => {
+  // If noRel is explicitly set, return null
   if (props.noRel) {
     return null
   }
 
-  if (props.rel) {
-    return props.rel
+  // If rel is explicitly set, use it
+  if (props.rel !== undefined) {
+    return props.rel || null
   }
 
-  if (isExternal.value) {
+  // Default to "noopener noreferrer" for external links or links with target
+  if (isExternal.value || hasTarget.value) {
     return 'noopener noreferrer'
   }
 
@@ -179,7 +184,7 @@ const navigate = handleNavigation
         disabled,
         href,
         navigate,
-        rel: linkRel,
+        rel,
         target: target || (isExternal ? '_blank' : undefined),
         isExternal,
         active: isLinkActive
@@ -195,7 +200,7 @@ const navigate = handleNavigation
       disabled,
       href,
       navigate,
-      rel: linkRel,
+      rel,
       target: target || (isExternal ? '_blank' : undefined),
       isExternal
     }"

--- a/src/runtime/vue/overrides/vue-router/Link.vue
+++ b/src/runtime/vue/overrides/vue-router/Link.vue
@@ -89,7 +89,7 @@ const route = useRoute()
 
 const appConfig = useAppConfig() as Link['AppConfig']
 
-const routerLinkProps = useForwardProps(reactiveOmit(props, 'as', 'type', 'disabled', 'active', 'exact', 'exactQuery', 'exactHash', 'activeClass', 'inactiveClass', 'to', 'href', 'raw', 'custom', 'class', 'rel', 'noRel'))
+const routerLinkProps = useForwardProps(reactiveOmit(props, 'as', 'type', 'disabled', 'active', 'exact', 'exactQuery', 'exactHash', 'activeClass', 'inactiveClass', 'to', 'href', 'raw', 'custom', 'class', 'target', 'rel', 'noRel'))
 
 const ui = computed(() => tv({
   extend: theme,

--- a/src/runtime/vue/overrides/vue-router/Link.vue
+++ b/src/runtime/vue/overrides/vue-router/Link.vue
@@ -89,7 +89,7 @@ const route = useRoute()
 
 const appConfig = useAppConfig() as Link['AppConfig']
 
-const routerLinkProps = useForwardProps(reactiveOmit(props, 'as', 'type', 'disabled', 'active', 'exact', 'exactQuery', 'exactHash', 'activeClass', 'inactiveClass', 'to', 'href', 'raw', 'custom', 'class', 'noRel'))
+const routerLinkProps = useForwardProps(reactiveOmit(props, 'as', 'type', 'disabled', 'active', 'exact', 'exactQuery', 'exactHash', 'activeClass', 'inactiveClass', 'to', 'href', 'raw', 'custom', 'class', 'rel', 'noRel'))
 
 const ui = computed(() => tv({
   extend: theme,

--- a/test/components/Link.spec.ts
+++ b/test/components/Link.spec.ts
@@ -20,6 +20,7 @@ describe('Link', () => {
     ['with external to', { props: { to: 'https://example.com' } }],
     ['with external to and target', { props: { to: 'https://example.com', target: '_blank' } }],
     ['with internal to and target', { props: { to: '/about', target: '_blank' } }],
+    ['with internal to object and target', { props: { to: { path: '/about' }, target: '_blank' } }],
     ['with internal to and rel', { props: { to: '/about', rel: 'nofollow' } }],
     ['with internal to and noRel', { props: { to: '/about', rel: 'nofollow', noRel: true } }],
     ['with external to and rel', { props: { to: 'https://example.com', rel: 'nofollow' } }],

--- a/test/components/Link.spec.ts
+++ b/test/components/Link.spec.ts
@@ -20,6 +20,9 @@ describe('Link', () => {
     ['with external to', { props: { to: 'https://example.com' } }],
     ['with external to and target', { props: { to: 'https://example.com', target: '_blank' } }],
     ['with internal to and target', { props: { to: '/about', target: '_blank' } }],
+    ['with internal to and rel', { props: { to: '/about', rel: 'nofollow' } }],
+    ['with internal to and noRel', { props: { to: '/about', rel: 'nofollow', noRel: true } }],
+    ['with external to and rel', { props: { to: 'https://example.com', rel: 'nofollow' } }],
     ['with external prop', { props: { to: '/api/download', external: true } }],
     // Slots
     ['with default slot', { slots: { default: () => 'Default slot' } }]

--- a/test/components/__snapshots__/Link-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Link-vue.spec.ts.snap
@@ -12,11 +12,17 @@ exports[`Link > renders with disabled correctly 1`] = `"<button type="button" di
 
 exports[`Link > renders with external prop correctly 1`] = `"<a href="/api/download" rel="noopener noreferrer" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
 
+exports[`Link > renders with external to and rel correctly 1`] = `"<a href="https://example.com" rel="nofollow" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
+
 exports[`Link > renders with external to and target correctly 1`] = `"<a href="https://example.com" rel="noopener noreferrer" target="_blank" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
 
 exports[`Link > renders with external to correctly 1`] = `"<a href="https://example.com" rel="noopener noreferrer" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
 
 exports[`Link > renders with inactiveClass correctly 1`] = `"<button type="button" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></button>"`;
+
+exports[`Link > renders with internal to and noRel correctly 1`] = `"<a href="/about" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
+
+exports[`Link > renders with internal to and rel correctly 1`] = `"<a href="/about" rel="nofollow" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
 
 exports[`Link > renders with internal to and target correctly 1`] = `"<a href="/about" rel="noopener noreferrer" target="_blank" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
 

--- a/test/components/__snapshots__/Link-vue.spec.ts.snap
+++ b/test/components/__snapshots__/Link-vue.spec.ts.snap
@@ -26,6 +26,8 @@ exports[`Link > renders with internal to and rel correctly 1`] = `"<a href="/abo
 
 exports[`Link > renders with internal to and target correctly 1`] = `"<a href="/about" rel="noopener noreferrer" target="_blank" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
 
+exports[`Link > renders with internal to object and target correctly 1`] = `"<a href="/about" rel="noopener noreferrer" target="_blank" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
+
 exports[`Link > renders with raw activeClass correctly 1`] = `"<button type="button" class="text-highlighted"></button>"`;
 
 exports[`Link > renders with raw correctly 1`] = `"<button type="button" class=""></button>"`;

--- a/test/components/__snapshots__/Link.spec.ts.snap
+++ b/test/components/__snapshots__/Link.spec.ts.snap
@@ -12,11 +12,17 @@ exports[`Link > renders with disabled correctly 1`] = `"<button type="button" di
 
 exports[`Link > renders with external prop correctly 1`] = `"<a href="/api/download" rel="noopener noreferrer" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
 
+exports[`Link > renders with external to and rel correctly 1`] = `"<a href="https://example.com" rel="nofollow" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
+
 exports[`Link > renders with external to and target correctly 1`] = `"<a href="https://example.com" rel="noopener noreferrer" target="_blank" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
 
 exports[`Link > renders with external to correctly 1`] = `"<a href="https://example.com" rel="noopener noreferrer" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
 
 exports[`Link > renders with inactiveClass correctly 1`] = `"<button type="button" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></button>"`;
+
+exports[`Link > renders with internal to and noRel correctly 1`] = `"<a href="/about" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
+
+exports[`Link > renders with internal to and rel correctly 1`] = `"<a href="/about" rel="nofollow" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
 
 exports[`Link > renders with internal to and target correctly 1`] = `"<a href="/about" rel="noopener noreferrer" target="_blank" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
 

--- a/test/components/__snapshots__/Link.spec.ts.snap
+++ b/test/components/__snapshots__/Link.spec.ts.snap
@@ -26,6 +26,8 @@ exports[`Link > renders with internal to and rel correctly 1`] = `"<a href="/abo
 
 exports[`Link > renders with internal to and target correctly 1`] = `"<a href="/about" rel="noopener noreferrer" target="_blank" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
 
+exports[`Link > renders with internal to object and target correctly 1`] = `"<a href="/about" rel="noopener noreferrer" target="_blank" class="outline-primary/25 focus-visible:outline-3 rounded-md text-muted hover:text-default transition-colors"></a>"`;
+
 exports[`Link > renders with raw activeClass correctly 1`] = `"<button type="button" class="text-highlighted"></button>"`;
 
 exports[`Link > renders with raw correctly 1`] = `"<button type="button" class=""></button>"`;


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6676

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`<ULink to="/internal" rel="nofollow">` (and therefore `UButton`, and every component that composes `ULink`) silently drops the `rel` attribute for internal links.

The internal branch of `Link.vue` sources `rel` from `NuxtLink`'s default slot props. However, `NuxtLink` only forwards its `rel` prop to `RouterLink` when it is **not** rendered with `custom` ([nuxt-link.ts](https://github.com/nuxt/nuxt/blob/main/packages/nuxt/src/app/components/nuxt-link.ts) — `routerLinkProps.rel = props.rel || undefined` sits inside `if (!props.custom)`, since the custom API can't support fallthrough attributes). With `custom`, the slot receives plain `RouterLink` slot props, which contain no `rel` at all — so `rest.rel` is always `undefined` for internal links.

This PR applies the prop directly via an `internalRel` computed, used as a fallback in both internal branches (`ULinkBase` and the `custom` slot, so custom consumers get the same value):

- `rel` is only rendered when explicitly provided — the `noopener noreferrer` fallback remains external-only, matching `NuxtLink`'s own behavior for non-custom internal links.
- `noRel` is respected.
- Links with `target` or a protocol keep going through the external branch with its existing `externalRel` handling.

The new `noRel` test case also surfaced a related bug in the Vue variant (`src/runtime/vue/overrides/vue-router/Link.vue`): `rel` was forwarded to `RouterLink`, which doesn't declare it as a prop, so it fell through the `custom` slot onto the rendered anchor — bypassing the `rel` computed entirely, including its `noRel` handling. It is now omitted from the forwarded props like `noRel` already was; the computed applies `rel` in all branches. Both environments now produce identical markup for every rel/noRel combination.

Added snapshot cases for internal + `rel`, internal + `noRel`, and external + `rel` (Nuxt and Vue). All existing snapshots are unchanged; `lint`, `typecheck`, and the full test suite pass.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
