### PR TITLE
feat(ChatTool): add `actions` prop for tool approval

### DIFF
--- a/docs/app/components/content/ComponentCode.vue
+++ b/docs/app/components/content/ComponentCode.vue
@@ -462,7 +462,7 @@ const { data: ast } = useAsyncData(codeKey, async () => {
         <component :is="component" v-bind="{ ...componentProps, ...componentEvents }">
           <template v-for="slot in Object.keys(slots || {})" :key="slot" #[slot]>
             <slot :name="slot" mdc-unwrap="p">
-              {{ slots?.[slot] }}
+              {{ typeof slots?.[slot] === 'string' ? slots[slot].trim() : slots?.[slot] }}
             </slot>
           </template>
         </component>

--- a/docs/app/components/content/examples/chat/ChatToolApprovalExample.vue
+++ b/docs/app/components/content/examples/chat/ChatToolApprovalExample.vue
@@ -1,0 +1,77 @@
+<script setup lang="ts">
+import type { ButtonProps } from '@nuxt/ui'
+
+const state = ref<'approval-requested' | 'output-available' | 'output-denied'>('approval-requested')
+const result = ref('')
+
+const text = computed(() => {
+  if (state.value === 'approval-requested') return 'Run terminal command'
+  if (state.value === 'output-denied') return 'Command cancelled'
+  return result.value ? 'Ran terminal command' : 'Running terminal command'
+})
+
+const output = computed(() => result.value || '$ pnpm run lint')
+
+const actions = computed<ButtonProps[] | undefined>(() => {
+  if (state.value !== 'approval-requested') return undefined
+
+  return [
+    { label: 'Approve', onClick: onApprove },
+    { label: 'Deny', color: 'neutral', variant: 'soft', onClick: onDeny }
+  ]
+})
+
+let timer: ReturnType<typeof setTimeout> | undefined
+
+function onApprove() {
+  state.value = 'output-available'
+
+  timer = setTimeout(() => {
+    result.value = `$ pnpm run lint
+
+> eslint .
+
+✔ No lint errors found.
+`
+  }, 2000)
+}
+
+function onDeny() {
+  state.value = 'output-denied'
+}
+
+function reset() {
+  state.value = 'approval-requested'
+  result.value = ''
+}
+
+onUnmounted(() => {
+  clearTimeout(timer)
+})
+</script>
+
+<template>
+  <div class="flex flex-col items-start gap-4">
+    <UChatTool
+      :text="text"
+      icon="i-lucide-terminal"
+      variant="card"
+      :streaming="state === 'output-available' && !result"
+      :actions="actions"
+      class="w-80"
+    >
+      <pre language="bash" v-text="output" />
+    </UChatTool>
+
+    <UButton
+      v-if="state !== 'approval-requested'"
+      label="Reset"
+      color="neutral"
+      variant="link"
+      size="xs"
+      icon="i-lucide-rotate-ccw"
+      class="p-0 absolute top-4 right-4"
+      @click="reset"
+    />
+  </div>
+</template>

--- a/docs/app/components/content/examples/chat/ChatToolApprovalExample.vue
+++ b/docs/app/components/content/examples/chat/ChatToolApprovalExample.vue
@@ -41,6 +41,7 @@ function onDeny() {
 }
 
 function reset() {
+  clearTimeout(timer)
   state.value = 'approval-requested'
   result.value = ''
 }

--- a/docs/content/docs/2.components/chat-tool.md
+++ b/docs/content/docs/2.components/chat-tool.md
@@ -246,7 +246,7 @@ slots:
 ---
 ::
 
-### Actions
+### Actions :badge{label="Soon" class="align-text-top"}
 
 Use the `actions` prop to display a list of [Button](/docs/components/button) below the trigger, useful for tools that require a user confirmation before running.
 
@@ -283,7 +283,7 @@ slots:
 Check the **Chat** overview page for installation instructions, server setup and usage examples.
 ::
 
-### With approval flow
+### With approval flow :badge{label="Soon" class="align-text-top"}
 
 Use the `actions` prop to build a tool approval flow with the [AI SDK](https://ai-sdk.dev/docs/agents/tool-approvals). When a tool part is in the `approval-requested` state, display the approve and deny actions and respond with `addToolApprovalResponse`.
 

--- a/docs/content/docs/2.components/chat-tool.md
+++ b/docs/content/docs/2.components/chat-tool.md
@@ -72,7 +72,7 @@ props:
 ::
 
 ::tip
-Use the `isToolStreaming` utility from `@nuxt/ui/utils/ai` to determine if a tool part is still running.
+Use the `isToolStreaming` utility from `@nuxt/ui/utils/ai` to determine if a tool part is still running. It returns `false` when the tool is waiting for a user approval.
 ::
 
 ### Shimmer
@@ -246,10 +246,80 @@ slots:
 ---
 ::
 
+### Actions
+
+Use the `actions` prop to display a list of [Button](/docs/components/button) below the trigger, useful for tools that require a user confirmation before running.
+
+::component-code
+---
+prettier: true
+hide:
+  - class
+ignore:
+  - text
+  - icon
+  - variant
+  - actions
+props:
+  actions:
+    - label: 'Approve'
+    - label: 'Deny'
+      color: neutral
+      variant: soft
+  text: 'Run terminal command'
+  variant: card
+  icon: i-lucide-terminal
+  class: 'w-60'
+slots:
+  default: |
+
+    $ pnpm run lint
+---
+::
+
 ## Examples
 
 ::tip{to="/docs/components/chat"}
 Check the **Chat** overview page for installation instructions, server setup and usage examples.
+::
+
+### With approval flow
+
+Use the `actions` prop to build a tool approval flow with the [AI SDK](https://ai-sdk.dev/docs/agents/tool-approvals). When a tool part is in the `approval-requested` state, display the approve and deny actions and respond with `addToolApprovalResponse`.
+
+::component-example
+---
+collapse: true
+prettier: true
+name: 'chat-tool-approval-example'
+---
+::
+
+::tip
+Use the `isToolApprovalPending` utility from `@nuxt/ui/utils/ai` to detect a pending approval, `isToolStreaming` returns `false` in this state.
+
+```vue
+<script setup lang="ts">
+import { useChat } from '@ai-sdk/vue'
+import { lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai'
+
+const { messages, addToolApprovalResponse } = useChat({
+  sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses
+})
+</script>
+
+<template>
+  <UChatTool
+    v-if="isToolUIPart(part)"
+    :text="getToolName(part)"
+    :streaming="isToolStreaming(part)"
+    :actions="part.state === 'approval-requested' ? [
+      { label: 'Approve', onClick: () => addToolApprovalResponse({ id: part.approval.id, approved: true }) },
+      { label: 'Deny', color: 'neutral', variant: 'ghost', onClick: () => addToolApprovalResponse({ id: part.approval.id, approved: false }) }
+    ] : undefined"
+  />
+</template>
+```
 ::
 
 ## API

--- a/docs/content/docs/2.components/chat.md
+++ b/docs/content/docs/2.components/chat.md
@@ -325,6 +325,40 @@ export default defineEventHandler(async (event) => {
 })
 ```
 
+### Tool Approval
+
+Require a user confirmation before a tool runs with the [`toolApproval`](https://ai-sdk.dev/docs/agents/tool-approvals) option. The tool part pauses in the `approval-requested` state until the user responds:
+
+```ts [server/api/chat.post.ts]
+import { streamText, convertToModelMessages, toUIMessageStream, createUIMessageStreamResponse, tool } from 'ai'
+import { gateway } from '@ai-sdk/gateway'
+import { z } from 'zod'
+
+export default defineEventHandler(async (event) => {
+  const { messages } = await readBody(event)
+
+  const result = streamText({
+    model: gateway('anthropic/claude-sonnet-5'),
+    maxOutputTokens: 10000,
+    instructions: 'You are a helpful assistant.',
+    messages: await convertToModelMessages(messages),
+    tools: {
+      deleteFile: tool({
+        description: 'Delete a file from the project',
+        inputSchema: z.object({ path: z.string() }),
+        execute: async ({ path }) => ({ deleted: path })
+      })
+    },
+    toolApproval: {
+      deleteFile: 'user-approval'
+    }
+  })
+
+  const stream = toUIMessageStream({ stream: result.stream })
+  return createUIMessageStreamResponse({ stream })
+})
+```
+
 ## Client Setup
 
 Use the `useChat` composable from `@ai-sdk/vue` to manage chat state and connect to your server endpoint:
@@ -333,14 +367,15 @@ Use the `useChat` composable from `@ai-sdk/vue` to manage chat state and connect
 #nuxt
 ```vue
 <script setup lang="ts">
-import { isReasoningUIPart, isTextUIPart, isToolUIPart, getToolName } from 'ai'
+import { isReasoningUIPart, isTextUIPart, isToolUIPart, getToolName, lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai'
 import { useChat } from '@ai-sdk/vue'
 import { isPartStreaming, isToolStreaming } from '@nuxt/ui/utils/ai'
 import highlight from '@comark/nuxt/plugins/highlight'
 
 const input = ref('')
 
-const { messages, status, error, sendMessage, regenerate, stop } = useChat({
+const { messages, status, error, sendMessage, regenerate, stop, addToolApprovalResponse } = useChat({
+  sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
   onError(error) {
     console.error(error)
   }
@@ -380,6 +415,10 @@ function onSubmit() {
           v-else-if="isToolUIPart(part)"
           :text="getToolName(part)"
           :streaming="isToolStreaming(part)"
+          :actions="part.state === 'approval-requested' ? [
+            { label: 'Approve', onClick: () => addToolApprovalResponse({ id: part.approval.id, approved: true }) },
+            { label: 'Deny', color: 'neutral', variant: 'ghost', onClick: () => addToolApprovalResponse({ id: part.approval.id, approved: false }) }
+          ] : undefined"
         />
 
         <template v-else-if="isTextUIPart(part)">
@@ -416,7 +455,7 @@ function onSubmit() {
 ```vue
 <script setup lang="ts">
 import { ref } from 'vue'
-import { isReasoningUIPart, isTextUIPart, isToolUIPart, getToolName } from 'ai'
+import { isReasoningUIPart, isTextUIPart, isToolUIPart, getToolName, lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai'
 import { useChat } from '@ai-sdk/vue'
 import { isPartStreaming, isToolStreaming } from '@nuxt/ui/utils/ai'
 import { Comark } from '@comark/vue'
@@ -424,7 +463,8 @@ import highlight from '@comark/vue/plugins/highlight'
 
 const input = ref('')
 
-const { messages, status, error, sendMessage, regenerate, stop } = useChat({
+const { messages, status, error, sendMessage, regenerate, stop, addToolApprovalResponse } = useChat({
+  sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
   onError(error) {
     console.error(error)
   }
@@ -464,6 +504,10 @@ function onSubmit() {
           v-else-if="isToolUIPart(part)"
           :text="getToolName(part)"
           :streaming="isToolStreaming(part)"
+          :actions="part.state === 'approval-requested' ? [
+            { label: 'Approve', onClick: () => addToolApprovalResponse({ id: part.approval.id, approved: true }) },
+            { label: 'Deny', color: 'neutral', variant: 'ghost', onClick: () => addToolApprovalResponse({ id: part.approval.id, approved: false }) }
+          ] : undefined"
         />
 
         <template v-else-if="isTextUIPart(part)">

--- a/playgrounds/nuxt/app/pages/chat.vue
+++ b/playgrounds/nuxt/app/pages/chat.vue
@@ -47,6 +47,7 @@ function getEmailToolText(state: string): string {
   if (isToolApprovalPending({ state })) return 'Send this email?'
   if (state === 'output-available') return 'Email sent'
   if (state === 'output-denied') return 'Email cancelled'
+  if (state === 'output-error') return 'Email failed'
   return 'Preparing email'
 }
 

--- a/playgrounds/nuxt/app/pages/chat.vue
+++ b/playgrounds/nuxt/app/pages/chat.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
-import { isReasoningUIPart, isTextUIPart, isToolUIPart, getToolName } from 'ai'
+import { isReasoningUIPart, isTextUIPart, isToolUIPart, getToolName, lastAssistantMessageIsCompleteWithApprovalResponses } from 'ai'
 import { useChat } from '@ai-sdk/vue'
-import { isPartStreaming, isToolStreaming } from '@nuxt/ui/utils/ai'
+import { isPartStreaming, isToolStreaming, isToolApprovalPending } from '@nuxt/ui/utils/ai'
 import { Comark } from '@comark/vue'
 import highlight from '@comark/vue/plugins/highlight'
 
@@ -9,7 +9,8 @@ const toast = useToast()
 
 const input = ref('')
 
-const { messages, status, error, sendMessage, regenerate, stop } = useChat({
+const { messages, status, error, sendMessage, regenerate, stop, addToolApprovalResponse } = useChat({
+  sendAutomaticallyWhen: lastAssistantMessageIsCompleteWithApprovalResponses,
   onError(error) {
     let message = error.message
     try {
@@ -40,6 +41,13 @@ function clearMessages() {
     stop()
   }
   messages.value = []
+}
+
+function getEmailToolText(state: string): string {
+  if (isToolApprovalPending({ state })) return 'Send this email?'
+  if (state === 'output-available') return 'Email sent'
+  if (state === 'output-denied') return 'Email cancelled'
+  return 'Preparing email'
 }
 
 function getDomain(url: string): string {
@@ -159,6 +167,22 @@ function generateMessages() {
                 <span class="text-xs text-dimmed ms-auto shrink-0">{{ getDomain(source.url) }}</span>
               </a>
             </div>
+          </UChatTool>
+
+          <UChatTool
+            v-else-if="isToolUIPart(part) && getToolName(part) === 'send_email'"
+            :text="getEmailToolText(part.state)"
+            :suffix="(part.input as { to?: string })?.to"
+            icon="i-lucide-mail"
+            chevron="leading"
+            variant="card"
+            :streaming="isToolStreaming(part)"
+            :actions="part.state === 'approval-requested' ? [
+              { label: 'Approve', color: 'neutral', onClick: () => addToolApprovalResponse({ id: part.approval!.id, approved: true }) },
+              { label: 'Deny', color: 'neutral', variant: 'soft', onClick: () => addToolApprovalResponse({ id: part.approval!.id, approved: false }) }
+            ] : undefined"
+          >
+            <pre class="text-xs whitespace-pre-wrap">{{ JSON.stringify(part.input, null, 2) }}</pre>
           </UChatTool>
         </template>
       </template>

--- a/playgrounds/nuxt/app/pages/components/chat-tool.vue
+++ b/playgrounds/nuxt/app/pages/components/chat-tool.vue
@@ -1,10 +1,16 @@
 <script setup lang="ts">
+import type { ButtonProps } from '@nuxt/ui'
+
+const actions: ButtonProps[] = [
+  { label: 'Approve', onClick: () => console.log('approve') },
+  { label: 'Deny', color: 'neutral', variant: 'soft', onClick: () => console.log('deny') }
+]
 </script>
 
 <template>
   <Navbar />
 
-  <div class="w-60 flex flex-col gap-4 items-start">
+  <div class="w-72 flex flex-col gap-4 items-start">
     <UChatTool
       text="Searched components"
       icon="i-lucide-search"
@@ -29,9 +35,7 @@
       icon="i-lucide-search"
       chevron="leading"
     >
-      <div class="text-sm text-muted">
-        Found 5 matching components.
-      </div>
+      Found 5 matching components.
     </UChatTool>
 
     <UChatTool
@@ -41,6 +45,18 @@
       class="w-full"
     >
       Found 5 matching components.
+    </UChatTool>
+
+    <UChatTool
+      text="Run terminal command"
+      suffix="pnpm run lint"
+      icon="i-lucide-terminal"
+      variant="card"
+      chevron="leading"
+      class="w-full"
+      :actions="actions"
+    >
+      <pre class="whitespace-pre-wrap">$ pnpm run lint</pre>
     </UChatTool>
   </div>
 </template>

--- a/playgrounds/nuxt/server/api/chat.post.ts
+++ b/playgrounds/nuxt/server/api/chat.post.ts
@@ -1,17 +1,30 @@
-import { streamText, convertToModelMessages, toUIMessageStream, createUIMessageStreamResponse } from 'ai'
+import { streamText, convertToModelMessages, toUIMessageStream, createUIMessageStreamResponse, tool } from 'ai'
 import { anthropic } from '@ai-sdk/anthropic'
 import type { AnthropicLanguageModelOptions } from '@ai-sdk/anthropic'
 import { gateway } from '@ai-sdk/gateway'
+import { z } from 'zod'
 
 export default defineEventHandler(async (event) => {
   const { messages } = await readBody(event)
 
   const result = streamText({
     model: gateway('anthropic/claude-sonnet-5'),
-    instructions: 'You are a helpful assistant. When answering questions, search the web for up-to-date information when relevant.',
+    instructions: 'You are a helpful assistant. When answering questions, search the web for up-to-date information when relevant. Use the `send_email` tool when the user asks to send an email.',
     messages: await convertToModelMessages(messages),
     tools: {
-      web_search: anthropic.tools.webSearch_20250305()
+      web_search: anthropic.tools.webSearch_20250305(),
+      send_email: tool({
+        description: 'Send an email to a recipient.',
+        inputSchema: z.object({
+          to: z.string().describe('The recipient email address'),
+          subject: z.string().describe('The email subject'),
+          body: z.string().describe('The email body')
+        }),
+        execute: async ({ to }) => ({ sent: true, to })
+      })
+    },
+    toolApproval: {
+      send_email: 'user-approval'
     },
     providerOptions: {
       anthropic: {

--- a/playgrounds/nuxt/server/api/chat.post.ts
+++ b/playgrounds/nuxt/server/api/chat.post.ts
@@ -16,9 +16,9 @@ export default defineEventHandler(async (event) => {
       send_email: tool({
         description: 'Send an email to a recipient.',
         inputSchema: z.object({
-          to: z.string().describe('The recipient email address'),
-          subject: z.string().describe('The email subject'),
-          body: z.string().describe('The email body')
+          to: z.email().describe('The recipient email address'),
+          subject: z.string().min(1).describe('The email subject'),
+          body: z.string().min(1).describe('The email body')
         }),
         execute: async ({ to }) => ({ sent: true, to })
       })

--- a/src/runtime/components/ChatTool.vue
+++ b/src/runtime/components/ChatTool.vue
@@ -3,6 +3,7 @@ import type { CollapsibleRootProps } from 'reka-ui'
 import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/chat-tool'
+import type { ButtonProps } from './Button.vue'
 import type { IconProps } from './Icon.vue'
 import type { ChatShimmerProps } from './ChatShimmer.vue'
 import type { ComponentConfig } from '../types/tv'
@@ -59,6 +60,11 @@ export interface ChatToolProps extends Pick<CollapsibleRootProps, 'defaultOpen' 
    * Customize the [`ChatShimmer`](https://ui.nuxt.com/docs/components/chat-shimmer) component when streaming.
    */
   shimmer?: Partial<Omit<ChatShimmerProps, 'text'>>
+  /**
+   * Display a list of actions below the trigger, useful for tool approval flows.
+   * `{ size: 'xs' }`{lang="ts-type"}
+   */
+  actions?: ButtonProps[]
   class?: any
   ui?: ChatTool['slots']
 }
@@ -69,15 +75,17 @@ export interface ChatToolEmits {
 
 export interface ChatToolSlots {
   default?(props: { open: boolean }): VNode[]
+  actions?(props?: {}): VNode[]
 }
 </script>
 
 <script setup lang="ts">
-import { ref, computed } from 'vue'
+import { ref, computed, watch } from 'vue'
 import { CollapsibleRoot, CollapsibleTrigger, CollapsibleContent } from 'reka-ui'
 import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
 import { tv } from '../utils/tv'
+import UButton from './Button.vue'
 import UIcon from './Icon.vue'
 import UChatShimmer from './ChatShimmer.vue'
 
@@ -113,6 +121,15 @@ function setOpen(value: boolean) {
 }
 
 const hasContent = computed(() => !!slots.default)
+
+// Auto-open when actions first appear (e.g. a pending tool approval) so the content
+// is visible while the user decides. Uncontrolled only, respects an explicit `defaultOpen`,
+// and fires once so the user can still collapse it.
+watch(() => !!props.actions?.length, (hasActions) => {
+  if (hasActions && hasContent.value && props.open === undefined && props.defaultOpen === undefined) {
+    internalOpen.value = true
+  }
+}, { immediate: true })
 
 const resolvedLoadingIcon = computed(() => props.loadingIcon || appConfig.ui.icons?.loading)
 const resolvedIcon = computed(() => props.loading ? resolvedLoadingIcon.value : props.icon)
@@ -170,5 +187,16 @@ const chevronIconName = computed(() => props.chevronIcon || appConfig.ui.icons?.
         <slot :open="isOpen" />
       </div>
     </CollapsibleContent>
+
+    <div
+      v-if="props.actions?.length || !!slots.actions"
+      data-slot="actions"
+      :data-state="hasContent && isOpen ? 'open' : 'closed'"
+      :class="ui.actions({ class: props.ui?.actions })"
+    >
+      <slot name="actions">
+        <UButton v-for="(action, index) in props.actions" :key="index" size="xs" v-bind="action" />
+      </slot>
+    </div>
   </CollapsibleRoot>
 </template>

--- a/src/runtime/utils/ai.ts
+++ b/src/runtime/utils/ai.ts
@@ -22,12 +22,21 @@ export function isPartStreaming(part: { state?: string }): boolean {
 }
 
 /**
- * Checks if a tool part is still streaming (hasn't reached a terminal state).
+ * Checks if a tool part is still streaming (hasn't reached a terminal state
+ * and isn't paused waiting for a user approval).
  *
- * Terminal states are `output-available`, `output-error`, and `output-denied`.
+ * Terminal states are `output-available`, `output-error`, and `output-denied`,
+ * `approval-requested` is a paused state.
  */
 export function isToolStreaming(part: { state: string }): boolean {
-  return !['output-available', 'output-error', 'output-denied'].includes(part.state)
+  return !['approval-requested', 'output-available', 'output-error', 'output-denied'].includes(part.state)
+}
+
+/**
+ * Checks if a tool part is waiting for a user approval response.
+ */
+export function isToolApprovalPending(part: { state: string }): boolean {
+  return part.state === 'approval-requested'
 }
 
 /**

--- a/src/theme/chat-message.ts
+++ b/src/theme/chat-message.ts
@@ -81,6 +81,7 @@ export default (options: Required<ModuleOptions>) => ({
     variant: 'naked',
     side: 'left',
     class: {
+      body: 'w-full',
       content: 'w-full'
     }
   }, ...(options.theme.colors || []).map((color: string) => ({

--- a/src/theme/chat-tool.ts
+++ b/src/theme/chat-tool.ts
@@ -11,25 +11,26 @@ export default (options: Required<ModuleOptions>) => ({
     suffix: 'text-dimmed ms-1',
     trailingIcon: 'size-4 shrink-0 group-data-[state=open]:rotate-180 transition-transform duration-200',
     content: 'data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden',
-    body: 'text-sm text-dimmed whitespace-pre-wrap'
+    body: 'text-sm text-dimmed whitespace-pre-wrap',
+    actions: 'flex items-center justify-end gap-1.5'
   },
   variants: {
     variant: {
       inline: {
         trigger: 'rounded-sm outline-primary/25 focus-visible:outline-3',
-        body: 'pt-2'
+        body: 'pt-2',
+        actions: 'pt-2'
       },
       card: {
         root: 'rounded-md ring ring-default overflow-hidden outline-primary/25 has-focus-visible:outline-3 has-focus-visible:ring-primary',
         trigger: 'px-2 py-1 focus:outline-none',
         trailingIcon: 'ms-auto',
-        body: 'border-t border-default p-2 max-h-[200px] overflow-y-auto focus:outline-none'
+        body: 'border-t border-default p-2 max-h-[200px] overflow-y-auto focus:outline-none',
+        actions: 'border-t border-default p-2'
       }
     },
     chevron: {
-      leading: {
-        leadingIcon: 'group-hover:opacity-0'
-      },
+      leading: '',
       trailing: ''
     },
     loading: {
@@ -39,7 +40,7 @@ export default (options: Required<ModuleOptions>) => ({
     },
     alone: {
       false: {
-        leadingIcon: ['absolute inset-0 group-data-[state=open]:opacity-0', options.theme.transitions && 'transition-opacity duration-200'],
+        leadingIcon: ['absolute inset-0 group-hover:opacity-0 group-data-[state=open]:opacity-0', options.theme.transitions && 'transition-opacity duration-200'],
         chevronIcon: ['absolute inset-0 opacity-0 group-hover:opacity-100 group-data-[state=open]:opacity-100', options.theme.transitions && 'transition-[rotate,opacity] duration-200']
       }
     }

--- a/test/components/ChatTool.spec.ts
+++ b/test/components/ChatTool.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import ChatTool from '../../src/runtime/components/ChatTool.vue'
@@ -22,12 +22,62 @@ describe('ChatTool', () => {
     ['with defaultOpen', { props: { ...props, defaultOpen: true } }],
     ['with chevron leading', { props: { ...props, chevron: 'leading' } }],
     ['with chevron leading and icon', { props: { ...props, chevron: 'leading', icon: 'i-lucide-search' } }],
+    ['with chevron leading, icon and content', { props: { ...props, chevron: 'leading', icon: 'i-lucide-search' }, slots: { default: () => 'Tool output content' } }],
     ['with chevronIcon', { props: { ...props, chevronIcon: 'i-lucide-arrow-down' } }],
     ['with class', { props: { ...props, class: 'my-5' } }],
     ['with ui', { props: { ...props, ui: { body: 'text-muted' } } }],
+    ['with actions', { props: { ...props, actions: [{ label: 'Approve' }, { label: 'Deny', color: 'neutral' as const, variant: 'soft' as const }] } }],
+    ['with actions variant card', { props: { ...props, variant: 'card' as const, actions: [{ label: 'Approve' }, { label: 'Deny' }] } }],
+    ['with actions and content', { props: { ...props, actions: [{ label: 'Approve' }, { label: 'Deny' }] }, slots: { default: () => 'Tool output content' } }],
     // Slots
-    ['with default slot', { props, slots: { default: () => 'Tool output content' } }]
+    ['with default slot', { props, slots: { default: () => 'Tool output content' } }],
+    ['with actions slot', { props, slots: { actions: () => 'Custom actions' } }]
   ])
+
+  it('auto-opens when actions and content are present', async () => {
+    const wrapper = await mountSuspended(ChatTool, {
+      props: { ...props, actions: [{ label: 'Approve' }] },
+      slots: { default: () => 'Tool output content' }
+    })
+
+    expect(wrapper.find('[data-slot="root"]').attributes('data-state')).toBe('open')
+  })
+
+  it('does not auto-open when there is no content', async () => {
+    const wrapper = await mountSuspended(ChatTool, {
+      props: { ...props, actions: [{ label: 'Approve' }] }
+    })
+
+    expect(wrapper.find('[data-slot="root"]').attributes('data-state')).toBe('closed')
+  })
+
+  it('does not auto-open when defaultOpen is explicitly set', async () => {
+    const wrapper = await mountSuspended(ChatTool, {
+      props: { ...props, actions: [{ label: 'Approve' }], defaultOpen: false },
+      slots: { default: () => 'Tool output content' }
+    })
+
+    expect(wrapper.find('[data-slot="root"]').attributes('data-state')).toBe('closed')
+  })
+
+  it('calls the action onClick when the action button is clicked', async () => {
+    const onClick = vi.fn()
+    const wrapper = await mountSuspended(ChatTool, {
+      props: { ...props, actions: [{ label: 'Approve', onClick }] }
+    })
+
+    await wrapper.find('[data-slot="actions"] button').trigger('click')
+
+    expect(onClick).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not render the actions without actions', async () => {
+    const wrapper = await mountSuspended(ChatTool, {
+      props
+    })
+
+    expect(wrapper.find('[data-slot="actions"]').exists()).toBe(false)
+  })
 
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(ChatTool, {

--- a/test/components/__snapshots__/ChatMessage-vue.spec.ts.snap
+++ b/test/components/__snapshots__/ChatMessage-vue.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`ChatMessage > renders with actions slot correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <div data-slot="actions" class="[@media(hover:hover)]:opacity-0 group-hover/message:opacity-100 absolute bottom-0 flex items-center transition-opacity">Actions slot</div>
     </div>
@@ -18,7 +18,7 @@ exports[`ChatMessage > renders with as correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -31,7 +31,7 @@ exports[`ChatMessage > renders with avatar correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <div data-slot="leading" class="inline-flex items-center justify-center min-h-6"><span data-slot="leadingAvatar" class="inline-flex items-center justify-center select-none rounded-full align-middle bg-elevated size-8 text-base shrink-0"><img src="https://github.com/benjamincanac.png" width="32" height="32" data-slot="image" class="h-full w-full rounded-[inherit] object-cover"></span></div>
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -44,7 +44,7 @@ exports[`ChatMessage > renders with class correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -57,7 +57,7 @@ exports[`ChatMessage > renders with compact correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-1.5 pb-3">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-2 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -70,7 +70,7 @@ exports[`ChatMessage > renders with content correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -83,7 +83,7 @@ exports[`ChatMessage > renders with content slot correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Content slot</div>
       <!--v-if-->
     </div>
@@ -98,7 +98,7 @@ exports[`ChatMessage > renders with files slot correctly 1`] = `
   </div>
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -111,7 +111,7 @@ exports[`ChatMessage > renders with header slot correctly 1`] = `
   <div data-slot="header" class="flex mb-1.5">Header slot</div>
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -124,7 +124,7 @@ exports[`ChatMessage > renders with icon correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <div data-slot="leading" class="inline-flex items-center justify-center min-h-6"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="leadingIcon" class="shrink-0 size-8"></svg></div>
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -137,7 +137,7 @@ exports[`ChatMessage > renders with leading slot correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <div data-slot="leading" class="inline-flex items-center justify-center min-h-6">Leading slot</div>
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -150,7 +150,7 @@ exports[`ChatMessage > renders with neutral variant naked correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -215,7 +215,7 @@ exports[`ChatMessage > renders with parts correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -228,7 +228,7 @@ exports[`ChatMessage > renders with primary variant naked correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full text-primary">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -293,7 +293,7 @@ exports[`ChatMessage > renders with role assistant correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -319,7 +319,7 @@ exports[`ChatMessage > renders with ui correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>

--- a/test/components/__snapshots__/ChatMessage.spec.ts.snap
+++ b/test/components/__snapshots__/ChatMessage.spec.ts.snap
@@ -5,7 +5,7 @@ exports[`ChatMessage > renders with actions slot correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <div data-slot="actions" class="[@media(hover:hover)]:opacity-0 group-hover/message:opacity-100 absolute bottom-0 flex items-center transition-opacity">Actions slot</div>
     </div>
@@ -18,7 +18,7 @@ exports[`ChatMessage > renders with as correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -31,7 +31,7 @@ exports[`ChatMessage > renders with avatar correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <div data-slot="leading" class="inline-flex items-center justify-center min-h-6"><span data-slot="leadingAvatar" class="inline-flex items-center justify-center select-none rounded-full align-middle bg-elevated size-8 text-base shrink-0"><img src="https://github.com/benjamincanac.png" width="32" height="32" data-slot="image" class="h-full w-full rounded-[inherit] object-cover"></span></div>
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -44,7 +44,7 @@ exports[`ChatMessage > renders with class correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -57,7 +57,7 @@ exports[`ChatMessage > renders with compact correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-1.5 pb-3">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-2 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -70,7 +70,7 @@ exports[`ChatMessage > renders with content correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -83,7 +83,7 @@ exports[`ChatMessage > renders with content slot correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Content slot</div>
       <!--v-if-->
     </div>
@@ -98,7 +98,7 @@ exports[`ChatMessage > renders with files slot correctly 1`] = `
   </div>
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -111,7 +111,7 @@ exports[`ChatMessage > renders with header slot correctly 1`] = `
   <div data-slot="header" class="flex mb-1.5">Header slot</div>
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -124,7 +124,7 @@ exports[`ChatMessage > renders with icon correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <div data-slot="leading" class="inline-flex items-center justify-center min-h-6"><span class="iconify i-lucide:user shrink-0 size-8" aria-hidden="true" data-slot="leadingIcon"></span></div>
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -137,7 +137,7 @@ exports[`ChatMessage > renders with leading slot correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <div data-slot="leading" class="inline-flex items-center justify-center min-h-6">Leading slot</div>
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -150,7 +150,7 @@ exports[`ChatMessage > renders with neutral variant naked correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -215,7 +215,7 @@ exports[`ChatMessage > renders with parts correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -228,7 +228,7 @@ exports[`ChatMessage > renders with primary variant naked correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full text-primary">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -293,7 +293,7 @@ exports[`ChatMessage > renders with role assistant correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>
@@ -319,7 +319,7 @@ exports[`ChatMessage > renders with ui correctly 1`] = `
   <!--v-if-->
   <div data-slot="container" class="relative flex items-start gap-3 pb-8">
     <!--v-if-->
-    <div data-slot="body" class="min-w-0">
+    <div data-slot="body" class="min-w-0 w-full">
       <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Hello, how are you?</div>
       <!--v-if-->
     </div>

--- a/test/components/__snapshots__/ChatMessages-vue.spec.ts.snap
+++ b/test/components/__snapshots__/ChatMessages-vue.spec.ts.snap
@@ -16,7 +16,7 @@ exports[`ChatMessages > renders with assistant correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <div data-slot="leading" class="inline-flex items-center justify-center min-h-6"><span data-slot="leadingAvatar" class="inline-flex items-center justify-center select-none rounded-full align-middle bg-elevated size-8 text-base shrink-0"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 text-muted"></svg></span></div>
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -43,7 +43,7 @@ exports[`ChatMessages > renders with class correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -70,7 +70,7 @@ exports[`ChatMessages > renders with compact correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-1.5 pb-3">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-2 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -97,7 +97,7 @@ exports[`ChatMessages > renders with content slot correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Content slot</div>
         <!--v-if-->
       </div>
@@ -131,7 +131,7 @@ exports[`ChatMessages > renders with files slot correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -158,7 +158,7 @@ exports[`ChatMessages > renders with indicator slot correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -168,7 +168,7 @@ exports[`ChatMessages > renders with indicator slot correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Indicator slot</div>
         <!--v-if-->
       </div>
@@ -194,7 +194,7 @@ exports[`ChatMessages > renders with messages correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -221,7 +221,7 @@ exports[`ChatMessages > renders with status error correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -248,7 +248,7 @@ exports[`ChatMessages > renders with status ready correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -275,7 +275,7 @@ exports[`ChatMessages > renders with status streaming correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -302,7 +302,7 @@ exports[`ChatMessages > renders with status submitted correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -312,7 +312,7 @@ exports[`ChatMessages > renders with status submitted correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">
           <div data-slot="indicator" class="h-6 flex items-center gap-1 py-3 *:size-2 *:rounded-full *:bg-elevated [&amp;>*:nth-child(1)]:animate-[bounce_1s_infinite] [&amp;>*:nth-child(2)]:animate-[bounce_1s_0.15s_infinite] [&amp;>*:nth-child(3)]:animate-[bounce_1s_0.3s_infinite]"><span></span><span></span><span></span></div>
         </div>
@@ -340,7 +340,7 @@ exports[`ChatMessages > renders with ui correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -367,7 +367,7 @@ exports[`ChatMessages > renders with user correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -394,7 +394,7 @@ exports[`ChatMessages > renders with viewport slot correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>

--- a/test/components/__snapshots__/ChatMessages.spec.ts.snap
+++ b/test/components/__snapshots__/ChatMessages.spec.ts.snap
@@ -16,7 +16,7 @@ exports[`ChatMessages > renders with assistant correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <div data-slot="leading" class="inline-flex items-center justify-center min-h-6"><span data-slot="leadingAvatar" class="inline-flex items-center justify-center select-none rounded-full align-middle bg-elevated size-8 text-base shrink-0"><span class="iconify i-lucide:bot shrink-0 text-muted" aria-hidden="true" data-slot="icon"></span></span></div>
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -43,7 +43,7 @@ exports[`ChatMessages > renders with class correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -70,7 +70,7 @@ exports[`ChatMessages > renders with compact correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-1.5 pb-3">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-2 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -97,7 +97,7 @@ exports[`ChatMessages > renders with content slot correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Content slot</div>
         <!--v-if-->
       </div>
@@ -131,7 +131,7 @@ exports[`ChatMessages > renders with files slot correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -158,7 +158,7 @@ exports[`ChatMessages > renders with indicator slot correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -168,7 +168,7 @@ exports[`ChatMessages > renders with indicator slot correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">Indicator slot</div>
         <!--v-if-->
       </div>
@@ -194,7 +194,7 @@ exports[`ChatMessages > renders with messages correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -221,7 +221,7 @@ exports[`ChatMessages > renders with status error correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -248,7 +248,7 @@ exports[`ChatMessages > renders with status ready correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -275,7 +275,7 @@ exports[`ChatMessages > renders with status streaming correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -302,7 +302,7 @@ exports[`ChatMessages > renders with status submitted correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -312,7 +312,7 @@ exports[`ChatMessages > renders with status submitted correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">
           <div data-slot="indicator" class="h-6 flex items-center gap-1 py-3 *:size-2 *:rounded-full *:bg-elevated [&amp;>*:nth-child(1)]:animate-[bounce_1s_infinite] [&amp;>*:nth-child(2)]:animate-[bounce_1s_0.15s_infinite] [&amp;>*:nth-child(3)]:animate-[bounce_1s_0.3s_infinite]"><span></span><span></span><span></span></div>
         </div>
@@ -340,7 +340,7 @@ exports[`ChatMessages > renders with ui correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -367,7 +367,7 @@ exports[`ChatMessages > renders with user correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>
@@ -394,7 +394,7 @@ exports[`ChatMessages > renders with viewport slot correctly 1`] = `
     <!--v-if-->
     <div data-slot="container" class="relative flex items-start gap-3 pb-8">
       <!--v-if-->
-      <div data-slot="body" class="min-w-0">
+      <div data-slot="body" class="min-w-0 w-full">
         <div data-slot="content" class="relative text-pretty wrap-break-word *:first:mt-0 *:last:mb-0 space-y-4 w-full">I am fine, thank you!</div>
         <!--v-if-->
       </div>

--- a/test/components/__snapshots__/ChatTool-vue.spec.ts.snap
+++ b/test/components/__snapshots__/ChatTool-vue.spec.ts.snap
@@ -1,12 +1,78 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
-exports[`ChatTool > renders with chevron leading and icon correctly 1`] = `
-"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group flex w-full items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default min-w-0 transition-colors rounded-sm outline-primary/25 focus-visible:outline-3"><span data-slot="leading" class="relative size-4 shrink-0"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="leadingIcon" class="size-4 shrink-0 group-hover:opacity-0"></svg><!--v-if--></span><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+exports[`ChatTool > renders with actions and content correctly 1`] = `
+"<div data-state="open" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="true" data-state="open" data-slot="trigger" class="group flex w-full items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default min-w-0 transition-colors rounded-sm outline-primary/25 focus-visible:outline-3">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="trailingIcon" class="size-4 shrink-0 group-data-[state=open]:rotate-180 transition-transform duration-200"></svg>
+  </button>
+  <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px; transition-duration: 0s; animation-name: none;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2">Tool output content</div>
+  </div>
+  <div data-slot="actions" data-state="open" class="flex items-center justify-end gap-1.5 pt-2"><button type="button" data-slot="base" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-inverted bg-primary hover:bg-primary/75 active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary outline-primary/25 focus-visible:outline-3">
+      <!--v-if--><span data-slot="label" class="truncate">Approve</span>
+      <!--v-if-->
+    </button><button type="button" data-slot="base" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-inverted bg-primary hover:bg-primary/75 active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary outline-primary/25 focus-visible:outline-3">
+      <!--v-if--><span data-slot="label" class="truncate">Deny</span>
+      <!--v-if-->
+    </button></div>
+</div>"
+`;
+
+exports[`ChatTool > renders with actions correctly 1`] = `
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group flex w-full items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default min-w-0 transition-colors rounded-sm outline-primary/25 focus-visible:outline-3">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
     <!--v-if-->
   </button>
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <div data-slot="actions" data-state="closed" class="flex items-center justify-end gap-1.5 pt-2"><button type="button" data-slot="base" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-inverted bg-primary hover:bg-primary/75 active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary outline-primary/25 focus-visible:outline-3">
+      <!--v-if--><span data-slot="label" class="truncate">Approve</span>
+      <!--v-if-->
+    </button><button type="button" data-slot="base" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-default bg-elevated hover:bg-accented/75 active:bg-accented/75 outline-inverted/25 focus-visible:outline-3 disabled:bg-elevated aria-disabled:bg-elevated">
+      <!--v-if--><span data-slot="label" class="truncate">Deny</span>
+      <!--v-if-->
+    </button></div>
+</div>"
+`;
+
+exports[`ChatTool > renders with actions slot correctly 1`] = `
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group flex w-full items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default min-w-0 transition-colors rounded-sm outline-primary/25 focus-visible:outline-3">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
+  </div>
+  <div data-slot="actions" data-state="closed" class="flex items-center justify-end gap-1.5 pt-2">Custom actions</div>
+</div>"
+`;
+
+exports[`ChatTool > renders with actions variant card correctly 1`] = `
+"<div data-state="closed" data-slot="root" class="rounded-md ring ring-default overflow-hidden outline-primary/25 has-focus-visible:outline-3 has-focus-visible:ring-primary"><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group flex w-full items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default min-w-0 transition-colors px-2 py-1 focus:outline-none">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap border-t border-default p-2 max-h-[200px] overflow-y-auto focus:outline-none"></div>
+  </div>
+  <div data-slot="actions" data-state="closed" class="flex items-center justify-end gap-1.5 border-t border-default p-2"><button type="button" data-slot="base" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-inverted bg-primary hover:bg-primary/75 active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary outline-primary/25 focus-visible:outline-3">
+      <!--v-if--><span data-slot="label" class="truncate">Approve</span>
+      <!--v-if-->
+    </button><button type="button" data-slot="base" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-inverted bg-primary hover:bg-primary/75 active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary outline-primary/25 focus-visible:outline-3">
+      <!--v-if--><span data-slot="label" class="truncate">Deny</span>
+      <!--v-if-->
+    </button></div>
+</div>"
+`;
+
+exports[`ChatTool > renders with chevron leading and icon correctly 1`] = `
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group flex w-full items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default min-w-0 transition-colors rounded-sm outline-primary/25 focus-visible:outline-3"><span data-slot="leading" class="relative size-4 shrink-0"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="leadingIcon" class="size-4 shrink-0"></svg><!--v-if--></span><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
+  </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -18,6 +84,18 @@ exports[`ChatTool > renders with chevron leading correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
+</div>"
+`;
+
+exports[`ChatTool > renders with chevron leading, icon and content correctly 1`] = `
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" data-slot="trigger" class="group flex w-full items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default min-w-0 transition-colors rounded-sm outline-primary/25 focus-visible:outline-3"><span data-slot="leading" class="relative size-4 shrink-0"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="leadingIcon" class="size-4 shrink-0 absolute inset-0 group-hover:opacity-0 group-data-[state=open]:opacity-0 transition-opacity duration-200"></svg><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="chevronIcon" class="size-4 shrink-0 group-data-[state=open]:rotate-180 absolute inset-0 opacity-0 group-hover:opacity-100 group-data-[state=open]:opacity-100 transition-[rotate,opacity] duration-200"></svg></span><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2">Tool output content</div>
+  </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -29,6 +107,7 @@ exports[`ChatTool > renders with chevronIcon correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -40,6 +119,7 @@ exports[`ChatTool > renders with class correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -50,6 +130,7 @@ exports[`ChatTool > renders with default slot correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2">Tool output content</div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -61,6 +142,7 @@ exports[`ChatTool > renders with defaultOpen correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px; transition-duration: 0s; animation-name: none;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -71,6 +153,7 @@ exports[`ChatTool > renders with icon correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -81,6 +164,7 @@ exports[`ChatTool > renders with loading and loadingIcon correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -91,6 +175,7 @@ exports[`ChatTool > renders with loading correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -103,6 +188,7 @@ exports[`ChatTool > renders with streaming correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -114,6 +200,7 @@ exports[`ChatTool > renders with suffix correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -125,6 +212,7 @@ exports[`ChatTool > renders with text correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -136,6 +224,7 @@ exports[`ChatTool > renders with ui correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm whitespace-pre-wrap pt-2 text-muted"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -147,6 +236,7 @@ exports[`ChatTool > renders with variant card correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap border-t border-default p-2 max-h-[200px] overflow-y-auto focus:outline-none"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -158,5 +248,6 @@ exports[`ChatTool > renders with variant inline correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;

--- a/test/components/__snapshots__/ChatTool.spec.ts.snap
+++ b/test/components/__snapshots__/ChatTool.spec.ts.snap
@@ -1,13 +1,79 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
+exports[`ChatTool > renders with actions and content correctly 1`] = `
+"<div data-state="open" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="true" data-state="open" data-slot="trigger" class="group flex w-full items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default min-w-0 transition-colors rounded-sm outline-primary/25 focus-visible:outline-3">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span><span class="iconify i-lucide:chevron-down size-4 shrink-0 group-data-[state=open]:rotate-180 transition-transform duration-200" aria-hidden="true" data-slot="trailingIcon"></span>
+  </button>
+  <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px; transition-duration: 0s; animation-name: none;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2">Tool output content</div>
+  </div>
+  <div data-slot="actions" data-state="open" class="flex items-center justify-end gap-1.5 pt-2"><button type="button" data-slot="base" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-inverted bg-primary hover:bg-primary/75 active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary outline-primary/25 focus-visible:outline-3">
+      <!--v-if--><span data-slot="label" class="truncate">Approve</span>
+      <!--v-if-->
+    </button><button type="button" data-slot="base" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-inverted bg-primary hover:bg-primary/75 active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary outline-primary/25 focus-visible:outline-3">
+      <!--v-if--><span data-slot="label" class="truncate">Deny</span>
+      <!--v-if-->
+    </button></div>
+</div>"
+`;
+
+exports[`ChatTool > renders with actions correctly 1`] = `
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group flex w-full items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default min-w-0 transition-colors rounded-sm outline-primary/25 focus-visible:outline-3">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
+  </div>
+  <div data-slot="actions" data-state="closed" class="flex items-center justify-end gap-1.5 pt-2"><button type="button" data-slot="base" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-inverted bg-primary hover:bg-primary/75 active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary outline-primary/25 focus-visible:outline-3">
+      <!--v-if--><span data-slot="label" class="truncate">Approve</span>
+      <!--v-if-->
+    </button><button type="button" data-slot="base" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-default bg-elevated hover:bg-accented/75 active:bg-accented/75 outline-inverted/25 focus-visible:outline-3 disabled:bg-elevated aria-disabled:bg-elevated">
+      <!--v-if--><span data-slot="label" class="truncate">Deny</span>
+      <!--v-if-->
+    </button></div>
+</div>"
+`;
+
+exports[`ChatTool > renders with actions slot correctly 1`] = `
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group flex w-full items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default min-w-0 transition-colors rounded-sm outline-primary/25 focus-visible:outline-3">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
+  </div>
+  <div data-slot="actions" data-state="closed" class="flex items-center justify-end gap-1.5 pt-2">Custom actions</div>
+</div>"
+`;
+
+exports[`ChatTool > renders with actions variant card correctly 1`] = `
+"<div data-state="closed" data-slot="root" class="rounded-md ring ring-default overflow-hidden outline-primary/25 has-focus-visible:outline-3 has-focus-visible:ring-primary"><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group flex w-full items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default min-w-0 transition-colors px-2 py-1 focus:outline-none">
+    <!--v-if--><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap border-t border-default p-2 max-h-[200px] overflow-y-auto focus:outline-none"></div>
+  </div>
+  <div data-slot="actions" data-state="closed" class="flex items-center justify-end gap-1.5 border-t border-default p-2"><button type="button" data-slot="base" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-inverted bg-primary hover:bg-primary/75 active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary outline-primary/25 focus-visible:outline-3">
+      <!--v-if--><span data-slot="label" class="truncate">Approve</span>
+      <!--v-if-->
+    </button><button type="button" data-slot="base" class="rounded-md font-medium inline-flex items-center disabled:cursor-not-allowed aria-disabled:cursor-not-allowed disabled:opacity-75 aria-disabled:opacity-75 transition-colors px-2 py-1 text-xs gap-1 text-inverted bg-primary hover:bg-primary/75 active:bg-primary/75 disabled:bg-primary aria-disabled:bg-primary outline-primary/25 focus-visible:outline-3">
+      <!--v-if--><span data-slot="label" class="truncate">Deny</span>
+      <!--v-if-->
+    </button></div>
+</div>"
+`;
+
 exports[`ChatTool > renders with chevron leading and icon correctly 1`] = `
-"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group flex w-full items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default min-w-0 transition-colors rounded-sm outline-primary/25 focus-visible:outline-3"><span data-slot="leading" class="relative size-4 shrink-0"><span class="iconify i-lucide:search size-4 shrink-0 group-hover:opacity-0" aria-hidden="true" data-slot="leadingIcon"></span>
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" disabled="" data-slot="trigger" class="group flex w-full items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default min-w-0 transition-colors rounded-sm outline-primary/25 focus-visible:outline-3"><span data-slot="leading" class="relative size-4 shrink-0"><span class="iconify i-lucide:search size-4 shrink-0" aria-hidden="true" data-slot="leadingIcon"></span>
     <!--v-if--></span><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
     <!--v-if-->
   </button>
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -19,6 +85,18 @@ exports[`ChatTool > renders with chevron leading correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
+</div>"
+`;
+
+exports[`ChatTool > renders with chevron leading, icon and content correctly 1`] = `
+"<div data-state="closed" data-slot="root" class=""><button type="button" aria-controls="" aria-expanded="false" data-state="closed" data-slot="trigger" class="group flex w-full items-center gap-1.5 text-muted text-sm disabled:cursor-default disabled:hover:text-muted hover:text-default min-w-0 transition-colors rounded-sm outline-primary/25 focus-visible:outline-3"><span data-slot="leading" class="relative size-4 shrink-0"><span class="iconify i-lucide:search size-4 shrink-0 absolute inset-0 group-hover:opacity-0 group-data-[state=open]:opacity-0 transition-opacity duration-200" aria-hidden="true" data-slot="leadingIcon"></span><span class="iconify i-lucide:chevron-down size-4 shrink-0 group-data-[state=open]:rotate-180 absolute inset-0 opacity-0 group-hover:opacity-100 group-data-[state=open]:opacity-100 transition-[rotate,opacity] duration-200" aria-hidden="true" data-slot="chevronIcon"></span></span><span data-slot="label" class="truncate">Searching components<!--v-if--></span>
+    <!--v-if-->
+  </button>
+  <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
+    <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2">Tool output content</div>
+  </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -30,6 +108,7 @@ exports[`ChatTool > renders with chevronIcon correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -41,6 +120,7 @@ exports[`ChatTool > renders with class correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -51,6 +131,7 @@ exports[`ChatTool > renders with default slot correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2">Tool output content</div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -62,6 +143,7 @@ exports[`ChatTool > renders with defaultOpen correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px; transition-duration: 0s; animation-name: none;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -73,6 +155,7 @@ exports[`ChatTool > renders with icon correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -84,6 +167,7 @@ exports[`ChatTool > renders with loading and loadingIcon correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -95,6 +179,7 @@ exports[`ChatTool > renders with loading correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -107,6 +192,7 @@ exports[`ChatTool > renders with streaming correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -118,6 +204,7 @@ exports[`ChatTool > renders with suffix correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -129,6 +216,7 @@ exports[`ChatTool > renders with text correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -140,6 +228,7 @@ exports[`ChatTool > renders with ui correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm whitespace-pre-wrap pt-2 text-muted"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -151,6 +240,7 @@ exports[`ChatTool > renders with variant card correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap border-t border-default p-2 max-h-[200px] overflow-y-auto focus:outline-none"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;
 
@@ -162,5 +252,6 @@ exports[`ChatTool > renders with variant inline correctly 1`] = `
   <div data-slot="content" class="data-[state=open]:animate-[collapsible-down_200ms_ease-out] data-[state=closed]:animate-[collapsible-up_200ms_ease-out] data-[state=closed]:overflow-hidden" id="reka-collapsible-content-v-0-0-0" hidden="" data-state="closed" style="--reka-collapsible-content-height: 0px; --reka-collapsible-content-width: 0px;">
     <div data-slot="body" class="text-sm text-dimmed whitespace-pre-wrap pt-2"></div>
   </div>
+  <!--v-if-->
 </div>"
 `;


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds an `actions` prop to `ChatTool` so tools that need a confirmation before running can display buttons below the trigger, useful for building [tool approval](https://ai-sdk.dev/docs/agents/tool-approvals) flows with the AI SDK. When a tool part is in the `approval-requested` state you pass approve and deny actions and respond with `addToolApprovalResponse`.

The prop mirrors the existing `actions` pattern on `Alert`, `Banner` and `ChatMessage` (`ButtonProps[]` rendered in a footer, overridable through the `actions` slot). Since the trigger is a native button, the actions render in a footer region that is a sibling of the trigger to avoid nesting interactive elements. When the tool has collapsible content it now auto opens the moment actions appear so the user can see what they are approving, while still being able to collapse it.

It also carries a few related fixes found along the way. There is a new `isToolApprovalPending` helper in `@nuxt/ui/utils/ai`, and `isToolStreaming` now returns `false` for `approval-requested` so the shimmer no longer animates while a tool is paused waiting for the user. The card footer border only shows when there is a body and the collapsible is open. The leading icon no longer disappears on hover when `chevron="leading"` is set without any collapsible content. And assistant messages (`ChatMessage`, naked left) now let the body fill the column instead of shrinking to its content, which previously made embedded tool cards grow when expanded.

Documentation, a playground page and an interactive example are included.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.