### PR TITLE
fix(InputNumber): keep previous value on unparseable input, emit null when cleared

### DIFF
--- a/src/runtime/components/InputNumber.vue
+++ b/src/runtime/components/InputNumber.vue
@@ -117,7 +117,13 @@ const modelValue = useVModel<InputNumberProps<T, Mod>, 'modelValue', 'update:mod
 const { t } = useLocale()
 const appConfig = useAppConfig() as InputNumber['AppConfig']
 
-const rootProps = useForwardProps(reactivePick(props, 'as', 'stepSnapping', 'formatOptions', 'disableWheelChange', 'invertWheelChange', 'required', 'readonly', 'focusOnChange', 'locale'), emits)
+// `update:modelValue` is normalized in `onUpdate()` instead of being forwarded as-is
+const forwardedEmits = ((event: any, ...args: any[]) => {
+  if (event !== 'update:modelValue') {
+    (emits as any)(event, ...args)
+  }
+}) as typeof emits
+const rootProps = useForwardProps(reactivePick(props, 'as', 'stepSnapping', 'formatOptions', 'disableWheelChange', 'invertWheelChange', 'required', 'readonly', 'focusOnChange', 'locale'), forwardedEmits)
 
 const { emitFormBlur, emitFormFocus, emitFormChange, emitFormInput, id, color, size: formFieldSize, name, highlight, disabled, ariaAttrs } = useFormField<InputNumberProps<T, Mod>>(_props)
 const { orientation, size: fieldGroupSize } = useFieldGroup<InputNumberProps<T, Mod>>(_props)
@@ -145,9 +151,16 @@ const decrementIcon = computed(() => props.decrementIcon || (props.orientation =
 const inputRef = useTemplateRef('inputRef')
 
 function onUpdate(value: ApplyModifiers<T, Mod> | undefined) {
-  if (props.modelModifiers?.optional) {
-    modelValue.value = value = value ?? undefined
+  // `undefined` covers both a cleared input and unparseable text ("." / "-")
+  if (value === undefined && inputRef.value?.$el?.value) {
+    return // non-empty text = unparseable; the controlled root restores the previous value
   }
+
+  if (props.modelModifiers?.optional) {
+    value = value ?? undefined
+  }
+
+  modelValue.value = value
 
   // @ts-expect-error - 'target' does not exist in type 'EventInit'
   const event = new Event('change', { target: { value } })

--- a/src/runtime/components/InputNumber.vue
+++ b/src/runtime/components/InputNumber.vue
@@ -151,13 +151,13 @@ const decrementIcon = computed(() => props.decrementIcon || (props.orientation =
 const inputRef = useTemplateRef('inputRef')
 
 function onUpdate(value: ApplyModifiers<T, Mod> | undefined) {
-  // `undefined` covers both a cleared input and unparseable text ("." / "-")
-  if (value === undefined && inputRef.value?.$el?.value) {
-    return // non-empty text = unparseable; the controlled root restores the previous value
-  }
+  if (value === undefined) {
+    // `undefined` covers both a cleared input and unparseable text ("." / "-")
+    if (inputRef.value?.$el?.value) {
+      return // non-empty text = unparseable; the controlled root restores the previous value
+    }
 
-  if (props.modelModifiers?.optional) {
-    value = value ?? undefined
+    value = (props.modelModifiers?.optional ? undefined : null) as ApplyModifiers<T, Mod>
   }
 
   modelValue.value = value

--- a/test/components/InputNumber.spec.ts
+++ b/test/components/InputNumber.spec.ts
@@ -88,6 +88,24 @@ describe('InputNumber', () => {
       expect(wrapper.emitted('update:modelValue')).toBeUndefined()
       expect((input.element as HTMLInputElement).value).toBe('5')
     })
+
+    test('emits null when cleared', async () => {
+      const wrapper = await mountSuspended(InputNumber, { props: { modelValue: 5 } })
+      const input = wrapper.find('input')
+      await input.setValue('')
+      await input.trigger('keydown', { key: 'Enter' })
+
+      expect(wrapper.emitted('update:modelValue')).toMatchObject([[null]])
+    })
+
+    test('emits undefined when cleared with the optional modifier', async () => {
+      const wrapper = await mountSuspended(InputNumber, { props: { modelValue: 5, modelModifiers: { optional: true } } })
+      const input = wrapper.find('input')
+      await input.setValue('')
+      await input.trigger('keydown', { key: 'Enter' })
+
+      expect(wrapper.emitted('update:modelValue')).toMatchObject([[undefined]])
+    })
   })
 
   describe('form integration', async () => {

--- a/test/components/InputNumber.spec.ts
+++ b/test/components/InputNumber.spec.ts
@@ -78,6 +78,16 @@ describe('InputNumber', () => {
       await input.trigger('blur')
       expect(wrapper.emitted()).toMatchObject({ blur: [[{ type: 'blur' }]] })
     })
+
+    test('keeps the previous value when committing unparseable input', async () => {
+      const wrapper = await mountSuspended(InputNumber, { props: { modelValue: 5 } })
+      const input = wrapper.find('input')
+      await input.setValue('.')
+      await input.trigger('keydown', { key: 'Enter' })
+
+      expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+      expect((input.element as HTMLInputElement).value).toBe('5')
+    })
   })
 
   describe('form integration', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6743

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

First, a root-cause correction for the issue title: no `NaN` is ever emitted. Committing unparseable text like `.` or `-` (Enter/blur) makes reka-ui's NumberField emit **`undefined`** — the reporter's `isNaN(v)` check reads true because `isNaN(undefined)` is true, and `undefined` poisons downstream arithmetic into NaN. Reka's `applyInputValue` conflates two situations that deserve different handling: a **cleared** input and **non-empty unparseable** text both nuke the model to `undefined` (and destroy the previous value).

Two commits, separable:

**1. `fix(InputNumber): keep previous value when committing unparseable input`** — what the reporter asked for ("maybe just revert to the previous value instead?"), matching react-spectrum's behavior. All model updates now flow through `onUpdate()` — previously the auto-forwarded `update:modelValue` handler bypassed it entirely in non-`.optional` mode (and double-emitted in `.optional` mode). When the committed value is `undefined` but the input still contains text, the update is dropped; since `NumberFieldRoot` runs controlled, it restores the last formatted value on its own. Verified in the added test: `.` + <kbd>Enter</kbd> on a model of `5` → no emit, input text back to `5`.

**2. `fix(InputNumber): emit null when cleared to match the declared model type`** — the typing-soundness half reported by @danekslama in the issue comments: the emit type is `number | null` (`undefined` only with the `.optional` modifier), but clearing leaked `undefined` at runtime regardless. Clearing now emits `null`, or `undefined` with `.optional` (unchanged). This one is mildly behavior-visible for consumers who relied on the untyped `undefined` — happy to drop this commit if you'd rather keep it wrapper-compatible, the first commit stands alone.

Tests cover all three paths (unparseable revert / clear → `null` / clear + `.optional` → `undefined`); existing suites and snapshots unchanged (110 tests green, `vue-tsc` clean).

Upstream note: the revert-on-unparseable behavior arguably belongs in reka-ui's `applyInputValue` eventually, but the wrapper can't wait on that and needs the `null` convention regardless — no reka-ui issue exists for it yet, I can file one.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
