### PR TITLE
fix(useResizable): share resize logic between mouse and touch

### DIFF
--- a/src/runtime/composables/useResizable.ts
+++ b/src/runtime/composables/useResizable.ts
@@ -141,7 +141,10 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
 
   const isDragging = ref(false)
 
-  const onMouseMove = (e: MouseEvent, initialPos: number, initialSize: number): void => {
+  // Read once per drag: `getComputedStyle` on every pointer move forces a style recalc.
+  const getRootFontSize = () => opts.value.unit === 'rem' ? Number.parseFloat(getComputedStyle(document.documentElement).fontSize) : 1
+
+  const resize = (clientX: number, initialPos: number, initialSize: number, rootFontSize: number): void => {
     if (!el.value || !opts.value.resizable) {
       return
     }
@@ -152,11 +155,9 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
     // In RTL mode, we need to invert the delta calculation
     let delta: number
     if (isRtl) {
-      // In RTL mode, invert the logic
-      delta = opts.value.side === 'left' ? initialPos - e.clientX : e.clientX - initialPos
+      delta = opts.value.side === 'left' ? initialPos - clientX : clientX - initialPos
     } else {
-      // Original LTR logic
-      delta = opts.value.side === 'left' ? e.clientX - initialPos : initialPos - e.clientX
+      delta = opts.value.side === 'left' ? clientX - initialPos : initialPos - clientX
     }
 
     const newSize = initialSize + delta
@@ -165,7 +166,6 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
     let newValue: number
     if (opts.value.unit === 'rem') {
       // Convert pixels to rem
-      const rootFontSize = Number.parseFloat(getComputedStyle(document.documentElement).fontSize)
       newValue = newSize / rootFontSize
     } else if (opts.value.unit === 'px') {
       // Use pixel value directly
@@ -201,11 +201,12 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
 
     const initialX = e.clientX
     const initialWidth = elWidth
+    const rootFontSize = getRootFontSize()
 
     isDragging.value = true
 
     const handleMouseMove = (e: MouseEvent) => {
-      onMouseMove(e, initialX, initialWidth)
+      resize(e.clientX, initialX, initialWidth, rootFontSize)
     }
 
     const handleMouseUp = () => {
@@ -216,51 +217,6 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
 
     document.addEventListener('mousemove', handleMouseMove)
     document.addEventListener('mouseup', handleMouseUp)
-  }
-
-  const onTouchMove = (e: TouchEvent, initialPos: number, initialSize: number): void => {
-    if (!el.value || !opts.value.resizable || !e.touches[0]) {
-      return
-    }
-
-    const parentSize = el.value.parentElement?.offsetWidth || 1
-    const isRtl = dir.value === 'rtl'
-
-    // In RTL mode, we need to invert the delta calculation
-    let delta: number
-    if (isRtl) {
-      // In RTL mode, invert the logic
-      delta = opts.value.side === 'left' ? initialPos - e.touches[0].clientX : e.touches[0].clientX - initialPos
-    } else {
-      // Original LTR logic
-      delta = opts.value.side === 'left' ? e.touches[0].clientX - initialPos : initialPos - e.touches[0].clientX
-    }
-
-    const newSize = initialSize + delta
-
-    // Calculate size based on the selected unit
-    let newValue: number
-    if (opts.value.unit === 'rem') {
-      // Convert pixels to rem
-      const rootFontSize = Number.parseFloat(getComputedStyle(document.documentElement).fontSize)
-      newValue = newSize / rootFontSize
-    } else if (opts.value.unit === 'px') {
-      // Use pixel value directly
-      newValue = newSize
-    } else {
-      // Default percentage calculation
-      newValue = (newSize / parentSize) * 100
-    }
-
-    // Auto collapse when dragging near collapsedSize
-    if (opts.value.collapsible && newValue < (opts.value.collapsedSize + 4)) {
-      collapse(true)
-      return
-    } else if (isCollapsed.value) {
-      collapse(false)
-    }
-
-    size.value = Math.min(opts.value.maxSize, Math.max(opts.value.minSize, newValue))
   }
 
   const onTouchStart = (e: TouchEvent) => {
@@ -278,11 +234,14 @@ export function useResizable(key: string, options: Ref<UseResizableProps> | UseR
 
     const initialX = e.touches[0].clientX
     const initialWidth = elWidth
+    const rootFontSize = getRootFontSize()
 
     isDragging.value = true
 
     const handleTouchMove = (e: TouchEvent) => {
-      onTouchMove(e, initialX, initialWidth)
+      if (e.touches[0]) {
+        resize(e.touches[0].clientX, initialX, initialWidth, rootFontSize)
+      }
     }
 
     const handleTouchEnd = () => {


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`onMouseMove` and `onTouchMove` were two ~45 line copies of the same delta, unit and auto collapse logic that only differed in where `clientX` comes from, so a fix landing in one path could silently miss the other. They're now a single `resize(clientX, ...)` handler. While in there, the root font size for the `rem` unit is read once per drag instead of calling `getComputedStyle` on every pointer move, which forced a style recalc per frame while dragging (the dashboard uses `unit="rem"`). No behavior change, mouse and touch dragging, auto collapse and RTL all work as before.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.