### PR TITLE
fix(CommandPalette): always escape search highlight to prevent XSS

### DIFF
--- a/src/runtime/utils/search.ts
+++ b/src/runtime/utils/search.ts
@@ -13,18 +13,6 @@ function escapeHTML(str: string): string {
   return str.replace(/[&<>"']/g, char => htmlEscapes[char]!)
 }
 
-// Check if string is already HTML-escaped to avoid double-escaping
-function isAlreadyEscaped(str: string): boolean {
-  return /&(?:amp|lt|gt|quot|#39);/.test(str)
-}
-
-function sanitize(str: string): string {
-  if (isAlreadyEscaped(str)) {
-    return str
-  }
-  return escapeHTML(str)
-}
-
 function truncateHTMLFromStart(html: string, maxLength: number) {
   let truncated = ''
   let totalLength = 0
@@ -93,16 +81,16 @@ export function highlight<T>(item: T & { matches?: FuseResult<T>['matches'] }, s
       const isMatched = (lastIndiceNextIndex - region[0]) >= minTokenLength
 
       content += [
-        sanitize(value.substring(nextUnhighlightedRegionStartingIndex, region[0])),
+        escapeHTML(value.substring(nextUnhighlightedRegionStartingIndex, region[0])),
         isMatched && `<mark>`,
-        sanitize(value.substring(region[0], lastIndiceNextIndex)),
+        escapeHTML(value.substring(region[0], lastIndiceNextIndex)),
         isMatched && '</mark>'
       ].filter(Boolean).join('')
 
       nextUnhighlightedRegionStartingIndex = lastIndiceNextIndex
     })
 
-    content += sanitize(value.substring(nextUnhighlightedRegionStartingIndex))
+    content += escapeHTML(value.substring(nextUnhighlightedRegionStartingIndex))
 
     const markIndex = content.indexOf('<mark>')
     if (markIndex !== -1) {

--- a/test/utils/search.spec.ts
+++ b/test/utils/search.spec.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { sanitizeSnippet } from '../../src/runtime/utils/search'
+import { highlight, sanitizeSnippet } from '../../src/runtime/utils/search'
 
 describe('sanitizeSnippet', () => {
   it('preserves <mark> highlights', () => {
@@ -27,5 +27,37 @@ describe('sanitizeSnippet', () => {
 
   it('handles empty input', () => {
     expect(sanitizeSnippet('')).toBe('')
+  })
+})
+
+describe('highlight', () => {
+  it('escapes an injected tag in the unmatched tail while keeping the match highlighted', () => {
+    const value = 'zzzzz &<img src=x onerror=alert(1)>'
+    const result = highlight({ label: value, matches: [{ key: 'label', value, indices: [[0, 4]] }] }, 'zzzzz', 'label')
+
+    expect(result).toContain('<mark>zzzzz</mark>')
+    expect(result).not.toContain('<img')
+    expect(result).toContain('&lt;img')
+    expect(result).toContain('&amp;')
+  })
+
+  it('escapes payloads that contain a pre-existing HTML entity (regression: sanitize bypass)', () => {
+    const value = '&amp;<img src=x onerror=alert(1)>'
+    const result = highlight({ label: value, matches: [{ key: 'label', value, indices: [] }] }, 'x', 'label')
+
+    expect(result).not.toContain('<img')
+    expect(result).toBe('&amp;amp;&lt;img src=x onerror=alert(1)&gt;')
+  })
+
+  it('escapes HTML-special characters around the highlighted region', () => {
+    const value = `match < & "a" 'b'`
+    const result = highlight({ label: value, matches: [{ key: 'label', value, indices: [[0, 4]] }] }, 'match', 'label')
+
+    expect(result).toBe(`<mark>match</mark> &lt; &amp; &quot;a&quot; &#39;b&#39;`)
+  })
+
+  it('returns undefined when there are no matches', () => {
+    expect(highlight({ label: 'foo', matches: [] }, 'foo', 'label')).toBeUndefined()
+    expect(highlight({ label: 'foo' }, 'foo', 'label')).toBeUndefined()
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves a privately reported XSS vulnerability in the search highlight.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `highlight` helper in `src/runtime/utils/search.ts` builds the HTML that `CommandPalette` renders through `v-html` (`labelHtml`, `suffixHtml`, `descriptionHtml`). Each text chunk was passed through a `sanitize` function that first checked `isAlreadyEscaped` to avoid double escaping, and returned the string untouched when it already contained any HTML entity.

That check is a global regex, so a value containing a single entity such as `&amp;` anywhere caused the whole string to be returned verbatim, including any markup after it. A field like `&amp;<img src=x onerror=...>` reached `v-html` unescaped.

The double escaping guard was never needed here since `highlight` always receives the raw Fuse match value, which is plain text rather than pre-escaped HTML. This removes `sanitize` and `isAlreadyEscaped` and escapes every chunk unconditionally with `escapeHTML`. The `<mark>` tags are still inserted as trusted literals between the escaped chunks, so highlighting keeps working, and `highlight` now behaves consistently with `sanitizeSnippet` which already always escapes.

The only behavior change is that a value containing a literal entity like `Tom &amp; Jerry` now renders the entity as text, which is the correct plain text semantics for a highlighted label.

Added tests in `test/utils/search.spec.ts` covering the injected tag case, the entity prefix regression, escaping of special characters around the match, and the no match case.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
