### PR TITLE
fix(Editor): prevent suggestion menu blinking on keystroke

### DIFF
--- a/src/runtime/composables/useEditorMenu.ts
+++ b/src/runtime/composables/useEditorMenu.ts
@@ -572,11 +572,6 @@ export function useEditorMenu<T = any>(options: EditorMenuOptions<T>) {
 
       const handlers = {
         onStart: (suggestionProps: SuggestionProps) => {
-          // When ignoreFilter is true, always use fresh items from the reactive source
-          filteredItems.value = options.ignoreFilter
-            ? items.value.slice(0, limit)
-            : suggestionProps.items as T[]
-
           // Start at first selectable item (index 0 in selectableItems)
           selectedIndex.value = 0
 
@@ -586,6 +581,17 @@ export function useEditorMenu<T = any>(options: EditorMenuOptions<T>) {
           // Store the trigger position (where the `/`, `@`, or `:` is)
           triggerClientRect = suggestionProps.clientRect as () => DOMRect | null
 
+          // The suggestion plugin emits a loading pass with placeholder (empty) items
+          // before the resolved items arrive; skip it to avoid opening with no items.
+          if (suggestionProps.loading) {
+            return
+          }
+
+          // When ignoreFilter is true, always use fresh items from the reactive source
+          filteredItems.value = options.ignoreFilter
+            ? items.value.slice(0, limit)
+            : suggestionProps.items as T[]
+
           // Only show menu if there are items
           if (!filteredItems.value.length) {
             return
@@ -594,13 +600,19 @@ export function useEditorMenu<T = any>(options: EditorMenuOptions<T>) {
           showMenu()
         },
         onUpdate: (suggestionProps: SuggestionProps) => {
+          // Update the command function
+          commandFn = (item: T) => suggestionProps.command(item)
+
+          // Skip the loading pass (placeholder items) so the menu stays mounted while the
+          // resolved items are fetched, otherwise it is destroyed and recreated on every keystroke.
+          if (suggestionProps.loading) {
+            return
+          }
+
           // When ignoreFilter is true, always use fresh items from the reactive source
           filteredItems.value = options.ignoreFilter
             ? items.value.slice(0, limit)
             : suggestionProps.items as T[]
-
-          // Update the command function
-          commandFn = (item: T) => suggestionProps.command(item)
 
           // Reset selected index if out of bounds (comparing against selectableItems)
           if (selectedIndex.value >= selectableItems.value.length) {


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

After pressing `/`, `@` or `:` to open the suggestion / mention / emoji menu, typing to refine the search made the popup blink on every character.

`@tiptap/suggestion` v3.27 dispatches each keystroke in two async phases: a loading pass carrying placeholder items (empty, since we don't set `initialItems`), then a resolved pass with the real filtered items. `useEditorMenu` acted on the empty loading pass and called `cleanupMenu()` (destroying the DOM element + `VueRenderer`), then the resolved pass recreated it via `showMenu()`. The recreated element re-ran the `scale-in` animation and repositioned from `(0,0)`, which is the blink.

Both `onStart` and `onUpdate` now capture the metadata they need up front, then bail out on the loading pass (`suggestionProps.loading`), so the popup stays mounted and only ever takes the `renderer.updateProps()` path.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
