### PR TITLE
fix(BlogPost/ChangelogVersion): format date in UTC to prevent hydration mismatch

### DIFF
--- a/src/runtime/components/BlogPost.vue
+++ b/src/runtime/components/BlogPost.vue
@@ -104,7 +104,7 @@ const date = computed(() => {
   }
 
   try {
-    return formatter.custom(new Date(props.date), { dateStyle: 'medium' })
+    return formatter.custom(new Date(props.date), { dateStyle: 'medium', timeZone: 'UTC' })
   } catch {
     return props.date
   }

--- a/src/runtime/components/ChangelogVersion.vue
+++ b/src/runtime/components/ChangelogVersion.vue
@@ -109,7 +109,7 @@ const date = computed(() => {
   }
 
   try {
-    return formatter.custom(new Date(props.date), { dateStyle: 'medium' })
+    return formatter.custom(new Date(props.date), { dateStyle: 'medium', timeZone: 'UTC' })
   } catch {
     return props.date
   }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6708

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`BlogPost` and `ChangelogVersion` format their `date` prop with `formatter.custom(new Date(props.date), { dateStyle: 'medium' })`. A date-only string like `2026-07-20` is parsed as UTC midnight, but `DateFormatter` renders it in the runtime's local timezone since no `timeZone` is passed. When SSR (usually UTC) and the browser (e.g. a US timezone) resolve to different calendar days, the rendered date differs and hydration mismatches.

This passes `timeZone: 'UTC'` so the visible date is formatted in a fixed zone, producing identical output on server and client. It also aligns the visible text with the adjacent `<time datetime>` attribute, which already emits a UTC ISO string via `.toISOString()`.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.