### PR TITLE
feat(Editor): allow disabling starter kit for plain text

### DIFF
--- a/docs/content/docs/2.components/editor.md
+++ b/docs/content/docs/2.components/editor.md
@@ -233,6 +233,10 @@ const value = ref('<h1>Hello World</h1>\n')
 </template>
 ```
 
+::tip
+Set `starter-kit` to `false` for a plain text editor. It keeps the essential nodes (paragraph, text, history) and disables every formatting feature such as bold, italic, headings, lists, code, blockquote, links and horizontal rules.
+::
+
 ::callout{icon="i-custom-tiptap" to="https://tiptap.dev/docs/editor/extensions/functionality/starterkit" target="_blank"}
 Learn more about StarterKit extension in the TipTap documentation.
 ::

--- a/src/runtime/components/Editor.vue
+++ b/src/runtime/components/Editor.vue
@@ -29,10 +29,11 @@ export interface EditorProps<T extends Content = Content, H extends EditorCustom
   contentType?: EditorContentType
   /**
    * The starter kit options to configure the editor.
+   * Set to `false` for a plain-text editor: keeps the essential nodes (paragraph, text, history) and disables all rich-text formatting.
    * @defaultValue { horizontalRule: false, link: { openOnClick: false }, dropcursor: { color: 'var(--ui-primary)', width: 2 } }
    * @see https://tiptap.dev/docs/editor/extensions/functionality/starterkit
    */
-  starterKit?: Partial<StarterKitOptions>
+  starterKit?: boolean | Partial<StarterKitOptions>
   /**
    * The placeholder text to show in empty paragraphs. Can be a string or PlaceholderOptions from `@tiptap/extension-placeholder`.
    * @defaultValue { showOnlyWhenEditable: false, showOnlyCurrent: true, mode: 'everyLine' }
@@ -109,7 +110,8 @@ defineOptions({ inheritAttrs: false })
 
 const _props = withDefaults(defineProps<EditorProps<T, H>>(), {
   image: true,
-  mention: true
+  mention: true,
+  starterKit: true
 })
 const emits = defineEmits<EditorEmits<T>>()
 
@@ -140,17 +142,44 @@ const editorProps = computed(() => defu(props.editorProps, {
 // eslint-disable-next-line vue/no-dupe-keys
 const contentType = computed(() => props.contentType || (typeof props.modelValue === 'string' ? 'html' : 'json'))
 // eslint-disable-next-line vue/no-dupe-keys
-const starterKit = computed(() => defu(props.starterKit, {
-  code: false,
-  horizontalRule: false,
-  dropcursor: {
-    color: 'var(--ui-primary)',
-    width: 2
-  },
-  link: {
-    openOnClick: false
-  }
-} as Partial<StarterKitOptions>))
+const starterKit = computed(() => {
+  const options: Partial<StarterKitOptions> = typeof props.starterKit === 'boolean' ? {} : (props.starterKit ?? {})
+
+  // When disabled, keep a plain-text editor: document, paragraph, text, hard break and history remain, all formatting is turned off
+  const plainText: Partial<StarterKitOptions> = props.starterKit === false
+    ? {
+        blockquote: false,
+        bold: false,
+        bulletList: false,
+        code: false,
+        codeBlock: false,
+        dropcursor: false,
+        gapcursor: false,
+        heading: false,
+        horizontalRule: false,
+        italic: false,
+        listItem: false,
+        listKeymap: false,
+        link: false,
+        orderedList: false,
+        strike: false,
+        underline: false,
+        trailingNode: false
+      }
+    : {}
+
+  return defu(options, plainText, {
+    code: false,
+    horizontalRule: false,
+    dropcursor: {
+      color: 'var(--ui-primary)',
+      width: 2
+    },
+    link: {
+      openOnClick: false
+    }
+  } as Partial<StarterKitOptions>)
+})
 // eslint-disable-next-line vue/no-dupe-keys
 const placeholder = computed(() => {
   const options = typeof props.placeholder === 'string' ? { placeholder: props.placeholder } : props.placeholder
@@ -189,10 +218,10 @@ const mention = computed(() => defu(typeof props.mention === 'boolean' ? {} : pr
 const extensions = computed(() => [
   contentType.value === 'markdown' && Markdown.configure(markdown.value),
   StarterKit.configure(starterKit.value),
-  Code.extend({
+  props.starterKit !== false && Code.extend({
     excludes: 'code'
   }),
-  HorizontalRule.extend({
+  props.starterKit !== false && HorizontalRule.extend({
     renderHTML() {
       return [
         'div',


### PR DESCRIPTION
### 🔗 Linked issue

<!-- No linked issue, self-initiated enhancement. -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `starter-kit` prop now accepts a boolean. Setting it to `false` gives a plain text editor: it keeps the essential nodes (document, paragraph, text) plus history and hard breaks, and disables every formatting feature such as bold, italic, headings, lists, code, blockquote, links and horizontal rules. The custom `Code` and `HorizontalRule` extensions are skipped too.

Previously the only way to get a plain text editor was to turn off each formatting feature by hand through the `starter-kit` object, for example when building a plain text `ChatPrompt`:

```ts
:starter-kit="{ bold: false, italic: false, strike: false, code: false, underline: false, heading: false, blockquote: false, bulletList: false, orderedList: false, listItem: false, codeBlock: false }"
```

This now becomes:

```vue
<UEditor :starter-kit="false" />
```

`starter-kit` set to `true` or an object keeps the current behavior unchanged.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
