### PR TITLE
perf(module): declare `sideEffects` for barrel tree-shaking

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,6 +98,9 @@
   },
   "style": "./dist/runtime/index.css",
   "main": "./dist/module.mjs",
+  "sideEffects": [
+    "**/*.css"
+  ],
   "files": [
     ".nuxt/ui.static.css",
     "dist",


### PR DESCRIPTION
### ❓ Type of change

- [x] 👌 Enhancement (improving an existing functionality)

### 📚 Description

Declares `"sideEffects": ["**/*.css"]` in `package.json` so consumer bundlers can tree-shake the barrel entry points (`./composables`, `./utils` and especially `./locale`, which re-exports 60+ locales). The CSS files stay marked side-effectful so nothing gets dropped.

Verified against a downstream build that the emitted CSS is unchanged (tokens intact), and the source barrels contain only pure re-exports with no import-time side effects.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
