### PR TITLE
test(ChatPrompt): avoid using fake timers before suspended

### DIFF
--- a/test/components/ChatPrompt.spec.ts
+++ b/test/components/ChatPrompt.spec.ts
@@ -56,12 +56,11 @@ describe('ChatPrompt', () => {
   })
 
   it('re-enables submit after compositionend cooldown', async () => {
-    vi.useFakeTimers()
-
     const wrapper = await mountSuspended(ChatPrompt, {
       props: { modelValue: 'Hello' }
     })
 
+    vi.useFakeTimers()
     const textarea = wrapper.find('textarea')
     await textarea.trigger('compositionend')
     vi.advanceTimersByTime(50)


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Changed the timing of `useFakeTimers` because using fake timers before `mountSuspended` might cause the mount to stop. (tested with the latest commit of test-utils, and this test failed)

Followed [this test](https://github.com/nuxt/ui/blob/c9c5232238f483f51b1be30128fa1c548a7b0329/test/components/ChatReasoning.spec.ts#L35).

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
