### PR TITLE
fix(ProseA): replace history entry for hash links

### DIFF
--- a/src/runtime/components/prose/A.vue
+++ b/src/runtime/components/prose/A.vue
@@ -35,10 +35,14 @@ const appConfig = useAppConfig() as ProseA['AppConfig']
 
 // eslint-disable-next-line vue/no-dupe-keys
 const ui = computed(() => tv({ extend: theme, ...(appConfig.ui?.prose?.a || {}) }))
+
+const shouldReplace = computed(() => {
+  return typeof props.href === 'string' && props.href.startsWith('#')
+})
 </script>
 
 <template>
-  <ULink :href="props.href" :target="props.target" :class="ui({ class: [props.ui?.base, props.class] })" raw>
+  <ULink :href="props.href" :target="props.target" :replace="shouldReplace" :class="ui({ class: [props.ui?.base, props.class] })" raw>
     <slot />
   </ULink>
 </template>


### PR DESCRIPTION
### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Use `replace` for same-page hash links (`#...`) rendered by `ProseA`.

This prevents creating a new history entry for each anchor navigation, allowing the browser back button to return directly to the previous page instead of stepping through every visited heading.
