### PR TITLE
fix(Slider): forward form aria attributes to thum

### DIFF
--- a/src/runtime/components/Slider.vue
+++ b/src/runtime/components/Slider.vue
@@ -111,7 +111,7 @@ function onChange(value: any) {
 
 <template>
   <SliderRoot
-    v-bind="{ ...rootProps, ...ariaAttrs }"
+    v-bind="{ ...rootProps }"
     :id="id"
     v-model="sliderValue"
     :name="name"
@@ -133,9 +133,9 @@ function onChange(value: any) {
         disable-closing-trigger
         v-bind="(typeof props.tooltip === 'object' ? props.tooltip : {})"
       >
-        <SliderThumb data-slot="thumb" :class="ui.thumb({ class: props.ui?.thumb })" :aria-label="thumbs === 1 ? 'Thumb' : `Thumb ${thumb} of ${thumbs}`" />
+        <SliderThumb data-slot="thumb" :class="ui.thumb({ class: props.ui?.thumb })" v-bind="{ 'aria-label': thumbs === 1 ? 'Thumb' : `Thumb ${thumb} of ${thumbs}`, ...ariaAttrs }" />
       </UTooltip>
-      <SliderThumb v-else data-slot="thumb" :class="ui.thumb({ class: props.ui?.thumb })" :aria-label="thumbs === 1 ? 'Thumb' : `Thumb ${thumb} of ${thumbs}`" />
+      <SliderThumb v-else data-slot="thumb" :class="ui.thumb({ class: props.ui?.thumb })" v-bind="{ 'aria-label': thumbs === 1 ? 'Thumb' : `Thumb ${thumb} of ${thumbs}`, ...ariaAttrs }" />
     </template>
   </SliderRoot>
 </template>


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

Closes #6749 

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [X] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Moves the form accessibility attributes returned by `useFormField` from `SliderRoot` to `SliderThumb`.

`SliderRoot` is not focusable and does not represent the interactive slider control. The focusable element exposed to assistive technologies is `SliderThumb`, which has `role="slider"`.

Applying attributes such as `aria-invalid`, `aria-describedby`, `aria-labelledby` and `aria-required` to the thumb ensures that the field label, description and validation state are announced when the slider receives focus.

The attributes are forwarded both when the tooltip is enabled and when it is disabled.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
