### PR TITLE
fix(types): type prose components in app config

### DIFF
--- a/src/runtime/types/tv.ts
+++ b/src/runtime/types/tv.ts
@@ -18,7 +18,7 @@ export type SlotClass = ClassValue | SlotClassReplacer
  * Defines the AppConfig object based on the tailwind-variants configuration.
  */
 export type TVConfig<T extends Record<string, any>> = {
-  [P in keyof T]?: {
+  [P in keyof T]?: P extends 'prose' ? TVConfig<T[P]> : {
     [K in keyof T[P]as K extends 'base' | 'slots' | 'variants' | 'defaultVariants' ? K : never]?: K extends 'base' ? SlotClass
       : K extends 'slots' ? {
         [S in keyof T[P]['slots']]?: SlotClass
@@ -28,7 +28,7 @@ export type TVConfig<T extends Record<string, any>> = {
             : never
   }
 } & {
-  [P in keyof T]?: {
+  [P in keyof T]?: P extends 'prose' ? TVConfig<T[P]> : {
     compoundVariants?: TVCompoundVariants<WidenVariantsValues<T[P]['variants']>, T[P]['slots'], ClassValue, object, undefined>
   }
 }


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Prose components are missing from the `ui` type in `app.config.ts`. The generated augmentation types the whole object with `TVConfig<typeof ui>`, but `#build/ui` exports prose as a nested namespace (`export * as prose from './prose'`) while `TVConfig` only keeps `base`, `slots`, `variants`, `defaultVariants` and `compoundVariants` per key without recursing. Since none of the prose components match that filter, `ui.prose` collapses to a single component config shape and `ui.prose.h1`, `ui.prose.code`, etc. are neither completed nor typed, even though the runtime reads exactly that shape (`appConfig.ui?.prose?.h1`).

This is a regression from 591d59fe8 (v3.1.1) where `TVConfig` replaced `DeepPartial`, which did recurse into the prose namespace. It broke `uiPro.prose` typing in `@nuxt/ui-pro` v3 at the time and was carried into v4 as `ui.prose` by #4675.

The fix makes `TVConfig` recurse when it hits the `prose` key, in both halves of the intersection. This covers the Nuxt template and the Vue plugin at once since both use `TVConfig<typeof ui>`, and it changes nothing when prose is disabled as `typeof ui` has no `prose` key in that case. Verified in the playground with type assertions: valid prose configs typecheck with completion, unknown prose components and slots error, flat components are unaffected, and the full typecheck suite passes.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.