### PR TITLE
perf(vue): skip rewriting unchanged templates

### DIFF
--- a/src/plugins/templates.ts
+++ b/src/plugins/templates.ts
@@ -15,15 +15,26 @@ export default function TemplatePlugin(options: NuxtUIOptions, appConfig: Record
   async function writeTemplates(root: string) {
     const map: Record<string, string> = {}
     const dir = path.join(root, 'node_modules', '.nuxt-ui')
+    const createdDirs = new Set<string>()
     for (const template of templates) {
       if (!template.write || !template.filename) {
         continue
       }
       const filePath = path.join(dir, template.filename)
-      if (!fs.existsSync(path.dirname(filePath))) {
-        fs.mkdirSync(path.dirname(filePath), { recursive: true })
+      const fileDir = path.dirname(filePath)
+      if (!createdDirs.has(fileDir)) {
+        if (!fs.existsSync(fileDir)) {
+          fs.mkdirSync(fileDir, { recursive: true })
+        }
+        createdDirs.add(fileDir)
       }
-      fs.writeFileSync(filePath, await template.getContents!({} as any))
+
+      const contents = await template.getContents!({} as any)
+      // Skip rewriting identical files so we don't churn mtimes on every config
+      // resolve, which needlessly invalidates watchers and Tailwind's source scan.
+      if (!fs.existsSync(filePath) || fs.readFileSync(filePath, 'utf8') !== contents) {
+        fs.writeFileSync(filePath, contents)
+      }
 
       map[`#build/${template.filename}`] = filePath
     }

--- a/src/plugins/templates.ts
+++ b/src/plugins/templates.ts
@@ -32,7 +32,15 @@ export default function TemplatePlugin(options: NuxtUIOptions, appConfig: Record
       const contents = await template.getContents!({} as any)
       // Skip rewriting identical files so we don't churn mtimes on every config
       // resolve, which needlessly invalidates watchers and Tailwind's source scan.
-      if (!fs.existsSync(filePath) || fs.readFileSync(filePath, 'utf8') !== contents) {
+      let existing: string | null = null
+      try {
+        existing = fs.readFileSync(filePath, 'utf8')
+      } catch (error: any) {
+        if (error.code !== 'ENOENT') {
+          throw error
+        }
+      }
+      if (existing !== contents) {
         fs.writeFileSync(filePath, contents)
       }
 


### PR DESCRIPTION
### ❓ Type of change

- [x] 👌 Enhancement (improving an existing functionality)

### 📚 Description

In the Vue (unplugin) integration, the template writer rewrites every generated theme file to `node_modules/.nuxt-ui` on each config resolve. That churns ~170 file mtimes for no reason, which needlessly invalidates watchers and Tailwind's source scan.

This compares the existing file contents before writing and skips the write when unchanged, and hoists the per-directory `mkdir` into a `Set`. Verified that an unchanged rebuild leaves the template mtimes untouched.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
