### PR TITLE
test(composables): add specs for defineLocale, useKbd and useFormField

### DIFF
--- a/test/composables/defineLocale.spec.ts
+++ b/test/composables/defineLocale.spec.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect } from 'vitest'
+import { defineLocale, extendLocale } from '../../src/runtime/composables/defineLocale'
+
+interface TestMessages {
+  greeting: string
+  nested: {
+    hello: string
+    bye: string
+  }
+}
+
+const baseOptions = {
+  name: 'English',
+  code: 'en',
+  messages: {
+    greeting: 'Hello',
+    nested: {
+      hello: 'Hello',
+      bye: 'Bye'
+    }
+  }
+}
+
+describe('defineLocale', () => {
+  it('returns the provided options untouched', () => {
+    const locale = defineLocale<TestMessages>(baseOptions)
+
+    expect(locale.name).toBe('English')
+    expect(locale.code).toBe('en')
+    expect(locale.messages).toEqual(baseOptions.messages)
+  })
+
+  it('defaults dir to ltr when not provided', () => {
+    const locale = defineLocale<TestMessages>(baseOptions)
+
+    expect(locale.dir).toBe('ltr')
+  })
+
+  it('keeps an explicit dir', () => {
+    const locale = defineLocale<TestMessages>({ ...baseOptions, dir: 'rtl' })
+
+    expect(locale.dir).toBe('rtl')
+  })
+})
+
+describe('extendLocale', () => {
+  it('overrides top-level fields', () => {
+    const base = defineLocale<TestMessages>(baseOptions)
+    const extended = extendLocale<TestMessages>(base, { name: 'British English', code: 'en-GB' })
+
+    expect(extended.name).toBe('British English')
+    expect(extended.code).toBe('en-GB')
+  })
+
+  it('deep-merges messages, keeping untouched keys from the base', () => {
+    const base = defineLocale<TestMessages>(baseOptions)
+    const extended = extendLocale<TestMessages>(base, {
+      messages: {
+        nested: {
+          hello: 'Hi'
+        }
+      }
+    })
+
+    expect(extended.messages.nested.hello).toBe('Hi')
+    // Untouched keys fall back to the base locale.
+    expect(extended.messages.nested.bye).toBe('Bye')
+    expect(extended.messages.greeting).toBe('Hello')
+  })
+
+  it('inherits dir from the base locale when not overridden', () => {
+    const base = defineLocale<TestMessages>({ ...baseOptions, dir: 'rtl' })
+    const extended = extendLocale<TestMessages>(base, { name: 'Variant' })
+
+    expect(extended.dir).toBe('rtl')
+  })
+
+  it('does not mutate the base locale', () => {
+    const base = defineLocale<TestMessages>(baseOptions)
+    extendLocale<TestMessages>(base, { name: 'Variant', messages: { greeting: 'Yo' } })
+
+    expect(base.name).toBe('English')
+    expect(base.messages.greeting).toBe('Hello')
+  })
+})

--- a/test/composables/useFormField.spec.ts
+++ b/test/composables/useFormField.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi } from 'vitest'
+import { describe, it, expect, vi, afterEach } from 'vitest'
 import { defineComponent, h, provide, computed, ref } from 'vue'
 import { useEventBus } from '@vueuse/core'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
@@ -30,10 +30,16 @@ interface Context {
   inputId?: string
 }
 
+const teardowns: Array<() => void> = []
+
+afterEach(() => {
+  teardowns.splice(0).forEach(fn => fn())
+})
+
 async function mountField(props?: FieldProps, opts?: FieldOpts, ctx: Context = {}) {
   const events: FormEvent<any>[] = []
   const bus = useEventBus<FormEvent<any>>(Symbol('test-form'))
-  bus.on(event => events.push(event))
+  const off = bus.on(event => events.push(event))
 
   const inputIdRef = ref<string | undefined>(ctx.inputId)
 
@@ -60,6 +66,7 @@ async function mountField(props?: FieldProps, opts?: FieldOpts, ctx: Context = {
   })
 
   const wrapper = await mountSuspended(Parent)
+  teardowns.push(off, () => wrapper.unmount())
   return { api, events, inputIdRef, wrapper }
 }
 

--- a/test/composables/useFormField.spec.ts
+++ b/test/composables/useFormField.spec.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi } from 'vitest'
+import { defineComponent, h, provide, computed, ref } from 'vue'
+import { useEventBus } from '@vueuse/core'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import {
+  useFormField,
+  formOptionsInjectionKey,
+  formBusInjectionKey,
+  formFieldInjectionKey,
+  inputIdInjectionKey
+} from '../../src/runtime/composables/useFormField'
+import type { FormEvent, FormFieldInjectedOptions, FormInjectedOptions } from '../../src/runtime/types/form'
+
+// Concrete stand-in for a component's props type so `size`/`color` accept strings.
+type TestProps = { size: string, color: string }
+
+interface FieldProps {
+  id?: string
+  name?: string
+  size?: string
+  color?: string
+  highlight?: boolean
+  disabled?: boolean
+}
+type FieldOpts = Parameters<typeof useFormField>[1]
+
+interface Context {
+  formOptions?: FormInjectedOptions
+  formField?: Partial<FormFieldInjectedOptions<any>>
+  inputId?: string
+}
+
+async function mountField(props?: FieldProps, opts?: FieldOpts, ctx: Context = {}) {
+  const events: FormEvent<any>[] = []
+  const bus = useEventBus<FormEvent<any>>(Symbol('test-form'))
+  bus.on(event => events.push(event))
+
+  const inputIdRef = ref<string | undefined>(ctx.inputId)
+
+  let api!: ReturnType<typeof useFormField<TestProps>>
+  const Child = defineComponent({
+    setup() {
+      api = useFormField<TestProps>(props, opts)
+      return () => null
+    }
+  })
+
+  const Parent = defineComponent({
+    setup() {
+      provide(formBusInjectionKey, bus)
+      provide(inputIdInjectionKey, inputIdRef)
+      if (ctx.formOptions) {
+        provide(formOptionsInjectionKey, computed(() => ctx.formOptions as FormInjectedOptions))
+      }
+      if (ctx.formField) {
+        provide(formFieldInjectionKey, computed(() => ctx.formField as FormFieldInjectedOptions<any>))
+      }
+      return () => h(Child)
+    }
+  })
+
+  const wrapper = await mountSuspended(Parent)
+  return { api, events, inputIdRef, wrapper }
+}
+
+describe('useFormField', () => {
+  describe('without a wrapping form field', () => {
+    it('derives its values from the props', async () => {
+      const { api } = await mountField({ id: 'my-id', name: 'my-name', size: 'lg', color: 'primary', highlight: true, disabled: true })
+
+      expect(api.id.value).toBe('my-id')
+      expect(api.name.value).toBe('my-name')
+      expect(api.size.value).toBe('lg')
+      expect(api.color.value).toBe('primary')
+      expect(api.highlight.value).toBe(true)
+      expect(api.disabled.value).toBe(true)
+    })
+
+    it('has no aria attributes', async () => {
+      const { api } = await mountField({ name: 'x' })
+
+      expect(api.ariaAttrs.value).toBeUndefined()
+    })
+
+    it('does not emit form events without an injected form field', async () => {
+      const { api, events } = await mountField({ name: 'x' })
+
+      api.emitFormBlur()
+      api.emitFormChange()
+      api.emitFormFocus()
+
+      expect(events).toHaveLength(0)
+    })
+  })
+
+  describe('with a wrapping form field', () => {
+    it('falls back to the field name, size and id', async () => {
+      const { api } = await mountField(
+        {},
+        undefined,
+        { formField: { name: 'field-name', size: 'sm', ariaId: 'aria-1' }, inputId: 'input-1' }
+      )
+
+      expect(api.name.value).toBe('field-name')
+      expect(api.size.value).toBe('sm')
+      expect(api.id.value).toBe('input-1')
+    })
+
+    it('lets explicit props win over the field', async () => {
+      const { api } = await mountField(
+        { name: 'prop-name', size: 'xl' },
+        undefined,
+        { formField: { name: 'field-name', size: 'sm', ariaId: 'aria-1' } }
+      )
+
+      expect(api.name.value).toBe('prop-name')
+      expect(api.size.value).toBe('xl')
+    })
+
+    it('forces error color and highlight when the field has an error', async () => {
+      const { api } = await mountField(
+        { color: 'primary', highlight: false },
+        undefined,
+        { formField: { ariaId: 'aria-1', error: 'Required' } }
+      )
+
+      expect(api.color.value).toBe('error')
+      expect(api.highlight.value).toBe(true)
+    })
+
+    it('builds aria attributes from the descriptive field slots', async () => {
+      const { api } = await mountField(
+        {},
+        undefined,
+        { formField: { ariaId: 'aria-1', error: 'Required', hint: 'Hint', description: 'Desc' } }
+      )
+
+      const attrs = api.ariaAttrs.value!
+      expect(attrs['aria-invalid']).toBe(true)
+      expect(attrs['aria-describedby']).toBe('aria-1-error aria-1-hint aria-1-description')
+    })
+
+    it('marks aria-invalid false and omits describedby when there is no error or description', async () => {
+      const { api } = await mountField({}, undefined, { formField: { ariaId: 'aria-1' } })
+
+      const attrs = api.ariaAttrs.value!
+      expect(attrs['aria-invalid']).toBe(false)
+      expect(attrs['aria-describedby']).toBeUndefined()
+    })
+
+    it('reflects the form-level disabled option', async () => {
+      const { api } = await mountField({}, undefined, { formField: { ariaId: 'aria-1' }, formOptions: { disabled: true } })
+
+      expect(api.disabled.value).toBe(true)
+    })
+  })
+
+  describe('input id binding', () => {
+    it('sets the input id from props.id by default', async () => {
+      const { inputIdRef } = await mountField({ id: 'bound-id' }, undefined, { formField: { ariaId: 'aria-1' }, inputId: 'initial' })
+
+      expect(inputIdRef.value).toBe('bound-id')
+    })
+
+    it('clears the input id when bind is false', async () => {
+      const { inputIdRef } = await mountField({ id: 'bound-id' }, { bind: false }, { formField: { ariaId: 'aria-1' }, inputId: 'initial' })
+
+      expect(inputIdRef.value).toBeUndefined()
+    })
+  })
+
+  describe('form events', () => {
+    it('emits blur, focus and change with the field name', async () => {
+      const { api, events } = await mountField({}, undefined, { formField: { name: 'email', ariaId: 'aria-1' } })
+
+      api.emitFormBlur()
+      api.emitFormFocus()
+      api.emitFormChange()
+
+      expect(events).toEqual([
+        { type: 'blur', name: 'email', eager: undefined },
+        { type: 'focus', name: 'email', eager: undefined },
+        { type: 'change', name: 'email', eager: undefined }
+      ])
+    })
+
+    it('emits a debounced eager input event', async () => {
+      const { api, events } = await mountField({}, undefined, { formField: { name: 'email', ariaId: 'aria-1' } })
+
+      api.emitFormInput()
+
+      await vi.waitFor(() => expect(events).toContainEqual({ type: 'input', name: 'email', eager: true }))
+    })
+
+    it('defers input validation when requested and the field is not eager', async () => {
+      const { api, events } = await mountField({}, { deferInputValidation: true }, { formField: { name: 'email', ariaId: 'aria-1', eagerValidation: false } })
+
+      api.emitFormInput()
+
+      await vi.waitFor(() => expect(events).toContainEqual({ type: 'input', name: 'email', eager: false }))
+    })
+
+    it('stays eager when the field opts into eager validation, even with defer', async () => {
+      const { api, events } = await mountField({}, { deferInputValidation: true }, { formField: { name: 'email', ariaId: 'aria-1', eagerValidation: true } })
+
+      api.emitFormInput()
+
+      await vi.waitFor(() => expect(events).toContainEqual({ type: 'input', name: 'email', eager: true }))
+    })
+  })
+})

--- a/test/composables/useKbd.spec.ts
+++ b/test/composables/useKbd.spec.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, afterEach } from 'vitest'
+import { defineComponent } from 'vue'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { useKbd } from '../../src/runtime/composables/useKbd'
+
+const originalUserAgent = navigator.userAgent
+
+function setUserAgent(ua: string) {
+  Object.defineProperty(navigator, 'userAgent', { value: ua, configurable: true })
+}
+
+describe('useKbd', () => {
+  // These run first so the shared composable initializes inside a mounted
+  // component (its `onMounted` only fills the meta/ctrl/alt map when mounted).
+  describe('platform-specific keys (meta/ctrl/alt)', () => {
+    let wrapper: Awaited<ReturnType<typeof mountSuspended>>
+
+    afterEach(() => {
+      wrapper?.unmount()
+      setUserAgent(originalUserAgent)
+    })
+
+    async function mountKbd() {
+      let api!: ReturnType<typeof useKbd>
+      const component = defineComponent({
+        setup() {
+          api = useKbd()
+          return () => null
+        }
+      })
+      wrapper = await mountSuspended(component)
+      return api
+    }
+
+    it('maps meta/ctrl/alt to macOS symbols on macOS', async () => {
+      setUserAgent('Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)')
+      const kbd = await mountKbd()
+
+      expect(kbd.macOS.value).toBeTruthy()
+      expect(kbd.getKbdKey('meta')).toBe('⌘')
+      expect(kbd.getKbdKey('ctrl')).toBe('⌃')
+      expect(kbd.getKbdKey('alt')).toBe('⌥')
+    })
+
+    it('maps meta/ctrl/alt to text labels off macOS', async () => {
+      setUserAgent('Mozilla/5.0 (Windows NT 10.0; Win64; x64)')
+      const kbd = await mountKbd()
+
+      expect(kbd.macOS.value).toBeFalsy()
+      expect(kbd.getKbdKey('meta')).toBe('Ctrl')
+      expect(kbd.getKbdKey('ctrl')).toBe('Ctrl')
+      expect(kbd.getKbdKey('alt')).toBe('Alt')
+    })
+  })
+
+  describe('static key resolution', () => {
+    it('maps named keys to their symbols', () => {
+      const { getKbdKey } = useKbd()
+
+      expect(getKbdKey('enter')).toBe('↵')
+      expect(getKbdKey('shift')).toBe('⇧')
+      expect(getKbdKey('escape')).toBe('Esc')
+      expect(getKbdKey('tab')).toBe('⇥')
+      expect(getKbdKey('backspace')).toBe('⌫')
+      expect(getKbdKey('delete')).toBe('⌦')
+      expect(getKbdKey('capslock')).toBe('⇪')
+      expect(getKbdKey('command')).toBe('⌘')
+    })
+
+    it('maps arrow keys to their symbols', () => {
+      const { getKbdKey } = useKbd()
+
+      expect(getKbdKey('arrowup')).toBe('↑')
+      expect(getKbdKey('arrowright')).toBe('→')
+      expect(getKbdKey('arrowdown')).toBe('↓')
+      expect(getKbdKey('arrowleft')).toBe('←')
+    })
+
+    it('returns the raw value for keys that are not in the map', () => {
+      const { getKbdKey } = useKbd()
+
+      expect(getKbdKey('a')).toBe('a')
+      expect(getKbdKey('f1')).toBe('f1')
+      expect(getKbdKey('/')).toBe('/')
+    })
+
+    it('returns undefined for a missing value', () => {
+      const { getKbdKey } = useKbd()
+
+      expect(getKbdKey()).toBeUndefined()
+      expect(getKbdKey('')).toBeUndefined()
+    })
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds test coverage for three public composables that had none: `defineLocale`/`extendLocale` (defaults, deep merge, no mutation), `useKbd` (platform specific keys, static map, fallbacks) and `useFormField` (prop vs field precedence, error color and highlight, aria attributes, input id binding, form events and input debouncing). Together with the suites shipping alongside the composable fixes, every public composable from `imports.ts` is now covered in both the nuxt and vue test projects.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.