### PR TITLE
fix(useResizable): recover from corrupted persisted storage

### DIFF
--- a/src/runtime/composables/useResizable.ts
+++ b/src/runtime/composables/useResizable.ts
@@ -127,7 +127,7 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
   }
 
   const isCollapsed = computed({
-    get: () => storageData.value?.collapsed ?? false,
+    get: () => storageData.value?.collapsed ?? defaultStorageValue.collapsed,
     set: (value: boolean) => {
       if (!opts.value.collapsible) {
         return

--- a/src/runtime/composables/useResizable.ts
+++ b/src/runtime/composables/useResizable.ts
@@ -116,8 +116,18 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
       : useStorage<StorageType>(key, defaultStorageValue, undefined, opts.value.storageOptions)
     : ref(defaultStorageValue)
 
+  // A persisted `null` (corrupted cookie/localStorage or cookie removed at runtime) bypasses
+  // the storage defaults and would crash every access, so guard reads and heal on write (#6517).
+  const writeStorage = (patch: Partial<StorageType>) => {
+    if (storageData.value) {
+      Object.assign(storageData.value, patch)
+    } else {
+      storageData.value = { ...defaultStorageValue, ...patch }
+    }
+  }
+
   const isCollapsed = computed({
-    get: () => storageData.value.collapsed,
+    get: () => storageData.value?.collapsed ?? false,
     set: (value: boolean) => {
       if (!opts.value.collapsible) {
         return
@@ -126,15 +136,17 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
       if (isRef(collapsed)) {
         collapsed.value = value
       }
-      storageData.value.collapsed = value
+      writeStorage({ collapsed: value })
     }
   })
 
   const previousSize = ref(opts.value.defaultSize)
 
   const size = computed({
-    get: () => storageData.value.size,
-    set: (value) => { storageData.value.size = value }
+    get: () => storageData.value?.size ?? opts.value.defaultSize,
+    set: (value) => {
+      writeStorage({ size: value })
+    }
   })
 
   const currentSize = computed(() => isCollapsed.value ? opts.value.collapsedSize : size.value)
@@ -328,7 +340,7 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
   }
 
   // Initial sync of storage value to external collapsed ref
-  if (isRef(collapsed) && storageData.value.collapsed) {
+  if (isRef(collapsed) && storageData.value?.collapsed) {
     collapsed.value = storageData.value.collapsed
   }
 
@@ -339,8 +351,8 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
         return
       }
 
-      if (storageData.value.collapsed !== value) {
-        storageData.value.collapsed = value
+      if (storageData.value?.collapsed !== value) {
+        isCollapsed.value = value
       }
     })
   }

--- a/test/composables/useResizable.spec.ts
+++ b/test/composables/useResizable.spec.ts
@@ -1,0 +1,184 @@
+import { describe, it, expect } from 'vitest'
+import { ref, nextTick } from 'vue'
+import { useResizable } from '../../src/runtime/composables/useResizable'
+
+// A fake pointer event carrying just what the handlers read.
+function mouseEvent(clientX = 0): MouseEvent {
+  return { clientX, preventDefault() {}, stopPropagation() {} } as unknown as MouseEvent
+}
+
+function touchEvent(clientX = 0): TouchEvent {
+  return { touches: [{ clientX }], preventDefault() {}, stopPropagation() {} } as unknown as TouchEvent
+}
+
+// An element with a known width whose parent has a known width, so the
+// percentage math in the drag handlers is deterministic.
+function mockEl(width = 100, parentWidth = 200): HTMLElement {
+  const parent = document.createElement('div')
+  Object.defineProperty(parent, 'offsetWidth', { value: parentWidth, configurable: true })
+  const el = document.createElement('div')
+  parent.appendChild(el)
+  el.getBoundingClientRect = () => ({ width, height: 0, top: 0, left: 0, right: 0, bottom: 0, x: 0, y: 0, toJSON: () => ({}) })
+  return el
+}
+
+describe('useResizable', () => {
+  describe('defaults', () => {
+    it('exposes sensible defaults', () => {
+      const r = useResizable('def', { persistent: false })
+
+      expect(r.size.value).toBe(0)
+      expect(r.isDragging.value).toBe(false)
+      expect(r.isCollapsed.value).toBe(false)
+    })
+
+    it('uses the provided default size', () => {
+      const r = useResizable('ds', { persistent: false, defaultSize: 42 })
+
+      expect(r.size.value).toBe(42)
+    })
+  })
+
+  describe('collapse', () => {
+    it('toggles collapse and reports the collapsed size while collapsed', () => {
+      const r = useResizable('col', { persistent: false, collapsible: true, defaultSize: 60, collapsedSize: 5 })
+
+      expect(r.isCollapsed.value).toBe(false)
+      expect(r.size.value).toBe(60)
+
+      r.collapse()
+      expect(r.isCollapsed.value).toBe(true)
+      expect(r.size.value).toBe(5)
+
+      // Expanding restores the previous size.
+      r.collapse()
+      expect(r.isCollapsed.value).toBe(false)
+      expect(r.size.value).toBe(60)
+    })
+
+    it('accepts an explicit collapsed value', () => {
+      const r = useResizable('col-explicit', { persistent: false, collapsible: true, defaultSize: 30, collapsedSize: 0 })
+
+      r.collapse(true)
+      expect(r.isCollapsed.value).toBe(true)
+
+      r.collapse(true)
+      expect(r.isCollapsed.value).toBe(true)
+    })
+
+    it('does nothing when collapsible is false', () => {
+      const r = useResizable('no-col', { persistent: false, collapsible: false, defaultSize: 30 })
+
+      r.collapse(true)
+
+      expect(r.isCollapsed.value).toBe(false)
+      expect(r.size.value).toBe(30)
+    })
+
+    it('syncs with an external collapsed ref both ways', async () => {
+      const collapsed = ref(false)
+      const r = useResizable('ext', { persistent: false, collapsible: true, defaultSize: 50, collapsedSize: 0 }, { collapsed })
+
+      // Internal -> external
+      r.collapse(true)
+      await nextTick()
+      expect(collapsed.value).toBe(true)
+      expect(r.isCollapsed.value).toBe(true)
+
+      // External -> internal
+      collapsed.value = false
+      await nextTick()
+      expect(r.isCollapsed.value).toBe(false)
+    })
+  })
+
+  describe('onDoubleClick', () => {
+    it('expands a collapsed panel and resets to the default size', () => {
+      const r = useResizable('dbl', { persistent: false, collapsible: true, defaultSize: 40, collapsedSize: 0 })
+      r.el.value = mockEl()
+
+      r.collapse(true)
+      expect(r.size.value).toBe(0)
+
+      r.onDoubleClick(mouseEvent())
+
+      expect(r.isCollapsed.value).toBe(false)
+      expect(r.size.value).toBe(40)
+    })
+  })
+
+  describe('mouse drag', () => {
+    it('starts dragging, resizes as a percentage, then stops on mouseup', () => {
+      const r = useResizable('drag', { persistent: false, unit: '%', side: 'left', minSize: 0, maxSize: 100 })
+      r.el.value = mockEl(100, 200)
+
+      r.onMouseDown(mouseEvent(0))
+      expect(r.isDragging.value).toBe(true)
+
+      // width 100 + 50px delta = 150px over a 200px parent = 75%.
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 50 }))
+      expect(r.size.value).toBe(75)
+
+      document.dispatchEvent(new MouseEvent('mouseup'))
+      expect(r.isDragging.value).toBe(false)
+    })
+
+    it('clamps the size to maxSize', () => {
+      const r = useResizable('clamp', { persistent: false, unit: '%', side: 'left', minSize: 10, maxSize: 60 })
+      r.el.value = mockEl(100, 200)
+
+      r.onMouseDown(mouseEvent(0))
+      // 100 + 300 = 400px over 200px = 200%, clamped to 60.
+      document.dispatchEvent(new MouseEvent('mousemove', { clientX: 300 }))
+      expect(r.size.value).toBe(60)
+
+      document.dispatchEvent(new MouseEvent('mouseup'))
+    })
+
+    it('ignores drag when not resizable', () => {
+      const r = useResizable('not-resizable', { persistent: false, resizable: false })
+      r.el.value = mockEl(100, 200)
+
+      r.onMouseDown(mouseEvent(0))
+
+      expect(r.isDragging.value).toBe(false)
+    })
+  })
+
+  describe('corrupted storage (#6517)', () => {
+    it('recovers with defaults when localStorage holds a literal null', () => {
+      // A literal `"null"` JSON-parses to `null`, bypassing the storage initial value.
+      localStorage.setItem('corrupted-local', 'null')
+
+      const r = useResizable('corrupted-local', { storage: 'local', collapsible: true, defaultSize: 25 })
+
+      expect(r.isCollapsed.value).toBe(false)
+      expect(r.size.value).toBe(25)
+
+      r.collapse(true)
+      expect(r.isCollapsed.value).toBe(true)
+    })
+
+    it('recovers with defaults when the persisted cookie parses to null', () => {
+      document.cookie = 'corrupted-cookie=null; path=/'
+
+      const r = useResizable('corrupted-cookie', { collapsible: true, defaultSize: 25 })
+
+      expect(r.isCollapsed.value).toBe(false)
+      expect(r.size.value).toBe(25)
+    })
+  })
+
+  describe('touch drag', () => {
+    it('starts dragging on touchstart and stops on touchend', () => {
+      const r = useResizable('touch', { persistent: false })
+      r.el.value = mockEl(100, 200)
+
+      r.onTouchStart(touchEvent(0))
+      expect(r.isDragging.value).toBe(true)
+
+      document.dispatchEvent(new Event('touchend'))
+      expect(r.isDragging.value).toBe(false)
+    })
+  })
+})

--- a/test/composables/useResizable.spec.ts
+++ b/test/composables/useResizable.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, afterEach } from 'vitest'
 import { ref, nextTick } from 'vue'
 import { useResizable } from '../../src/runtime/composables/useResizable'
 
@@ -23,6 +23,17 @@ function mockEl(width = 100, parentWidth = 200): HTMLElement {
 }
 
 describe('useResizable', () => {
+  afterEach(() => {
+    // The corrupted-storage tests write real localStorage/cookies; keep them out of other suites.
+    localStorage.clear()
+    for (const cookie of document.cookie.split(';')) {
+      const name = cookie.split('=')[0]!.trim()
+      if (name) {
+        document.cookie = `${name}=; expires=Thu, 01 Jan 1970 00:00:00 GMT; path=/`
+      }
+    }
+  })
+
   describe('defaults', () => {
     it('exposes sensible defaults', () => {
       const r = useResizable('def', { persistent: false })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6517

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When the persisted value parses to a literal `null` the whole page crashed with `Cannot read properties of null (reading 'collapsed')` on every render. This happens with `storage: 'local'` when localStorage holds the string `"null"` (it JSON parses to `null`, bypassing the initial value), and with cookies at runtime since `useCookie`'s sync path assigns `null` without falling back to the default when the cookie is deleted in devtools, written from another tab or refreshed after corruption. On older Nuxt versions the reload path crashed too, as reported in the issue.

The `isCollapsed` and `size` getters now fall back to the defaults when storage is `null`, writes go through a single `writeStorage` helper that heals the storage, and the init sync and external `collapsed` watch are guarded. Comes with a `useResizable` test suite, including corruption regressions for both storages that reproduce the exact crash without the fix.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.