### PR TITLE
feat(prose): configurable heading anchors and copy button

### DIFF
--- a/docs/app/components/chat/Chat.vue
+++ b/docs/app/components/chat/Chat.vue
@@ -269,6 +269,14 @@ defineShortcuts({
     </template>
 
     <UTheme
+      :props="{
+        prose: {
+          h1: { anchor: false },
+          h2: { anchor: false },
+          h3: { anchor: false },
+          h4: { anchor: false }
+        }
+      }"
       :ui="{
         prose: {
           p: { base: 'my-2 text-sm/6' },

--- a/docs/content/docs/4.typography/2.headers-and-text.md
+++ b/docs/content/docs/4.typography/2.headers-and-text.md
@@ -7,14 +7,24 @@ description: 'Beautifully styled headings, paragraphs, text formatting, and link
 
 Use headings to organize your content and make it easier to read.
 
-H1 to H3 headings get anchor links and show up in the table of contents for easy navigation.
+Headings can be wrapped in an anchor link when they have an `id`, with a hash icon shown on hover for `H2` and `H3` so readers can link directly to a section.
+
+Anchor links are off by default. Use the [`Theme`](/docs/components/theme) component with the `anchor` prop to toggle them for a section of your app:
+
+```vue
+<template>
+  <UTheme :props="{ prose: { h2: { anchor: true }, h3: { anchor: true }, h4: { anchor: true } } }">
+    <!-- your rendered markdown -->
+  </UTheme>
+</template>
+```
 
 ::framework-only
 #nuxt
 :::div
 
 ::::note
-When using `@nuxt/content`, you can control [anchor links](https://content.nuxt.com/docs/getting-started/configuration#anchorlinks) generation (for example, for AI chat interfaces) in your `nuxt.config.ts`:
+When using `@nuxt/content`, anchor links are enabled for `H2`, `H3` and `H4` by default. You can control their [generation](https://content.nuxt.com/docs/getting-started/configuration#anchorlinks) (for example, to disable them for AI chat interfaces) in your `nuxt.config.ts`:
 
 ```ts [nuxt.config.ts]
 export default defineNuxtConfig({

--- a/docs/content/docs/4.typography/5.code.md
+++ b/docs/content/docs/4.typography/5.code.md
@@ -187,6 +187,8 @@ These filename icons come from the [`vscode-icons`](https://icones.js.org/collec
 
 Every code-block has a built-in copy button that will copy the code to your clipboard.
 
+Set the `copy` prop to `false` to hide the button, or pass [Button](/docs/components/button) props to customize it.
+
 ::tip
 You can change the icon through the `ui.icons.copy` and `ui.icons.copyCheck` keys in your app configuration:
 

--- a/src/runtime/components/prose/H1.vue
+++ b/src/runtime/components/prose/H1.vue
@@ -8,6 +8,11 @@ type ProseH1 = ComponentConfig<typeof theme, AppConfig, 'h1', 'ui.prose'>
 
 export interface ProseH1Props {
   id?: string
+  /**
+   * Wrap the heading in an anchor link when an `id` is present.
+   * @defaultValue false
+   */
+  anchor?: boolean
   class?: any
   ui?: ProseH1['slots']
 }
@@ -30,12 +35,13 @@ defineSlots<ProseH1Slots>()
 const props = useComponentProps('prose.h1', _props)
 
 const appConfig = useAppConfig() as ProseH1['AppConfig']
+// NOTE: the `mdc.headings.anchorLinks` fallback is deprecated, remove in v5 in favor of the `anchor` prop.
 const { headings } = useRuntimeConfig().public?.mdc || {}
 
 // eslint-disable-next-line vue/no-dupe-keys
 const ui = computed(() => tv({ extend: theme, ...(appConfig.ui?.prose?.h1 || {}) })())
 
-const generate = computed(() => props.id && typeof headings?.anchorLinks === 'object' && headings.anchorLinks.h1)
+const generate = computed(() => props.id && (props.anchor ?? (typeof headings?.anchorLinks === 'boolean' ? headings.anchorLinks : headings?.anchorLinks?.h1) ?? false))
 </script>
 
 <template>

--- a/src/runtime/components/prose/H2.vue
+++ b/src/runtime/components/prose/H2.vue
@@ -8,6 +8,12 @@ type ProseH2 = ComponentConfig<typeof theme, AppConfig, 'h2', 'ui.prose'>
 
 export interface ProseH2Props {
   id?: string
+  /**
+   * Wrap the heading in an anchor link when an `id` is present.
+   * `@nuxt/content` and `@nuxtjs/mdc` enable this for H2–H4 by default.
+   * @defaultValue false
+   */
+  anchor?: boolean
   class?: any
   ui?: ProseH2['slots']
 }
@@ -31,12 +37,13 @@ defineSlots<ProseH2Slots>()
 const props = useComponentProps('prose.h2', _props)
 
 const appConfig = useAppConfig() as ProseH2['AppConfig']
+// NOTE: the `mdc.headings.anchorLinks` fallback is deprecated, remove in v5 in favor of the `anchor` prop.
 const { headings } = useRuntimeConfig().public?.mdc || {}
 
 // eslint-disable-next-line vue/no-dupe-keys
 const ui = computed(() => tv({ extend: theme, ...(appConfig.ui?.prose?.h2 || {}) })())
 
-const generate = computed(() => props.id && typeof headings?.anchorLinks === 'object' && headings.anchorLinks.h2)
+const generate = computed(() => props.id && (props.anchor ?? (typeof headings?.anchorLinks === 'boolean' ? headings.anchorLinks : headings?.anchorLinks?.h2) ?? false))
 </script>
 
 <template>

--- a/src/runtime/components/prose/H3.vue
+++ b/src/runtime/components/prose/H3.vue
@@ -8,6 +8,12 @@ type ProseH3 = ComponentConfig<typeof theme, AppConfig, 'h3', 'ui.prose'>
 
 export interface ProseH3Props {
   id?: string
+  /**
+   * Wrap the heading in an anchor link when an `id` is present.
+   * `@nuxt/content` and `@nuxtjs/mdc` enable this for H2–H4 by default.
+   * @defaultValue false
+   */
+  anchor?: boolean
   class?: any
   ui?: ProseH3['slots']
 }
@@ -31,12 +37,13 @@ defineSlots<ProseH3Slots>()
 const props = useComponentProps('prose.h3', _props)
 
 const appConfig = useAppConfig() as ProseH3['AppConfig']
+// NOTE: the `mdc.headings.anchorLinks` fallback is deprecated, remove in v5 in favor of the `anchor` prop.
 const { headings } = useRuntimeConfig().public?.mdc || {}
 
 // eslint-disable-next-line vue/no-dupe-keys
 const ui = computed(() => tv({ extend: theme, ...(appConfig.ui?.prose?.h3 || {}) })())
 
-const generate = computed(() => props.id && typeof headings?.anchorLinks === 'object' && headings.anchorLinks.h3)
+const generate = computed(() => props.id && (props.anchor ?? (typeof headings?.anchorLinks === 'boolean' ? headings.anchorLinks : headings?.anchorLinks?.h3) ?? false))
 </script>
 
 <template>

--- a/src/runtime/components/prose/H4.vue
+++ b/src/runtime/components/prose/H4.vue
@@ -8,6 +8,12 @@ type ProseH4 = ComponentConfig<typeof theme, AppConfig, 'h4', 'ui.prose'>
 
 export interface ProseH4Props {
   id?: string
+  /**
+   * Wrap the heading in an anchor link when an `id` is present.
+   * `@nuxt/content` and `@nuxtjs/mdc` enable this for H2–H4 by default.
+   * @defaultValue false
+   */
+  anchor?: boolean
   class?: any
   ui?: ProseH4['slots']
 }
@@ -30,12 +36,13 @@ defineSlots<ProseH4Slots>()
 const props = useComponentProps('prose.h4', _props)
 
 const appConfig = useAppConfig() as ProseH4['AppConfig']
+// NOTE: the `mdc.headings.anchorLinks` fallback is deprecated, remove in v5 in favor of the `anchor` prop.
 const { headings } = useRuntimeConfig().public?.mdc || {}
 
 // eslint-disable-next-line vue/no-dupe-keys
 const ui = computed(() => tv({ extend: theme, ...(appConfig.ui?.prose?.h4 || {}) })())
 
-const generate = computed(() => props.id && typeof headings?.anchorLinks === 'object' && headings.anchorLinks.h4)
+const generate = computed(() => props.id && (props.anchor ?? (typeof headings?.anchorLinks === 'boolean' ? headings.anchorLinks : headings?.anchorLinks?.h4) ?? false))
 </script>
 
 <template>

--- a/src/runtime/components/prose/Pre.vue
+++ b/src/runtime/components/prose/Pre.vue
@@ -3,6 +3,8 @@ import type { VNode } from 'vue'
 import type { AppConfig } from '@nuxt/schema'
 import theme from '#build/ui/prose/pre'
 import type { IconProps } from '../Icon.vue'
+import type { ButtonProps } from '../Button.vue'
+import type { LinkPropsKeys } from '../Link.vue'
 import type { ComponentConfig } from '../../types/tv'
 
 type ProsePre = ComponentConfig<typeof theme, AppConfig, 'pre', 'ui.prose'>
@@ -15,6 +17,12 @@ export interface ProsePreProps {
   highlights?: number[]
   hideHeader?: boolean
   meta?: string
+  /**
+   * Display a button to copy the code to the clipboard.
+   * `{ size: 'sm', color: 'neutral', variant: 'outline' }`{lang="ts-type"}
+   * @defaultValue true
+   */
+  copy?: boolean | Omit<ButtonProps, LinkPropsKeys>
   class?: any
   ui?: ProsePre['slots']
 }
@@ -34,14 +42,16 @@ import { tv } from '../../utils/tv'
 import UCodeIcon from './CodeIcon.vue'
 import UButton from '../Button.vue'
 
-const _props = defineProps<ProsePreProps>()
+const _props = withDefaults(defineProps<ProsePreProps>(), {
+  copy: true
+})
 
 defineSlots<ProsePreSlots>()
 
 const props = useComponentProps('prose.pre', _props)
 
 const { t } = useLocale()
-const { copy, copied } = useClipboard()
+const { copy: copyToClipboard, copied } = useClipboard()
 const appConfig = useAppConfig() as ProsePre['AppConfig']
 
 const baseRef = useTemplateRef('baseRef')
@@ -52,7 +62,7 @@ const ui = computed(() => tv({ extend: theme, ...(appConfig.ui?.prose?.pre || {}
 function copyCode() {
   const code = props.code ?? baseRef.value?.textContent ?? ''
 
-  copy(code)
+  copyToClipboard(code)
 }
 </script>
 
@@ -65,11 +75,13 @@ function copyCode() {
     </div>
 
     <UButton
+      v-if="props.copy"
       :icon="copied ? appConfig.ui.icons.copyCheck : appConfig.ui.icons.copy"
       color="neutral"
       variant="outline"
       size="sm"
       :aria-label="t('prose.pre.copy')"
+      v-bind="(typeof props.copy === 'object' ? props.copy : {})"
       :class="ui.copy({ class: props.ui?.copy })"
       @click="copyCode"
     />

--- a/src/runtime/types/theme.ts
+++ b/src/runtime/types/theme.ts
@@ -126,6 +126,37 @@ export interface ThemeDefaults {
   pricingPlans?: Partial<ComponentTypes.PricingPlansProps>
   pricingTable?: Partial<ComponentTypes.PricingTableProps>
   progress?: Partial<ComponentTypes.ProgressProps>
+  /**
+   * Prose components that expose overridable props, under a `prose` namespace
+   * (mirrors `app.config.ui.prose` and `useComponentProps('prose.<tag>', …)`).
+   * Set prop defaults per element to scope behavior for a subtree, e.g.
+   * `{ prose: { h2: { anchor: true }, img: { zoom: false } } }`. Class-only
+   * elements (`p`, `li`, `table`, `em`, …) are omitted — restyle them via `:ui`.
+   */
+  prose?: {
+    a?: Partial<ComponentTypes.ProseAProps>
+    accordion?: Partial<ComponentTypes.ProseAccordionProps>
+    callout?: Partial<ComponentTypes.ProseCalloutProps>
+    card?: Partial<ComponentTypes.ProseCardProps>
+    code?: Partial<ComponentTypes.ProseCodeProps>
+    codeCollapse?: Partial<ComponentTypes.ProseCodeCollapseProps>
+    codeGroup?: Partial<ComponentTypes.ProseCodeGroupProps>
+    codeTree?: Partial<ComponentTypes.ProseCodeTreeProps>
+    collapsible?: Partial<ComponentTypes.ProseCollapsibleProps>
+    field?: Partial<ComponentTypes.ProseFieldProps>
+    fieldGroup?: Partial<ComponentTypes.ProseFieldGroupProps>
+    h1?: Partial<ComponentTypes.ProseH1Props>
+    h2?: Partial<ComponentTypes.ProseH2Props>
+    h3?: Partial<ComponentTypes.ProseH3Props>
+    h4?: Partial<ComponentTypes.ProseH4Props>
+    img?: Partial<ComponentTypes.ProseImgProps>
+    pre?: Partial<ComponentTypes.ProsePreProps>
+    prompt?: Partial<ComponentTypes.ProsePromptProps>
+    steps?: Partial<ComponentTypes.ProseStepsProps>
+    tabs?: Partial<ComponentTypes.ProseTabsProps>
+    td?: Partial<ComponentTypes.ProseTdProps>
+    th?: Partial<ComponentTypes.ProseThProps>
+  }
   radioGroup?: Partial<ComponentTypes.RadioGroupProps>
   scrollArea?: Partial<ComponentTypes.ScrollAreaProps>
   select?: Partial<ComponentTypes.SelectProps>

--- a/test/composables/useComponentProps.spec.ts
+++ b/test/composables/useComponentProps.spec.ts
@@ -7,18 +7,17 @@ import type { ThemeDefaults } from '../../src/runtime/types/theme'
 
 /**
  * Hand-maintained list of `#build/ui` exports that intentionally don't
- * participate in `<UTheme :props>` overrides. Two reasons land here:
+ * participate in `<UTheme :props>` overrides: the matching Vue file doesn't
+ * run `useComponentProps`, so a `:props` entry would types-check but no-op at
+ * runtime. If a key stays here long-term, consider migrating the component to
+ * `useComponentProps` and removing it from this list.
  *
- *   - `prose` is a namespace, not a single component (its children live
- *     under `prose.<tag>` and are read via `useComponentProps('prose.p', …)`).
- *   - The matching Vue file doesn't run `useComponentProps`, so a `:props`
- *     entry would types-check but no-op at runtime. If a key stays here
- *     long-term, consider migrating the component to `useComponentProps`
- *     and removing it from this list.
+ * Note: `prose` is a namespace whose children (`prose.h2`, …) *do* read
+ * `useComponentProps('prose.<tag>', …)`, so it participates via a nested
+ * `ThemeDefaults['prose']` shape and is not excluded here.
  */
 type NonProxyComponents
-  = | 'prose'
-    | 'link'
+  = | 'link'
     | 'editorEmojiMenu'
     | 'editorMentionMenu'
     | 'editorSuggestionMenu'


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Two related additions that make prose components configurable through props and `<UTheme :props>`, plus the shared plumbing to support it.

Prose heading anchor generation was reading `useRuntimeConfig().public.mdc.headings.anchorLinks`, which ties the components to `@nuxtjs/mdc`. As we move toward Comark (Vite friendly, no global runtime config) this needs to become framework agnostic. This adds an `anchor` prop to `ProseH1` through `ProseH4` with the priority chain explicit prop / `<UTheme :props>` / `app.config` defaultVariants, then the mdc config as a deprecated fallback, then a built in default of off. The fallback keeps `@nuxt/content` and `@nuxtjs/mdc` users on their current behavior (H2 to H4 enabled) with zero change, while content free Comark and plain Vue apps stay quiet by default. It also fixes a case where a boolean `anchorLinks: true` was ignored because only the object form was handled.

`ProsePre` gets a `copy` prop (`boolean | ButtonProps`) so the code copy button can be hidden or customized, mirroring the `close` prop on `Alert`. It defaults to `true`, so current behavior is unchanged.

To make these props controllable the way they are meant to be used (prose is rendered by the markdown renderer, not written by hand), a `prose` namespace is exposed on `<UTheme :props>` covering the prose components that have overridable props, so anchors, the copy button and similar can be toggled for a subtree. The docs AI chat uses this to keep heading anchors out of assistant messages.

The typography docs are updated for both props.
