### PR TITLE
docs(installation): note vue-tsc build race with auto-import declarations

### DIFF
--- a/docs/content/docs/1.getting-started/2.installation/2.vue.md
+++ b/docs/content/docs/1.getting-started/2.installation/2.vue.md
@@ -126,6 +126,19 @@ components.d.ts
 
 ::
 
+::warning
+These declaration files are only written when Vite runs. The default `create-vue` `build` script runs `vue-tsc` in parallel with `vite build` (`run-p type-check "build-only {@}"`), so on a clean checkout type-checking can start before the files exist and fail with errors like `Cannot find name 'useToast'`. Run the type-check after the build instead so the declarations are generated first.
+
+```json [package.json]
+{
+  "scripts": {
+    "build": "run-s build-only type-check"
+  }
+}
+```
+
+::
+
 ::tip
 Internally, Nuxt UI relies on custom alias to resolve the theme types. If you're using TypeScript, you should add an alias to your `tsconfig` to enable auto-completion in your `vite.config.ts`.
 


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6769

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `auto-imports.d.ts` and `components.d.ts` files only exist once Vite has run. The default `create-vue` build script type-checks in parallel with the Vite build, so on a clean checkout `vue-tsc` can run before those files are generated and fail with errors like `Cannot find name 'useToast'`. This adds a warning to the Vue installation page explaining the race and how to avoid it by type-checking after the build.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
