### PR TITLE
fix(SelectMenu/InputMenu): only re-highlight first item with `create-item`

### DIFF
--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -555,9 +555,11 @@ const comboboxRootRef = useTemplateRef('comboboxRootRef')
 // reka-ui only re-highlights the first item when the list goes from empty to non-empty.
 // With `create-item`, the create item is always registered so the count never drops to 0,
 // leaving the highlight stale when async `items` load. Re-highlight when items change while open.
+// Scoped to `create-item` only, otherwise this fires on infinite-scroll appends too and
+// scrolls the viewport back to the top.
 // Wait an extra tick so freshly mounted items are registered in reka-ui's collection before highlighting.
 watch(() => props.items, async () => {
-  if (!isOpen.value) {
+  if (!isOpen.value || !props.createItem) {
     return
   }
 

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -503,9 +503,11 @@ const comboboxRootRef = useTemplateRef('comboboxRootRef')
 // reka-ui only re-highlights the first item when the list goes from empty to non-empty.
 // With `create-item`, the create item is always registered so the count never drops to 0,
 // leaving the highlight stale when async `items` load. Re-highlight when items change while open.
+// Scoped to `create-item` only, otherwise this fires on infinite-scroll appends too and
+// scrolls the viewport back to the top.
 // Wait an extra tick so freshly mounted items are registered in reka-ui's collection before highlighting.
 watch(() => props.items, async () => {
-  if (!isOpen.value) {
+  if (!isOpen.value || !props.createItem) {
     return
   }
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6665

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

#6538 added a `watch` on `props.items` that calls `highlightFirstItem()` whenever `items` change while the menu is open. That fixes the stale-highlight with `create-item` (#5974), but it also fires on infinite-scroll appends, and re-highlighting the first item scrolls the viewport back to the top. You can see it right in the docs on the [infinite scroll example](https://ui.nuxt.com/docs/components/select-menu#with-infinite-scroll).

The re-highlight is only needed with `create-item`: reka-ui re-highlights on its own when the item count goes from `0` to non-zero, but the create item is always registered so that transition never happens. This scopes the watcher to `props.createItem`, so plain infinite-scroll lists keep their scroll position while `create-item` still gets the fix from #5974.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
