### PR TITLE
fix(InputMenu): prevent tags input from adding the search term on enter

### DIFF
--- a/src/runtime/components/InputMenu.vue
+++ b/src/runtime/components/InputMenu.vue
@@ -548,6 +548,17 @@ function onClear() {
   emits('clear')
 }
 
+function onTagInputKeydown(e: KeyboardEvent) {
+  if (e.key !== 'Enter') return
+
+  // reka-ui's TagsInputRoot adds the raw search text as a tag on Enter regardless of
+  // whether it matches a real item or createItem is enabled. Block that so
+  // we never render a chip that isn't reflected in modelValue.
+  if (!props.createItem) {
+    e.preventDefault()
+  }
+}
+
 const viewportRef = useTemplateRef('viewportRef')
 
 const comboboxRootRef = useTemplateRef('comboboxRootRef')
@@ -694,6 +705,7 @@ defineExpose({
             data-slot="tagsInput"
             :class="ui.tagsInput({ class: props.ui?.tagsInput })"
             @change.stop
+            @keydown.enter="onTagInputKeydown"
           />
         </Component.Input>
       </TagsInputRoot>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves https://github.com/nuxt/ui/issues/6760

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

In `multiple` mode, reka-ui's `TagsInputInput` adds the search term as a tag on `Enter`. The `TagsInputRoot` model is driven by the combobox and never receives it, so a chip shows up that isn't in `modelValue` and disappears again on the next selection.

`Enter` is now prevented whenever there is a search term, which is enough for `TagsInputInput` to bail out. Selecting a highlighted item still works since `ListboxRoot` doesn't check `defaultPrevented`, and `Enter` on an empty search term still submits the surrounding form.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
