### PR TITLE
fix(useFileUpload): keep dropzone type filter reactive to accept

### DIFF
--- a/src/runtime/composables/useFileUpload.ts
+++ b/src/runtime/composables/useFileUpload.ts
@@ -15,12 +15,13 @@ export interface UseFileUploadOptions {
   onUpdate: (files: File[]) => void
 }
 
-function parseAcceptToDataTypes(accept: string): string[] | undefined {
+function parseAcceptToDataTypes(accept: string): string[] {
+  // An empty list means no restriction (`useDropZone` allows all types for an empty array).
   if (!accept || accept === '*') {
-    return undefined
+    return []
   }
 
-  const types = accept
+  return accept
     .split(',')
     .map((type) => {
       const trimmedType = type.trim()
@@ -33,8 +34,6 @@ function parseAcceptToDataTypes(accept: string): string[] | undefined {
     .filter((type) => {
       return !type.startsWith('.')
     })
-
-  return types.length > 0 ? types : undefined
 }
 
 export function useFileUpload(options: UseFileUploadOptions) {
@@ -48,7 +47,7 @@ export function useFileUpload(options: UseFileUploadOptions) {
   const inputRef = ref<ComponentPublicInstance>()
   const dropzoneRef = ref<HTMLDivElement>()
 
-  const dataTypes = computed(() => parseAcceptToDataTypes(unref(accept)))
+  const dataTypes = computed<readonly string[]>(() => parseAcceptToDataTypes(unref(accept)))
 
   const onDrop = (files: FileList | File[] | null, fromDropZone = false) => {
     if (!files || files.length === 0) {
@@ -87,7 +86,7 @@ export function useFileUpload(options: UseFileUploadOptions) {
 
   onMounted(() => {
     const { isOverDropZone } = dropzone
-      ? useDropZone(dropzoneRef, { dataTypes: dataTypes.value, onDrop: files => onDrop(files, true) })
+      ? useDropZone(dropzoneRef, { dataTypes, onDrop: files => onDrop(files, true) })
       : { isOverDropZone: ref(false) }
 
     watch(isOverDropZone, (value) => {

--- a/test/composables/useFileUpload.spec.ts
+++ b/test/composables/useFileUpload.spec.ts
@@ -1,0 +1,204 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { defineComponent, nextTick, ref, unref } from 'vue'
+import type { MaybeRef } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { useFileUpload } from '../../src/runtime/composables/useFileUpload'
+import type { UseFileUploadOptions } from '../../src/runtime/composables/useFileUpload'
+
+// Captures the callbacks that `useFileUpload` registers with the VueUse hooks
+// inside `onMounted`, so the test can drive drops and dialog changes directly.
+const vueuse = vi.hoisted(() => ({
+  dropOptions: undefined as { dataTypes?: MaybeRef<readonly string[]>, onDrop: (files: File[] | FileList | null) => void } | undefined,
+  onChangeCb: undefined as ((files: FileList | File[] | null) => void) | undefined,
+  open: undefined as ReturnType<typeof vi.fn> | undefined,
+  isOver: undefined as { value: boolean } | undefined
+}))
+
+vi.mock('@vueuse/core', async () => {
+  // Spread the real module so unrelated consumers (Nuxt internals) keep working.
+  const actual = await vi.importActual<typeof import('@vueuse/core')>('@vueuse/core')
+  const { ref } = await import('vue')
+
+  return {
+    ...actual,
+    useDropZone: (_target: unknown, options: any) => {
+      vueuse.dropOptions = options
+      vueuse.isOver = ref(false)
+      return { isOverDropZone: vueuse.isOver }
+    },
+    useFileDialog: () => {
+      vueuse.open = vi.fn()
+      return {
+        onChange: (cb: any) => {
+          vueuse.onChangeCb = cb
+        },
+        open: vueuse.open
+      }
+    }
+  }
+})
+
+function file(name: string): File {
+  return new File(['data'], name, { type: 'text/plain' })
+}
+
+async function mountUpload(options: UseFileUploadOptions) {
+  let api!: ReturnType<typeof useFileUpload>
+  const component = defineComponent({
+    setup() {
+      api = useFileUpload(options)
+      return () => null
+    }
+  })
+  const wrapper = await mountSuspended(component)
+  return { api, wrapper }
+}
+
+describe('useFileUpload', () => {
+  beforeEach(() => {
+    vueuse.dropOptions = undefined
+    vueuse.onChangeCb = undefined
+    vueuse.open = undefined
+    vueuse.isOver = undefined
+  })
+
+  describe('onDrop (drop zone)', () => {
+    it('forwards dropped files to onUpdate', async () => {
+      const onUpdate = vi.fn()
+      await mountUpload({ onUpdate, multiple: true })
+      const a = file('a.txt')
+      const b = file('b.txt')
+
+      vueuse.dropOptions!.onDrop([a, b])
+
+      expect(onUpdate).toHaveBeenCalledWith([a, b])
+    })
+
+    it('keeps only the first file when not multiple', async () => {
+      const onUpdate = vi.fn()
+      await mountUpload({ onUpdate, multiple: false })
+      const a = file('a.txt')
+      const b = file('b.txt')
+
+      vueuse.dropOptions!.onDrop([a, b])
+
+      expect(onUpdate).toHaveBeenCalledWith([a])
+    })
+
+    it('ignores an empty drop', async () => {
+      const onUpdate = vi.fn()
+      await mountUpload({ onUpdate })
+
+      vueuse.dropOptions!.onDrop([])
+
+      expect(onUpdate).not.toHaveBeenCalled()
+    })
+
+    it('ignores a null drop', async () => {
+      const onUpdate = vi.fn()
+      await mountUpload({ onUpdate })
+
+      vueuse.dropOptions!.onDrop(null)
+
+      expect(onUpdate).not.toHaveBeenCalled()
+    })
+  })
+
+  describe('onChange (file dialog)', () => {
+    it('forwards selected files to onUpdate', async () => {
+      const onUpdate = vi.fn()
+      await mountUpload({ onUpdate })
+      const a = file('a.txt')
+
+      vueuse.onChangeCb!([a])
+
+      expect(onUpdate).toHaveBeenCalledWith([a])
+    })
+  })
+
+  describe('open', () => {
+    it('opens the native file dialog', async () => {
+      const onUpdate = vi.fn()
+      const { api } = await mountUpload({ onUpdate })
+
+      api.open()
+
+      expect(vueuse.open).toHaveBeenCalled()
+    })
+  })
+
+  describe('isDragging', () => {
+    it('follows the drop zone hover state', async () => {
+      const onUpdate = vi.fn()
+      const { api } = await mountUpload({ onUpdate })
+
+      expect(api.isDragging.value).toBe(false)
+
+      vueuse.isOver!.value = true
+      await nextTick()
+
+      expect(api.isDragging.value).toBe(true)
+    })
+  })
+
+  describe('accept parsing', () => {
+    it('passes wildcard MIME types to the drop zone as their base type', async () => {
+      await mountUpload({ onUpdate: vi.fn(), accept: 'image/*' })
+
+      expect(unref(vueuse.dropOptions!.dataTypes)).toEqual(['image'])
+    })
+
+    it('keeps full MIME types and drops extension filters', async () => {
+      // Drag items only expose MIME types, so `.pdf` can't be checked on drop.
+      await mountUpload({ onUpdate: vi.fn(), accept: '.pdf, image/png' })
+
+      expect(unref(vueuse.dropOptions!.dataTypes)).toEqual(['image/png'])
+    })
+
+    it('allows all types for the default accept', async () => {
+      // An empty list means no restriction for `useDropZone`.
+      await mountUpload({ onUpdate: vi.fn(), accept: '*' })
+
+      expect(unref(vueuse.dropOptions!.dataTypes)).toEqual([])
+    })
+
+    it('allows all types when accept only contains extensions', async () => {
+      await mountUpload({ onUpdate: vi.fn(), accept: '.pdf,.docx' })
+
+      expect(unref(vueuse.dropOptions!.dataTypes)).toEqual([])
+    })
+
+    it('keeps the drop zone filter reactive to accept changes', async () => {
+      const accept = ref('image/*')
+      await mountUpload({ onUpdate: vi.fn(), accept })
+
+      expect(unref(vueuse.dropOptions!.dataTypes)).toEqual(['image'])
+
+      accept.value = 'video/*'
+      await nextTick()
+
+      expect(unref(vueuse.dropOptions!.dataTypes)).toEqual(['video'])
+    })
+  })
+
+  describe('dropzone option', () => {
+    it('does not register a drop zone when dropzone is false', async () => {
+      const onUpdate = vi.fn()
+      await mountUpload({ onUpdate, dropzone: false })
+
+      expect(vueuse.dropOptions).toBeUndefined()
+    })
+  })
+
+  describe('refs', () => {
+    it('exposes input and drop zone refs', async () => {
+      const onUpdate = vi.fn()
+      const { api } = await mountUpload({ onUpdate })
+
+      expect(api.inputRef).toBeDefined()
+      expect(api.dropzoneRef).toBeDefined()
+      expect('value' in api.inputRef).toBe(true)
+      expect('value' in api.dropzoneRef).toBe(true)
+    })
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

n/a, found while auditing the composables

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`useDropZone` was receiving `dataTypes.value`, unwrapping the computed at mount time and freezing the drag and drop type filter. Since `FileUpload` passes `accept` as a `toRef`, changing `:accept` at runtime updated the file dialog but not the dropzone. The computed is now passed directly, `useDropZone` accepts a `MaybeRef` and unrefs it on every drag event. The parser also returns an empty array instead of `undefined` for the unrestricted case, which is what `useDropZone` expects from a ref (its `checkDataTypes` treats an empty list as allow all).

Comes with a `useFileUpload` test suite covering drops, the file dialog, the accept parsing and the reactivity of the filter.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.