### PR TITLE
fix(useToast): dedupe duplicate ids and handle max of 0

### DIFF
--- a/src/runtime/composables/useToast.ts
+++ b/src/runtime/composables/useToast.ts
@@ -45,7 +45,9 @@ export function useToast() {
       const toast = queue.shift()!
       const maxValue = max?.value ?? 5
       if (maxValue <= 0) {
-        toasts.value = []
+        if (toasts.value.length) {
+          toasts.value = []
+        }
         continue
       }
 

--- a/src/runtime/composables/useToast.ts
+++ b/src/runtime/composables/useToast.ts
@@ -24,6 +24,14 @@ export function useToast() {
 
   const generateId = () => `${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
 
+  function mergeDuplicate(index: number, toast: Toast) {
+    toasts.value[index] = {
+      ...toasts.value[index] as Toast,
+      ...toast,
+      _duplicate: ((toasts.value[index] as Toast)._duplicate || 0) + 1
+    }
+  }
+
   async function processQueue() {
     if (running.value || queue.length === 0) {
       return
@@ -32,11 +40,23 @@ export function useToast() {
     running.value = true
 
     while (queue.length > 0) {
-      const toast = queue.shift()!
-
       await nextTick()
 
-      toasts.value = [...toasts.value, toast].slice(-(max?.value ?? 5))
+      const toast = queue.shift()!
+      const maxValue = max?.value ?? 5
+      if (maxValue <= 0) {
+        toasts.value = []
+        continue
+      }
+
+      // Dedupe at display time so duplicate ids merge no matter which `useToast()` instance queued them.
+      const existingIndex = toasts.value.findIndex((t: Toast) => t.id === toast.id)
+      if (existingIndex !== -1) {
+        mergeDuplicate(existingIndex, toast)
+        continue
+      }
+
+      toasts.value = [...toasts.value, toast].slice(-maxValue)
     }
 
     running.value = false
@@ -51,11 +71,7 @@ export function useToast() {
 
     const existingIndex = toasts.value.findIndex((t: Toast) => t.id === body.id)
     if (existingIndex !== -1) {
-      toasts.value[existingIndex] = {
-        ...toasts.value[existingIndex] as Toast,
-        ...body,
-        _duplicate: ((toasts.value[existingIndex] as Toast)._duplicate || 0) + 1
-      }
+      mergeDuplicate(existingIndex, body)
 
       return body
     }

--- a/test/composables/useToast.spec.ts
+++ b/test/composables/useToast.spec.ts
@@ -1,0 +1,206 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+import { defineComponent, h, provide, ref } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { useToast, toastMaxInjectionKey } from '../../src/runtime/composables/useToast'
+import type { Toast } from '../../src/runtime/composables/useToast'
+
+describe('useToast', () => {
+  let toast: ReturnType<typeof useToast>
+
+  beforeEach(() => {
+    toast = useToast()
+    toast.clear()
+  })
+
+  afterEach(() => {
+    toast.clear()
+  })
+
+  describe('add', () => {
+    it('returns a toast with a generated id and open state', () => {
+      const body = toast.add({ title: 'Hello' })
+
+      expect(body.id).toBeDefined()
+      expect(body.open).toBe(true)
+      expect(body.title).toBe('Hello')
+    })
+
+    it('keeps an explicit id', () => {
+      const body = toast.add({ id: 'custom', title: 'Hello' })
+
+      expect(body.id).toBe('custom')
+    })
+
+    it('pushes the toast to the list after the queue drains', async () => {
+      toast.add({ id: 'a', title: 'A' })
+
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+      expect(toast.toasts.value[0]!.id).toBe('a')
+    })
+
+    it('increments _duplicate instead of adding a toast with an existing id', async () => {
+      toast.add({ id: 'dup', title: 'First' })
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+
+      toast.add({ id: 'dup', title: 'Second' })
+
+      expect(toast.toasts.value).toHaveLength(1)
+      expect(toast.toasts.value[0]!.title).toBe('Second')
+      expect(toast.toasts.value[0]!._duplicate).toBe(1)
+    })
+
+    it('does not duplicate a toast added twice with the same id in the same tick', async () => {
+      // Both adds land before the queue drains, so dedup must happen at display time.
+      toast.add({ id: 'dup', title: 'First' })
+      toast.add({ id: 'dup', title: 'Second' })
+
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+      await new Promise(resolve => setTimeout(resolve, 20))
+
+      expect(toast.toasts.value).toHaveLength(1)
+      expect(toast.toasts.value[0]!.title).toBe('Second')
+      expect(toast.toasts.value[0]!._duplicate).toBe(1)
+    })
+
+    it('does not duplicate a toast added from two useToast instances in the same tick', async () => {
+      // Each instance has its own queue, only `toasts` is shared, so the queues can't see each other.
+      const other = useToast()
+
+      toast.add({ id: 'cross-dup', title: 'First' })
+      other.add({ id: 'cross-dup', title: 'Second' })
+
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+      await new Promise(resolve => setTimeout(resolve, 20))
+
+      expect(toast.toasts.value).toHaveLength(1)
+      expect(toast.toasts.value[0]!.title).toBe('Second')
+      expect(toast.toasts.value[0]!._duplicate).toBe(1)
+    })
+  })
+
+  describe('max', () => {
+    it('keeps at most 5 toasts by default', async () => {
+      for (let i = 0; i < 7; i++) {
+        toast.add({ id: `t${i}`, title: `T${i}` })
+      }
+
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(5))
+      // Oldest are dropped, keeping the last 5.
+      expect(toast.toasts.value.map((t: Toast) => t.id)).toEqual(['t2', 't3', 't4', 't5', 't6'])
+    })
+
+    // `max` is injected, so it must be provided by an ancestor, not the same setup.
+    async function mountWithMax(maxValue: number) {
+      let scoped!: ReturnType<typeof useToast>
+      const Child = defineComponent({
+        setup() {
+          scoped = useToast()
+          return () => null
+        }
+      })
+      const Parent = defineComponent({
+        setup() {
+          provide(toastMaxInjectionKey, ref(maxValue))
+          return () => h(Child)
+        }
+      })
+      const wrapper = await mountSuspended(Parent)
+      scoped.clear()
+      return { scoped, wrapper }
+    }
+
+    it('respects a provided max', async () => {
+      const { scoped, wrapper } = await mountWithMax(2)
+
+      for (let i = 0; i < 4; i++) {
+        scoped.add({ id: `m${i}`, title: `M${i}` })
+      }
+
+      await vi.waitFor(() => expect(scoped.toasts.value).toHaveLength(2))
+      expect(scoped.toasts.value.map((t: Toast) => t.id)).toEqual(['m2', 'm3'])
+
+      wrapper.unmount()
+    })
+
+    it('displays no toasts when max is 0', async () => {
+      const { scoped, wrapper } = await mountWithMax(0)
+
+      scoped.add({ id: 'a' })
+      scoped.add({ id: 'b' })
+
+      await new Promise(resolve => setTimeout(resolve, 50))
+
+      expect(scoped.toasts.value).toHaveLength(0)
+
+      wrapper.unmount()
+    })
+  })
+
+  describe('update', () => {
+    it('updates the fields of an existing toast', async () => {
+      toast.add({ id: 'u', title: 'Before' })
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+
+      toast.update('u', { title: 'After' })
+
+      expect(toast.toasts.value[0]!.title).toBe('After')
+      expect(toast.toasts.value[0]!.open).toBe(true)
+    })
+
+    it('does nothing for an unknown id', async () => {
+      toast.add({ id: 'u', title: 'Before' })
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+
+      toast.update('missing', { title: 'After' })
+
+      expect(toast.toasts.value[0]!.title).toBe('Before')
+    })
+  })
+
+  describe('remove', () => {
+    it('closes then removes the toast after the exit delay', async () => {
+      toast.add({ id: 'r', title: 'Bye' })
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+
+      toast.remove('r')
+
+      // Closed immediately so the exit transition can play...
+      expect(toast.toasts.value[0]!.open).toBe(false)
+      // ...then dropped from the list once the transition is done.
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(0))
+    })
+
+    it('does not remove a toast that was just updated', async () => {
+      toast.add({ id: 'g', title: 'Keep' })
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+
+      // `update` flags the toast as `_updated` for the current tick.
+      toast.update('g', { title: 'Updated' })
+      toast.remove('g')
+
+      // The remove is ignored while the toast is flagged as updated.
+      expect(toast.toasts.value).toHaveLength(1)
+      expect(toast.toasts.value[0]!.open).toBe(true)
+    })
+
+    it('does nothing for an unknown id', async () => {
+      toast.add({ id: 'r', title: 'Bye' })
+      await vi.waitFor(() => expect(toast.toasts.value).toHaveLength(1))
+
+      expect(() => toast.remove('missing')).not.toThrow()
+      expect(toast.toasts.value).toHaveLength(1)
+    })
+  })
+
+  describe('clear', () => {
+    it('removes all toasts', async () => {
+      toast.add({ id: 'a' })
+      toast.add({ id: 'b' })
+      await vi.waitFor(() => expect(toast.toasts.value.length).toBeGreaterThan(0))
+
+      toast.clear()
+
+      expect(toast.toasts.value).toHaveLength(0)
+    })
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

n/a, found while auditing the composables

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Two fixes in `useToast`. Adding a toast with the same id twice in the same tick created two toasts with the same id because the duplicate check only looked at the displayed list while the second toast was still sitting in the queue. The dedupe now happens at display time in `processQueue`, which also covers adds coming from two different `useToast()` instances since only `toasts` is shared state. Second, `max: 0` used to keep every toast because `slice(-0)` is `slice(0)`, it now shows none as you'd expect.

Comes with a `useToast` test suite covering the queue, duplicates across ticks and instances, max handling, update, remove and clear.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.