### PR TITLE
feat(ChatPrompt): add body slot and focus highlight

### DIFF
--- a/docs/app/components/chat/Chat.vue
+++ b/docs/app/components/chat/Chat.vue
@@ -353,7 +353,6 @@ defineShortcuts({
         variant="naked"
         size="sm"
         autofocus
-        :ui="{ base: 'px-0' }"
         class="px-4"
         @submit="onSubmit"
       >

--- a/docs/app/components/content/examples/chat/ChatPromptEditorExample.vue
+++ b/docs/app/components/content/examples/chat/ChatPromptEditorExample.vue
@@ -1,0 +1,146 @@
+<script setup lang="ts">
+import { Extension } from '@tiptap/core'
+import type { StarterKitOptions } from '@tiptap/starter-kit'
+import type { EditorMentionMenuItem, SelectItem } from '@nuxt/ui'
+
+const input = ref('')
+const mode = ref('auto')
+const attachments = ref<{ name: string, src?: string }[]>([])
+const fileInputRef = useTemplateRef('fileInputRef')
+
+const files: EditorMentionMenuItem[] = [
+  { label: 'app.vue', icon: 'i-vscode-icons-file-type-vue' },
+  { label: 'nuxt.config.ts', icon: 'i-vscode-icons-file-type-nuxt' },
+  { label: 'package.json', icon: 'i-vscode-icons-file-type-json' },
+  { label: 'README.md', icon: 'i-vscode-icons-file-type-markdown' },
+  { label: 'AuthForm.vue', icon: 'i-vscode-icons-file-type-vue' },
+  { label: 'useChat.ts', icon: 'i-vscode-icons-file-type-typescript' }
+]
+
+const commands: EditorMentionMenuItem[] = [
+  { label: 'init', icon: 'i-lucide-sparkles' },
+  { label: 'review', icon: 'i-lucide-search-code' },
+  { label: 'security-review', icon: 'i-lucide-shield-check' },
+  { label: 'clear', icon: 'i-lucide-eraser' },
+  { label: 'compact', icon: 'i-lucide-fold-vertical' },
+  { label: 'config', icon: 'i-lucide-settings' }
+]
+
+const modes = [
+  { label: 'Manual', value: 'manual', icon: 'i-lucide-hand' },
+  { label: 'Edit automatically', value: 'edit', icon: 'i-lucide-code-xml' },
+  { label: 'Plan mode', value: 'plan', icon: 'i-lucide-list-checks' },
+  { label: 'Auto mode', value: 'auto', icon: 'i-lucide-zap' }
+] satisfies SelectItem[]
+
+// Disable rich-text formatting so the prompt stays plain text (no bold, headings, lists, code, etc.)
+const starterKit: Partial<StarterKitOptions> = {
+  bold: false,
+  italic: false,
+  strike: false,
+  code: false,
+  underline: false,
+  heading: false,
+  blockquote: false,
+  bulletList: false,
+  orderedList: false,
+  listItem: false,
+  codeBlock: false
+}
+
+// SSR-safe target so the menus aren't clipped by overflow
+const appendToBody = import.meta.client ? () => document.body : undefined
+
+function onFilesChange(event: Event) {
+  const target = event.target as HTMLInputElement
+  for (const file of Array.from(target.files ?? [])) {
+    attachments.value.push({
+      name: file.name,
+      src: file.type.startsWith('image/') ? URL.createObjectURL(file) : undefined
+    })
+  }
+  target.value = ''
+}
+
+function onSubmit() {
+  input.value = ''
+  attachments.value = []
+}
+</script>
+
+<template>
+  <UChatPrompt
+    v-model="input"
+    class="w-full p-0 gap-0"
+    placeholder="Press / to open the command menu"
+    :ui="{
+      header: 'px-2.5 py-2 border-b border-default',
+      footer: 'px-2.5 py-2 border-t border-default'
+    }"
+    @submit="onSubmit"
+  >
+    <template v-if="attachments.length" #header>
+      <UButton
+        v-for="(file, index) in attachments"
+        :key="index"
+        :label="file.name"
+        :avatar="file.src ? { src: file.src } : undefined"
+        :icon="file.src ? undefined : 'i-lucide-file'"
+        color="neutral"
+        variant="soft"
+        size="xs"
+        square
+        trailing-icon="i-lucide-x"
+        @click="attachments.splice(index, 1)"
+      />
+    </template>
+
+    <template #body="{ submit, placeholder }">
+      <UEditor
+        v-slot="{ editor }"
+        v-model="input"
+        content-type="markdown"
+        :starter-kit="starterKit"
+        :placeholder="placeholder"
+        class="w-full min-h-12"
+        :ui="{ base: 'p-2.5! [&_.mention]:bg-primary/5 [&_.mention]:rounded-sm [&_.mention]:px-0.5 [&_.mention]:py-0.25' }"
+        :extensions="[Extension.create({
+          name: 'chatPromptSubmit',
+          priority: 1000,
+          addKeyboardShortcuts: () => ({ Enter: () => (submit(), true) })
+        })]"
+      >
+        <UEditorMentionMenu :editor="editor" char="@" plugin-key="mention" :items="files" :append-to="appendToBody" />
+        <UEditorMentionMenu :editor="editor" char="/" plugin-key="command" :items="commands" :append-to="appendToBody" />
+      </UEditor>
+    </template>
+
+    <template #footer>
+      <div class="flex items-center gap-0.5">
+        <UButton
+          icon="i-lucide-plus"
+          color="neutral"
+          variant="ghost"
+          aria-label="Attach files"
+          size="sm"
+          @click="fileInputRef?.click()"
+        />
+        <input ref="fileInputRef" type="file" multiple class="hidden" @change="onFilesChange">
+      </div>
+
+      <div class="flex items-center gap-1">
+        <USelect
+          v-model="mode"
+          :items="modes"
+          :icon="modes.find(item => item.value === mode)?.icon"
+          color="neutral"
+          variant="ghost"
+          size="sm"
+          square
+        />
+
+        <UChatPromptSubmit size="sm" />
+      </div>
+    </template>
+  </UChatPrompt>
+</template>

--- a/docs/app/components/content/examples/chat/ChatPromptEditorExample.vue
+++ b/docs/app/components/content/examples/chat/ChatPromptEditorExample.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { Extension } from '@tiptap/core'
-import type { StarterKitOptions } from '@tiptap/starter-kit'
 import type { EditorMentionMenuItem, SelectItem } from '@nuxt/ui'
 
 const input = ref('')
@@ -33,21 +32,6 @@ const modes = [
   { label: 'Auto mode', value: 'auto', icon: 'i-lucide-zap' }
 ] satisfies SelectItem[]
 
-// Disable rich-text formatting so the prompt stays plain text (no bold, headings, lists, code, etc.)
-const starterKit: Partial<StarterKitOptions> = {
-  bold: false,
-  italic: false,
-  strike: false,
-  code: false,
-  underline: false,
-  heading: false,
-  blockquote: false,
-  bulletList: false,
-  orderedList: false,
-  listItem: false,
-  codeBlock: false
-}
-
 // SSR-safe target so the menus aren't clipped by overflow
 const appendToBody = import.meta.client ? () => document.body : undefined
 
@@ -63,6 +47,8 @@ function onFilesChange(event: Event) {
 }
 
 function onSubmit() {
+  console.log('submit', input.value)
+
   input.value = ''
   attachments.value = []
 }
@@ -100,7 +86,7 @@ function onSubmit() {
         v-slot="{ editor }"
         v-model="input"
         content-type="markdown"
-        :starter-kit="starterKit"
+        :starter-kit="false"
         :placeholder="placeholder"
         class="w-full min-h-12"
         :ui="{ base: 'p-2.5! [&_.mention]:bg-primary/5 [&_.mention]:rounded-sm [&_.mention]:px-0.5 [&_.mention]:py-0.25' }"
@@ -139,7 +125,7 @@ function onSubmit() {
           square
         />
 
-        <UChatPromptSubmit size="sm" />
+        <UChatPromptSubmit size="sm" :disabled="!input.trim()" />
       </div>
     </template>
   </UChatPrompt>

--- a/docs/app/components/content/examples/chat/ChatPromptExample.vue
+++ b/docs/app/components/content/examples/chat/ChatPromptExample.vue
@@ -1,0 +1,38 @@
+<script setup lang="ts">
+import type { SelectItem } from '@nuxt/ui'
+
+const input = ref('')
+const model = ref('claude-opus-4.6')
+
+const models = [
+  { label: 'Claude Opus 4.6', value: 'claude-opus-4.6', icon: 'i-simple-icons-anthropic' },
+  { label: 'Gemini 3 Pro', value: 'gemini-3-pro', icon: 'i-simple-icons-googlegemini' },
+  { label: 'GPT-5', value: 'gpt-5', icon: 'i-simple-icons-openai' }
+] satisfies SelectItem[]
+
+function onSubmit() {
+  input.value = ''
+}
+</script>
+
+<template>
+  <UChatPrompt v-model="input" class="w-full" @submit="onSubmit">
+    <template #footer>
+      <UButton icon="i-lucide-plus" color="neutral" variant="ghost" size="sm" />
+
+      <div class="flex items-center gap-1.5">
+        <USelect
+          v-model="model"
+          :items="models"
+          :icon="models.find(item => item.value === model)?.icon"
+          placeholder="Select a model"
+          variant="ghost"
+          size="sm"
+          square
+        />
+
+        <UChatPromptSubmit size="sm" />
+      </div>
+    </template>
+  </UChatPrompt>
+</template>

--- a/docs/app/components/content/examples/sidebar/SidebarChatExample.vue
+++ b/docs/app/components/content/examples/sidebar/SidebarChatExample.vue
@@ -108,7 +108,6 @@ const ui = {
           :autofocus="false"
           variant="subtle"
           size="sm"
-          :ui="{ base: 'px-0' }"
           @submit="onSubmit"
         >
           <UChatPromptSubmit

--- a/docs/content/docs/2.components/chat-prompt.md
+++ b/docs/content/docs/2.components/chat-prompt.md
@@ -15,43 +15,11 @@ links:
 
 The ChatPrompt component renders a `<form>` element and extends the [Textarea](/docs/components/textarea) component so you can pass any property such as `icon`, `placeholder`, `autofocus`, etc.
 
-::code-preview
-
-:::u-chat-prompt
+::component-example
 ---
-variant: 'subtle'
+collapse: true
+name: 'chat-prompt-example'
 ---
-
-#default
-::::u-chat-prompt-submit
----
-color: 'neutral'
-class: 'rounded-full'
----
-::::
-
-#footer
-::::u-select
----
-placeholder: 'Select a model'
-variant: 'ghost'
-icon: 'i-simple-icons-anthropic'
-modelValue: 'claude-opus-4.6'
-items:
-  - label: 'Claude Opus 4.6'
-    value: 'claude-opus-4.6'
-    icon: 'i-simple-icons-anthropic'
-  - label: 'Gemini 3 Pro'
-    value: 'gemini-3-pro'
-    icon: 'i-simple-icons-googlegemini'
-  - label: 'GPT-5'
-    value: 'gpt-5'
-    icon: 'i-simple-icons-openai'
----
-::::
-
-:::
-
 ::
 
 ::note
@@ -81,9 +49,24 @@ props:
 Check the **Chat** overview page for installation instructions, server setup and usage examples.
 ::
 
-### As a starting point
+### With an Editor :badge{label="Soon" class="align-text-top"}
 
-You can also use it as a starting point for a chat interface.
+Compose the `#header`, `#body` and `#footer` slots to build a rich prompt: file attachments, an [Editor](/docs/components/editor) with `@` mentions and `/` commands through [EditorMentionMenu](/docs/components/editor-mention-menu), and a mode selector.
+
+::component-example
+---
+name: 'chat-prompt-editor-example'
+class: 'justify-center'
+---
+::
+
+::note
+The `#body` slot replaces the internal textarea and exposes `submit` and `close` handlers, so you can wire the editor's keyboard shortcuts to the form. When a mention menu is open, pressing :kbd{value="enter"} selects the highlighted item instead of submitting.
+::
+
+### As home page
+
+You can also use it in your chat interface home page.
 
 ```vue [pages/index.vue] {2,4,8-15,24,26}
 <script setup lang="ts">

--- a/docs/content/docs/2.components/chat-prompt.md
+++ b/docs/content/docs/2.components/chat-prompt.md
@@ -55,6 +55,7 @@ Compose the `#header`, `#body` and `#footer` slots to build a rich prompt: file 
 
 ::component-example
 ---
+collapse: true
 name: 'chat-prompt-editor-example'
 class: 'justify-center'
 ---

--- a/playgrounds/nuxt/app/composables/useNavigation.ts
+++ b/playgrounds/nuxt/app/composables/useNavigation.ts
@@ -14,6 +14,7 @@ const components = [
   'card',
   'carousel',
   'chat-message',
+  'chat-prompt',
   'chat-reasoning',
   'chat-shimmer',
   'chat-tool',

--- a/playgrounds/nuxt/app/pages/components/chat-prompt.vue
+++ b/playgrounds/nuxt/app/pages/components/chat-prompt.vue
@@ -1,0 +1,36 @@
+<script setup lang="ts">
+import theme from '#build/ui/chat-prompt'
+
+const variants = Object.keys(theme.variants.variant)
+const colors = Object.keys(theme.variants.color)
+
+const attrs = reactive({
+  color: [theme.defaultVariants.color],
+  variant: [theme.defaultVariants.variant]
+})
+
+const input = ref('')
+
+function onSubmit() {
+  console.log('submit', input.value)
+  input.value = ''
+}
+</script>
+
+<template>
+  <Navbar>
+    <USelect v-model="attrs.color" :items="colors" multiple />
+    <USelect v-model="attrs.variant" :items="variants" multiple />
+  </Navbar>
+
+  <Matrix v-slot="props" :attrs="attrs" class="flex-col" container-class="w-80">
+    <UChatPrompt
+      v-model="input"
+      placeholder="Type your message here..."
+      v-bind="props"
+      @submit="onSubmit"
+    >
+      <UChatPromptSubmit :color="props?.color" />
+    </UChatPrompt>
+  </Matrix>
+</template>

--- a/playgrounds/nuxt/app/pages/components/sidebar.vue
+++ b/playgrounds/nuxt/app/pages/components/sidebar.vue
@@ -108,7 +108,6 @@ function onSubmit() {
           :error="error"
           variant="subtle"
           size="sm"
-          :ui="{ base: 'px-0' }"
           @submit="onSubmit"
         >
           <UChatPromptSubmit size="sm" :status="status" @stop="stop()" @reload="regenerate()" />

--- a/src/runtime/components/ChatPrompt.vue
+++ b/src/runtime/components/ChatPrompt.vue
@@ -19,6 +19,10 @@ export interface ChatPromptProps extends Pick<TextareaProps, 'rows' | 'autofocus
    */
   placeholder?: string
   /**
+   * @defaultValue 'primary'
+   */
+  color?: ChatPrompt['variants']['color']
+  /**
    * @defaultValue 'outline'
    */
   variant?: ChatPrompt['variants']['variant']
@@ -41,6 +45,10 @@ export interface ChatPromptEmits {
 export interface ChatPromptSlots extends TextareaSlots {
   header?(props?: {}): VNode[]
   footer?(props?: {}): VNode[]
+  /**
+   * Replace the internal textarea, e.g. to render an [Editor](/docs/components/editor) with mentions.
+   */
+  body?(props: { submit: (event?: Event) => void, close: (event?: Event) => void, placeholder: string, disabled: boolean, ui: any }): VNode[]
 }
 </script>
 
@@ -78,27 +86,28 @@ const appConfig = useAppConfig() as ChatPrompt['AppConfig']
 
 const textareaProps = useForwardProps(reactivePick(props, 'rows', 'autofocus', 'autofocusDelay', 'autoresize', 'autoresizeDelay', 'maxrows', 'icon', 'avatar', 'loading', 'loadingIcon'))
 
-const getProxySlots = () => omit(slots, ['header', 'footer'])
+const getProxySlots = () => omit(slots, ['header', 'footer', 'body'])
 
 // eslint-disable-next-line vue/no-dupe-keys
 const ui = computed(() => tv({ extend: theme, ...(appConfig.ui?.chatPrompt || {}) })({
+  color: props.color,
   variant: props.variant
 }))
 
 const textareaRef = useTemplateRef('textareaRef')
 
-function submit(e: Event) {
+function submit(e?: Event) {
   if (model.value.trim() === '') {
     return
   }
 
-  emits('submit', e)
+  emits('submit', e ?? new Event('submit'))
 }
 
-function blur(e: Event) {
+function blur(e?: Event) {
   textareaRef.value?.textareaRef?.blur()
 
-  emits('close', e)
+  emits('close', e ?? new Event('close'))
 }
 
 const { onKeydown: onEnter, onCompositionEnd } = useIMEGuard((event) => {
@@ -134,24 +143,33 @@ defineExpose({
       <slot name="header" />
     </div>
 
-    <UTextarea
-      ref="textareaRef"
-      v-model="model"
+    <slot
+      name="body"
+      :submit="submit"
+      :close="blur"
       :placeholder="props.placeholder ?? t('chatPrompt.placeholder')"
       :disabled="Boolean(props.error) || props.disabled"
-      variant="none"
-      fixed
-      v-bind="{ ...textareaProps, ...$attrs }"
-      :ui="transformUI(omit(ui, ['root', 'body', 'header', 'footer']), props.ui)"
-      data-slot="body"
-      :class="ui.body({ class: props.ui?.body })"
-      @keydown="onKeydown"
-      @compositionend="onCompositionEnd"
+      :ui="ui"
     >
-      <template v-for="(_, name) in getProxySlots()" #[name]="slotData">
-        <slot :name="name" v-bind="slotData" />
-      </template>
-    </UTextarea>
+      <UTextarea
+        ref="textareaRef"
+        v-model="model"
+        :placeholder="props.placeholder ?? t('chatPrompt.placeholder')"
+        :disabled="Boolean(props.error) || props.disabled"
+        variant="none"
+        fixed
+        v-bind="{ ...textareaProps, ...$attrs }"
+        :ui="transformUI(omit(ui, ['root', 'body', 'header', 'footer']), props.ui)"
+        data-slot="body"
+        :class="ui.body({ class: props.ui?.body })"
+        @keydown="onKeydown"
+        @compositionend="onCompositionEnd"
+      >
+        <template v-for="(_, name) in getProxySlots()" #[name]="slotData">
+          <slot :name="name" v-bind="slotData" />
+        </template>
+      </UTextarea>
+    </slot>
 
     <div v-if="!!slots.footer" data-slot="footer" :class="ui.footer({ class: props.ui?.footer })">
       <slot name="footer" />

--- a/src/theme/chat-prompt.ts
+++ b/src/theme/chat-prompt.ts
@@ -1,12 +1,23 @@
-export default {
+import type { ModuleOptions } from '../module'
+
+// Highlight the prompt like a focused input when the text surface (native textarea or editor's contenteditable) is focused, without reacting to header/footer controls.
+const focusHighlight = (utilities: string) => ['textarea', '[contenteditable]']
+  .flatMap(element => utilities.split(' ').map(utility => `has-[${element}:focus-visible]:${utility}`))
+  .join(' ')
+
+export default (options: Required<ModuleOptions>) => ({
   slots: {
     root: 'relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur',
     header: 'flex items-center gap-1.5',
-    body: 'items-start',
+    body: 'items-start gap-1.5',
     footer: 'flex items-center justify-between gap-1.5',
-    base: ''
+    base: 'px-0'
   },
   variants: {
+    color: {
+      ...Object.fromEntries((options.theme.colors || []).map((color: string) => [color, ''])),
+      neutral: ''
+    },
     variant: {
       outline: {
         root: 'bg-default/75 ring ring-default'
@@ -22,7 +33,25 @@ export default {
       }
     }
   },
+  compoundVariants: [...(options.theme.colors || []).map((color: string) => ({
+    color,
+    variant: ['outline', 'subtle'],
+    class: { root: `outline-${color}/25 ${focusHighlight(`outline-3 ring-${color}`)}` }
+  })), ...(options.theme.colors || []).map((color: string) => ({
+    color,
+    variant: 'soft',
+    class: { root: `outline-${color}/25 ${focusHighlight('outline-3')}` }
+  })), {
+    color: 'neutral',
+    variant: ['outline', 'subtle'],
+    class: { root: `outline-inverted/25 ${focusHighlight('outline-3 ring-inverted')}` }
+  }, {
+    color: 'neutral',
+    variant: 'soft',
+    class: { root: `outline-inverted/25 ${focusHighlight('outline-3')}` }
+  }],
   defaultVariants: {
+    color: 'primary',
     variant: 'outline'
   }
-}
+})

--- a/test/components/ChatPrompt.spec.ts
+++ b/test/components/ChatPrompt.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi } from 'vitest'
+import { h } from 'vue'
 import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { renderEach } from '../component-render'
@@ -18,7 +19,8 @@ describe('ChatPrompt', () => {
     ['with ui', { props: { ui: { footer: 'justify-end' } } }],
     // Slots
     ['with header slot', { slots: { header: () => 'Header slot' } }],
-    ['with footer slot', { slots: { footer: () => 'Footer slot' } }]
+    ['with footer slot', { slots: { footer: () => 'Footer slot' } }],
+    ['with body slot', { slots: { body: () => 'Body slot' } }]
   ])
 
   it('emits submit on Enter', async () => {
@@ -102,6 +104,52 @@ describe('ChatPrompt', () => {
     await textarea.trigger('keydown', { key: 'Enter', metaKey: true })
 
     expect(wrapper.emitted('submit')).toHaveLength(1)
+  })
+
+  it('replaces the textarea with the body slot', async () => {
+    const wrapper = await mountSuspended(ChatPrompt, {
+      slots: { body: () => h('div', { 'data-test': 'editor' }, 'Custom body') }
+    })
+
+    expect(wrapper.find('textarea').exists()).toBe(false)
+    expect(wrapper.find('[data-test="editor"]').text()).toBe('Custom body')
+  })
+
+  it('exposes submit and close to the body slot', async () => {
+    const slotProps: { submit?: () => void, close?: () => void } = {}
+    const wrapper = await mountSuspended(ChatPrompt, {
+      props: { modelValue: 'Hello' },
+      slots: {
+        body: (props: any) => {
+          slotProps.submit = props.submit
+          slotProps.close = props.close
+          return h('div', 'body')
+        }
+      }
+    })
+
+    slotProps.submit?.()
+    expect(wrapper.emitted('submit')).toHaveLength(1)
+
+    slotProps.close?.()
+    expect(wrapper.emitted('close')).toHaveLength(1)
+  })
+
+  it('does not emit submit from the body slot when the value is empty', async () => {
+    const slotProps: { submit?: () => void } = {}
+    const wrapper = await mountSuspended(ChatPrompt, {
+      props: { modelValue: '  ' },
+      slots: {
+        body: (props: any) => {
+          slotProps.submit = props.submit
+          return h('div', 'body')
+        }
+      }
+    })
+
+    slotProps.submit?.()
+
+    expect(wrapper.emitted('submit')).toBeUndefined()
   })
 
   it('passes accessibility tests', async () => {

--- a/test/components/__snapshots__/ChatPrompt-vue.spec.ts.snap
+++ b/test/components/__snapshots__/ChatPrompt-vue.spec.ts.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ChatPrompt > renders with as correctly 1`] = `
-"<section data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default">
+"<section data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -11,10 +11,17 @@ exports[`ChatPrompt > renders with as correctly 1`] = `
 </section>"
 `;
 
-exports[`ChatPrompt > renders with class correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default p-5">
+exports[`ChatPrompt > renders with body slot correctly 1`] = `
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
+  <!--v-if-->Body slot
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+</form>"
+`;
+
+exports[`ChatPrompt > renders with class correctly 1`] = `
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary p-5">
+  <!--v-if-->
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -23,9 +30,9 @@ exports[`ChatPrompt > renders with class correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with error correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" disabled="" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" disabled="" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -34,9 +41,9 @@ exports[`ChatPrompt > renders with error correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with footer slot correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -45,9 +52,9 @@ exports[`ChatPrompt > renders with footer slot correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with header slot correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <div data-slot="header" class="flex items-center gap-1.5">Header slot</div>
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -56,9 +63,9 @@ exports[`ChatPrompt > renders with header slot correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with placeholder correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Placeholder" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Placeholder" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -67,9 +74,9 @@ exports[`ChatPrompt > renders with placeholder correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with ui correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -80,7 +87,7 @@ exports[`ChatPrompt > renders with ui correctly 1`] = `
 exports[`ChatPrompt > renders with variant naked correctly 1`] = `
 "<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -89,9 +96,9 @@ exports[`ChatPrompt > renders with variant naked correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with variant outline correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -100,9 +107,9 @@ exports[`ChatPrompt > renders with variant outline correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with variant soft correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-elevated/50">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-elevated/50 outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:outline-3">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -111,9 +118,9 @@ exports[`ChatPrompt > renders with variant soft correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with variant subtle correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-elevated/50 ring ring-default">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-elevated/50 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>

--- a/test/components/__snapshots__/ChatPrompt.spec.ts.snap
+++ b/test/components/__snapshots__/ChatPrompt.spec.ts.snap
@@ -1,9 +1,9 @@
 // Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
 
 exports[`ChatPrompt > renders with as correctly 1`] = `
-"<section data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default">
+"<section data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -11,10 +11,17 @@ exports[`ChatPrompt > renders with as correctly 1`] = `
 </section>"
 `;
 
-exports[`ChatPrompt > renders with class correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default p-5">
+exports[`ChatPrompt > renders with body slot correctly 1`] = `
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
+  <!--v-if-->Body slot
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+</form>"
+`;
+
+exports[`ChatPrompt > renders with class correctly 1`] = `
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary p-5">
+  <!--v-if-->
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -23,9 +30,9 @@ exports[`ChatPrompt > renders with class correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with error correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" disabled="" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" disabled="" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -34,9 +41,9 @@ exports[`ChatPrompt > renders with error correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with footer slot correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -45,9 +52,9 @@ exports[`ChatPrompt > renders with footer slot correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with header slot correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <div data-slot="header" class="flex items-center gap-1.5">Header slot</div>
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -56,9 +63,9 @@ exports[`ChatPrompt > renders with header slot correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with placeholder correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Placeholder" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Placeholder" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -67,9 +74,9 @@ exports[`ChatPrompt > renders with placeholder correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with ui correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -80,7 +87,7 @@ exports[`ChatPrompt > renders with ui correctly 1`] = `
 exports[`ChatPrompt > renders with variant naked correctly 1`] = `
 "<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -89,9 +96,9 @@ exports[`ChatPrompt > renders with variant naked correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with variant outline correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-default/75 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -100,9 +107,9 @@ exports[`ChatPrompt > renders with variant outline correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with variant soft correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-elevated/50">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-elevated/50 outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:outline-3">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>
@@ -111,9 +118,9 @@ exports[`ChatPrompt > renders with variant soft correctly 1`] = `
 `;
 
 exports[`ChatPrompt > renders with variant subtle correctly 1`] = `
-"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-elevated/50 ring ring-default">
+"<form data-slot="root" class="relative flex flex-col items-stretch gap-2 px-2.5 py-2 w-full rounded-lg backdrop-blur bg-elevated/50 ring ring-default outline-primary/25 has-[textarea:focus-visible]:outline-3 has-[textarea:focus-visible]:ring-primary has-[[contenteditable]:focus-visible]:outline-3 has-[[contenteditable]:focus-visible]:ring-primary">
   <!--v-if-->
-  <div data-slot="body" class="relative inline-flex items-start"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors px-2.5 py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none" data-slot="base" value=""></textarea>
+  <div data-slot="body" class="relative inline-flex items-start gap-1.5"><textarea rows="1" placeholder="Type your message here…" class="w-full rounded-md border-0 appearance-none placeholder:text-dimmed disabled:cursor-not-allowed disabled:opacity-75 transition-colors py-1.5 text-base/5 gap-1.5 text-highlighted bg-transparent focus:outline-none resize-none px-0" data-slot="base" value=""></textarea>
     <!--v-if-->
     <!--v-if-->
   </div>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- No linked issue, self-initiated enhancement. -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Adds a `#body` slot to `ChatPrompt` so the internal textarea can be swapped for a custom input, for example a `UEditor` with `@` mentions and `/` commands rendered as inline chips. The slot exposes `submit` and `close` handlers so the editor's keyboard shortcuts can drive the form, with the textarea kept as the default fallback so existing usage is unchanged.

Also adds a `color` prop and a focus highlight: the prompt now outlines like a focused input when the inner text surface (textarea or contenteditable) is focus-visible, and the ring is only recolored on variants that already have one (`outline`, `subtle`), matching the `Input` behavior. The textarea's start padding is dropped by default so the text lines up with the header and footer controls.

Docs get a basic usage example and a richer editor example modeled on the Claude Code prompt (attachments, mentions, commands, mode selector), plus a playground page.

> [!NOTE]
> Draft: the editor example and focus styles still want a visual pass on a running server (spacing, the `[contenteditable]` focus highlight, and the `soft` variant), and there is no linked issue yet.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.