### PR TITLE
fix(defineShortcuts): add missing `arrowdown` to shiftable keys

### DIFF
--- a/src/runtime/composables/defineShortcuts.ts
+++ b/src/runtime/composables/defineShortcuts.ts
@@ -38,7 +38,7 @@ interface Shortcut {
 const chainedShortcutRegex = /^[^-]+.*-.*[^-]+$/
 const combinedShortcutRegex = /^[^_]+.*_.*[^_]+$/
 // keyboard keys which can be combined with Shift modifier (in addition to alphabet keys)
-const shiftableKeys = ['arrowleft', 'arrowright', 'arrowup', 'arrowright', 'tab', 'escape', 'enter', 'backspace']
+const shiftableKeys = ['arrowleft', 'arrowright', 'arrowup', 'arrowdown', 'tab', 'escape', 'enter', 'backspace']
 
 // Simple key to code conversion for layout independence
 function convertKeyToCode(key: string): string {

--- a/test/composables/defineShortcuts.spec.ts
+++ b/test/composables/defineShortcuts.spec.ts
@@ -302,6 +302,22 @@ describe('defineShortcuts', () => {
       fireKeydown('Escape', { shiftKey: true })
       expect(handler).toHaveBeenCalledOnce()
     })
+
+    it('shift_arrowdown triggers with Shift+ArrowDown', async () => {
+      const handler = vi.fn()
+      await registerShortcuts({ shift_arrowdown: handler })
+
+      fireKeydown('ArrowDown', { shiftKey: true })
+      expect(handler).toHaveBeenCalledOnce()
+    })
+
+    it('arrowdown does NOT trigger with Shift+ArrowDown', async () => {
+      const handler = vi.fn()
+      await registerShortcuts({ arrowdown: handler })
+
+      fireKeydown('ArrowDown', { shiftKey: true })
+      expect(handler).not.toHaveBeenCalled()
+    })
   })
 
   describe('chained shortcuts', () => {


### PR DESCRIPTION
### 🔗 Linked issue

n/a, found while auditing the composables

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `shiftableKeys` list had `arrowright` twice and no `arrowdown`, a typo. As a result an `arrowdown` shortcut also fired when pressing Shift+ArrowDown while every other arrow correctly distinguished the two, and `shift_arrowdown` couldn't be told apart from plain `arrowdown`. One word fix plus tests locking the behavior in.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.