### PR TITLE
fix(defineShortcuts): defer standalone shortcuts that prefix a chain

### DIFF
--- a/src/runtime/composables/defineShortcuts.ts
+++ b/src/runtime/composables/defineShortcuts.ts
@@ -2,7 +2,7 @@
 /* eslint-disable regexp/no-super-linear-backtracking */
 import { ref, computed, toValue } from 'vue'
 import type { MaybeRef } from 'vue'
-import { useEventListener, useActiveElement, useDebounceFn } from '@vueuse/core'
+import { useEventListener, useActiveElement, useDebounceFn, useTimeoutFn } from '@vueuse/core'
 import { useKbd } from './useKbd'
 
 type Handler = (e?: any) => void
@@ -94,11 +94,32 @@ export function extractShortcuts(items: any[] | any[][], separator: '_' | '-' = 
 }
 
 export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: ShortcutsOptions = {}) {
+  const chainDelay = options.chainDelay ?? 800
   const chainedInputs = ref<string[]>([])
   const clearChainedInput = () => {
     chainedInputs.value.splice(0, chainedInputs.value.length)
   }
-  const debouncedClearChainedInput = useDebounceFn(clearChainedInput, options.chainDelay ?? 800)
+  const debouncedClearChainedInput = useDebounceFn(clearChainedInput, chainDelay)
+
+  // A standalone shortcut that is also the first key of a chained shortcut (e.g. `f` and `f-h`)
+  // is held back until the chain either completes or the delay elapses, so pressing `f` doesn't
+  // fire the standalone and swallow the chain (#5654). Its `preventDefault` already ran on keydown.
+  let pendingShortcut: { shortcut: Shortcut, event: KeyboardEvent } | undefined
+  const cancelPendingShortcut = () => {
+    pendingShortcut = undefined
+    pendingTimer.stop()
+  }
+  const runPendingShortcut = () => {
+    const pending = pendingShortcut
+    cancelPendingShortcut()
+    if (pending?.shortcut.enabled) {
+      pending.shortcut.handler(pending.event)
+    }
+  }
+  const pendingTimer = useTimeoutFn(() => {
+    runPendingShortcut()
+    clearChainedInput()
+  }, chainDelay, { immediate: false })
 
   const { macOS } = useKbd()
   const activeElement = useActiveElement()
@@ -124,10 +145,13 @@ export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: Shor
     if (chainedInputs.value.length >= 2) {
       chainedKey = chainedInputs.value.slice(-2).join('-')
 
-      for (const shortcut of shortcuts.value.filter(s => s.chained)) {
+      for (const shortcut of chainedShortcuts.value) {
         if (shortcut.key !== chainedKey) {
           continue
         }
+
+        // The chain completed, so the held-back standalone from its first key must not fire.
+        cancelPendingShortcut()
 
         if (shortcut.enabled) {
           e.preventDefault()
@@ -138,8 +162,11 @@ export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: Shor
       }
     }
 
+    // This key didn't complete a chain, so honor any standalone held back by the previous key.
+    runPendingShortcut()
+
     // try matching a standard shortcut
-    for (const shortcut of shortcuts.value.filter(s => !s.chained)) {
+    for (const shortcut of standardShortcuts.value) {
       if (layoutIndependent) {
         // compare by code
         if (e.code !== shortcut.key) {
@@ -170,6 +197,18 @@ export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: Shor
       // Without meta/ctrl, shift changes the key itself (e.g. / -> ?) so the check is skipped.
       if ((alphabetKey || shiftableKey || shortcut.shiftKey || (e.shiftKey && (e.metaKey || e.ctrlKey))) && e.shiftKey !== shortcut.shiftKey) {
         continue
+      }
+
+      // If this key also starts a chained shortcut, hold it back until the chain can complete.
+      const isUnmodified = !shortcut.metaKey && !shortcut.ctrlKey && !shortcut.altKey && !shortcut.shiftKey
+      if (isUnmodified && chainPrefixes.value.has(shortcut.key)) {
+        if (shortcut.enabled) {
+          // Must run now: preventDefault is a no-op once the event finished dispatching.
+          e.preventDefault()
+        }
+        pendingShortcut = { shortcut, event: e }
+        pendingTimer.start()
+        return
       }
 
       if (shortcut.enabled) {
@@ -280,6 +319,12 @@ export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: Shor
       return shortcut
     }).filter(Boolean) as Shortcut[]
   })
+
+  // Cached so each keydown doesn't re-filter (and re-allocate) the shortcuts list.
+  const chainedShortcuts = computed(() => shortcuts.value.filter(s => s.chained))
+  const standardShortcuts = computed(() => shortcuts.value.filter(s => !s.chained))
+  // First key of every chained shortcut, used to hold back a matching standalone shortcut.
+  const chainPrefixes = computed(() => new Set(chainedShortcuts.value.map(s => s.key.split('-')[0])))
 
   return useEventListener('keydown', onKeyDown)
 }

--- a/src/runtime/composables/defineShortcuts.ts
+++ b/src/runtime/composables/defineShortcuts.ts
@@ -112,8 +112,15 @@ export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: Shor
   const runPendingShortcut = () => {
     const pending = pendingShortcut
     cancelPendingShortcut()
-    if (pending?.shortcut.enabled) {
-      pending.shortcut.handler(pending.event)
+    if (!pending) {
+      return
+    }
+
+    // Re-resolve instead of trusting the held snapshot: `enabled` may have changed in the
+    // meantime (e.g. focus moved into an input), and the pending shortcut is always unmodified.
+    const shortcut = standardShortcuts.value.find(s => s.key === pending.shortcut.key && !s.metaKey && !s.ctrlKey && !s.altKey && !s.shiftKey)
+    if (shortcut?.enabled) {
+      shortcut.handler(pending.event)
     }
   }
   const pendingTimer = useTimeoutFn(() => {
@@ -150,12 +157,15 @@ export function defineShortcuts(config: MaybeRef<ShortcutsConfig>, options: Shor
           continue
         }
 
-        // The chain completed, so the held-back standalone from its first key must not fire.
-        cancelPendingShortcut()
-
         if (shortcut.enabled) {
+          // The chain completed, so the held-back standalone from its first key must not fire.
+          cancelPendingShortcut()
+
           e.preventDefault()
           shortcut.handler(e)
+        } else {
+          // A disabled chain must not swallow the held-back standalone.
+          runPendingShortcut()
         }
         clearChainedInput()
         return

--- a/test/composables/defineShortcuts.spec.ts
+++ b/test/composables/defineShortcuts.spec.ts
@@ -19,6 +19,8 @@ describe('defineShortcuts', () => {
 
   afterEach(() => {
     wrapper?.unmount()
+    // Failure-safe teardown for tests that focus an input, so a thrown assertion can't leak focus.
+    document.body.innerHTML = ''
   })
 
   async function registerShortcuts(config: ShortcutsConfig, options?: ShortcutsOptions) {
@@ -383,6 +385,39 @@ describe('defineShortcuts', () => {
       expect(x).toHaveBeenCalledOnce()
       expect(f).toHaveBeenCalledBefore(x)
       expect(fh).not.toHaveBeenCalled()
+    })
+
+    it('fires the held standalone when the completing chain is disabled', async () => {
+      const f = vi.fn()
+      const fh = vi.fn()
+      // The standalone stays enabled inside inputs, the chain does not.
+      await registerShortcuts({ 'f': { handler: f, usingInput: true }, 'f-h': fh }, { chainDelay: 50 })
+
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+
+      fireKeydown('f')
+      fireKeydown('h')
+
+      expect(f).toHaveBeenCalledOnce()
+      expect(fh).not.toHaveBeenCalled()
+    })
+
+    it('does not fire a held standalone that got disabled before the delay elapsed', async () => {
+      const f = vi.fn()
+      await registerShortcuts({ f, 'f-h': vi.fn() }, { chainDelay: 50 })
+
+      fireKeydown('f')
+
+      // Moving focus into an input disables the shortcut while it's still held back.
+      const input = document.createElement('input')
+      document.body.appendChild(input)
+      input.focus()
+
+      await new Promise(resolve => setTimeout(resolve, 80))
+
+      expect(f).not.toHaveBeenCalled()
     })
   })
 

--- a/test/composables/defineShortcuts.spec.ts
+++ b/test/composables/defineShortcuts.spec.ts
@@ -406,7 +406,8 @@ describe('defineShortcuts', () => {
 
     it('does not fire a held standalone that got disabled before the delay elapsed', async () => {
       const f = vi.fn()
-      await registerShortcuts({ f, 'f-h': vi.fn() }, { chainDelay: 50 })
+      const fh = vi.fn()
+      await registerShortcuts({ f, 'f-h': fh }, { chainDelay: 50 })
 
       fireKeydown('f')
 

--- a/test/composables/defineShortcuts.spec.ts
+++ b/test/composables/defineShortcuts.spec.ts
@@ -340,6 +340,51 @@ describe('defineShortcuts', () => {
     })
   })
 
+  describe('chained shortcut sharing a prefix with a standalone (#5654)', () => {
+    it('fires the chain, not the standalone, when the sequence completes', async () => {
+      const f = vi.fn()
+      const fh = vi.fn()
+      const h = vi.fn()
+      await registerShortcuts({ f, 'f-h': fh, h })
+
+      fireKeydown('f')
+      fireKeydown('h')
+
+      expect(fh).toHaveBeenCalledOnce()
+      expect(f).not.toHaveBeenCalled()
+      expect(h).not.toHaveBeenCalled()
+    })
+
+    it('fires the standalone alone once the chain delay elapses', async () => {
+      const f = vi.fn()
+      const fh = vi.fn()
+      await registerShortcuts({ f, 'f-h': fh }, { chainDelay: 50 })
+
+      fireKeydown('f')
+      // Deferred: the standalone waits in case a chain follows.
+      expect(f).not.toHaveBeenCalled()
+
+      await new Promise(resolve => setTimeout(resolve, 80))
+
+      expect(f).toHaveBeenCalledOnce()
+      expect(fh).not.toHaveBeenCalled()
+    })
+
+    it('fires the pending standalone then the next key when the sequence does not complete', async () => {
+      const f = vi.fn()
+      const fh = vi.fn()
+      const x = vi.fn()
+      await registerShortcuts({ f, 'f-h': fh, x }, { chainDelay: 50 })
+
+      fireKeydown('f')
+      fireKeydown('x')
+
+      expect(f).toHaveBeenCalledOnce()
+      expect(x).toHaveBeenCalledOnce()
+      expect(fh).not.toHaveBeenCalled()
+    })
+  })
+
   describe('shortcut config object', () => {
     it('supports handler in config object', async () => {
       const handler = vi.fn()

--- a/test/composables/defineShortcuts.spec.ts
+++ b/test/composables/defineShortcuts.spec.ts
@@ -381,6 +381,7 @@ describe('defineShortcuts', () => {
 
       expect(f).toHaveBeenCalledOnce()
       expect(x).toHaveBeenCalledOnce()
+      expect(f).toHaveBeenCalledBefore(x)
       expect(fh).not.toHaveBeenCalled()
     })
   })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #5654

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With `{ f, 'f-h', h }` registered, pressing F fired the standalone immediately and cleared the chain buffer, so the `f-h` sequence could never complete. A standalone shortcut whose key is also the first key of a chained shortcut is now held back: if the chain completes it fires alone, otherwise the standalone fires once `chainDelay` elapses or immediately when the next key doesn't continue the chain. `preventDefault` still runs synchronously on keydown since it would be a no-op after the event finishes dispatching, and the pending timer is scoped through `useTimeoutFn` so it can't fire after unmount. Only unmodified standalones are deferred, chains can't contain modifiers so something like `ctrl_k` keeps firing instantly.

The tradeoff is inherent to the ambiguity: a single key shortcut that prefixes a chain now fires after the chain delay instead of instantly. The keydown handler also stops re-filtering the shortcuts list on every keypress, the chained and standard lists are now cached computeds.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.