### PR TITLE
fix(Slider): bind form aria attributes on thumbs instead of root

### DIFF
--- a/src/runtime/components/Slider.vue
+++ b/src/runtime/components/Slider.vue
@@ -111,7 +111,7 @@ function onChange(value: any) {
 
 <template>
   <SliderRoot
-    v-bind="{ ...rootProps, ...ariaAttrs }"
+    v-bind="rootProps"
     :id="id"
     v-model="sliderValue"
     :name="name"
@@ -133,9 +133,9 @@ function onChange(value: any) {
         disable-closing-trigger
         v-bind="(typeof props.tooltip === 'object' ? props.tooltip : {})"
       >
-        <SliderThumb data-slot="thumb" :class="ui.thumb({ class: props.ui?.thumb })" :aria-label="thumbs === 1 ? 'Thumb' : `Thumb ${thumb} of ${thumbs}`" />
+        <SliderThumb data-slot="thumb" :class="ui.thumb({ class: props.ui?.thumb })" :aria-label="thumbs === 1 ? 'Thumb' : `Thumb ${thumb} of ${thumbs}`" v-bind="ariaAttrs" />
       </UTooltip>
-      <SliderThumb v-else data-slot="thumb" :class="ui.thumb({ class: props.ui?.thumb })" :aria-label="thumbs === 1 ? 'Thumb' : `Thumb ${thumb} of ${thumbs}`" />
+      <SliderThumb v-else data-slot="thumb" :class="ui.thumb({ class: props.ui?.thumb })" :aria-label="thumbs === 1 ? 'Thumb' : `Thumb ${thumb} of ${thumbs}`" v-bind="ariaAttrs" />
     </template>
   </SliderRoot>
 </template>

--- a/test/components/FormField.spec.ts
+++ b/test/components/FormField.spec.ts
@@ -118,6 +118,18 @@ describe('FormField', () => {
         const label = wrapper.find('label[for=v-0-0]')
         expect(label.exists()).toBe(false)
       })
+    } else {
+      test('binds label for', async () => {
+        const wrapper = await renderFormField({
+          props: { label: 'Label' },
+          inputComponent
+        })
+        const label = wrapper.find('label[for=v-0-0]')
+        expect(label.exists()).toBe(true)
+
+        const input = wrapper.find('[id=v-0-0]')
+        expect(input.exists()).toBe(true)
+      })
     }
 
     if (name === 'Slider') {
@@ -131,20 +143,6 @@ describe('FormField', () => {
         expect(invalid).toHaveLength(1)
         expect(invalid[0]!.attributes('role')).toBe('slider')
         expect(invalid[0]!.attributes('aria-describedby')).toBe('v-0-0-error')
-      })
-    }
-
-    if (name !== 'RadioGroup') {
-      test('binds label for', async () => {
-        const wrapper = await renderFormField({
-          props: { label: 'Label' },
-          inputComponent
-        })
-        const label = wrapper.find('label[for=v-0-0]')
-        expect(label.exists()).toBe(true)
-
-        const input = wrapper.find('[id=v-0-0]')
-        expect(input.exists()).toBe(true)
       })
     }
 

--- a/test/components/FormField.spec.ts
+++ b/test/components/FormField.spec.ts
@@ -118,7 +118,23 @@ describe('FormField', () => {
         const label = wrapper.find('label[for=v-0-0]')
         expect(label.exists()).toBe(false)
       })
-    } else {
+    }
+
+    if (name === 'Slider') {
+      test('binds aria attributes on the thumb', async () => {
+        const wrapper = await renderFormField({
+          props: { error: 'Error' },
+          inputComponent
+        })
+
+        const invalid = wrapper.findAll('[aria-invalid="true"]')
+        expect(invalid).toHaveLength(1)
+        expect(invalid[0]!.attributes('role')).toBe('slider')
+        expect(invalid[0]!.attributes('aria-describedby')).toBe('v-0-0-error')
+      })
+    }
+
+    if (name !== 'RadioGroup') {
       test('binds label for', async () => {
         const wrapper = await renderFormField({
           props: { label: 'Label' },


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6749

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`useFormField`'s `ariaAttrs` (`aria-invalid`, `aria-describedby`) were bound on `SliderRoot`, which reka-ui renders as a plain `<span>` with no role and no `tabindex` — assistive technologies never announce attributes there. The focusable control is the thumb (`role="slider"`, `tabindex="0"`), so this moves the binding onto each `SliderThumb` (both the tooltip and plain branches).

Per the APG slider pattern each thumb is a separate slider control, so both thumbs of a range slider sharing the same `aria-describedby` is correct. `:id` stays on the root (multiple thumbs can't share one id), keeping the existing `label[for]` association tests green. When used outside a `UFormField`, `ariaAttrs` is `undefined` and `v-bind="undefined"` is a no-op — no snapshot changes.

Includes a placement-specific regression test in `FormField.spec.ts` asserting the attributes land on the `role="slider"` element (exactly one match) rather than anywhere in the tree.

Credit: #6750 by @nononavasgit proposed the same direction before being closed by its author.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
