### PR TITLE
docs(chat): rework ai endpoint around `ToolLoopAgent`

### DIFF
--- a/docs/app/components/chat/Chat.vue
+++ b/docs/app/components/chat/Chat.vue
@@ -3,7 +3,7 @@ import type { ToolUIPart, DynamicToolUIPart } from 'ai'
 import { DefaultChatTransport, isToolUIPart, isReasoningUIPart, isTextUIPart, getToolName } from 'ai'
 import { useChat as useAIChat } from '@ai-sdk/vue'
 import { isPartStreaming, isToolStreaming } from '@nuxt/ui/utils/ai'
-import * as theme from '#build/ui'
+import type { DocsChatMessage, DocsChatTools } from '~~/server/api/ai.post'
 
 const input = ref('')
 
@@ -31,7 +31,7 @@ function processThemeToolCalls() {
       const name = getToolName(part)
       if (name === 'applyTheme' && part.input) {
         _themeApplied.add(part.toolCallId)
-        applyThemeSettings(part.input)
+        applyThemeSettings(part.input as DocsChatTools['applyTheme']['input'])
       } else if (name === 'resetTheme') {
         _themeApplied.add(part.toolCallId)
         resetTheme()
@@ -40,11 +40,11 @@ function processThemeToolCalls() {
   }
 }
 
-const { messages: chatMessages, status, error, sendMessage, regenerate, stop } = useAIChat({
+const { messages: chatMessages, status, error, sendMessage, regenerate, stop } = useAIChat<DocsChatMessage>({
   messages: messages.value,
-  transport: new DefaultChatTransport({
+  transport: new DefaultChatTransport<DocsChatMessage>({
     api: '/api/ai',
-    body: () => ({ theme, framework: framework.value, currentPage: route.path.startsWith('/docs/') ? route.path : null })
+    body: () => ({ framework: framework.value, currentPage: route.path.startsWith('/docs/') ? route.path : null })
   }),
   onError: (error) => {
     let message = error.message

--- a/docs/app/composables/useChat.ts
+++ b/docs/app/composables/useChat.ts
@@ -1,9 +1,9 @@
-import type { UIMessage } from 'ai'
 import { createSharedComposable, useLocalStorage } from '@vueuse/core'
+import type { DocsChatMessage } from '~~/server/api/ai.post'
 
 export const useChat = createSharedComposable(() => {
   const storageOpen = useLocalStorage('chat-open', false)
-  const messages = useLocalStorage<UIMessage[]>('chat-messages', [])
+  const messages = useLocalStorage<DocsChatMessage[]>('chat-messages', [])
 
   const open = ref(false)
 

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,6 @@
   "dependencies": {
     "@ai-sdk/anthropic": "^4.0.21",
     "@ai-sdk/gateway": "^4.0.28",
-    "@ai-sdk/mcp": "^2.0.16",
     "@ai-sdk/vue": "^4.0.37",
     "@comark/vue": "^0.5.1",
     "@iconify-json/logos": "^1.2.11",

--- a/docs/server/api/ai.post.ts
+++ b/docs/server/api/ai.post.ts
@@ -331,7 +331,7 @@ export default defineConfig({
 
 NEVER recommend \`appConfig.theme.*\` properties (like \`blackAsPrimary\`, \`radius\`, \`font\`) — those are internal to the docs site. Users should use CSS variables in main.css for radius, fonts, and monochrome primary.`
   })
-}) satisfies Tool
+})
 
 const tools = {
   ...mcpToolsToAiTools(),
@@ -452,9 +452,17 @@ export default defineEventHandler(async (event) => {
     experimental_transform: smoothStream(),
     consumeSseStream: consumeStream,
     onError: (error) => {
-      console.error('[api/ai] stream error:', error)
+      // Provider errors carry the outgoing prompt in `requestBodyValues` and the raw
+      // `responseBody`, so log identifying fields only and keep chat content out of the logs.
+      const statusCode = APICallError.isInstance(error) ? error.statusCode : undefined
 
-      if (APICallError.isInstance(error) && error.statusCode === 429) {
+      console.error('[api/ai] stream error:', {
+        name: error instanceof Error ? error.name : 'UnknownError',
+        message: error instanceof Error ? error.message : String(error),
+        statusCode
+      })
+
+      if (statusCode === 429) {
         return 'You have reached the message limit for now. Please try again later.'
       }
 

--- a/docs/server/api/ai.post.ts
+++ b/docs/server/api/ai.post.ts
@@ -1,12 +1,16 @@
-import { streamText, convertToModelMessages, smoothStream, jsonSchema, isStepCount, toUIMessageStream, createUIMessageStreamResponse } from 'ai'
+import type { UIMessage, InferUITools, Tool } from 'ai'
+import { ToolLoopAgent, createAgentUIStreamResponse, tool, dynamicTool, jsonSchema, smoothStream, isStepCount, consumeStream, APICallError } from 'ai'
 import type { AnthropicLanguageModelOptions } from '@ai-sdk/anthropic'
-import { gateway } from '@ai-sdk/gateway'
+import type { GatewayProviderOptions } from '@ai-sdk/gateway'
 import { z } from 'zod'
 import { tools as mcpToolDefinitions } from '#nuxt-mcp-toolkit/tools.mjs'
+import * as theme from '../../.nuxt/ui'
 import { themeIcons, cssVariableDefaults } from '../../app/utils/theme'
 
+const componentNames = Object.keys(theme)
+
 function mcpToolsToAiTools() {
-  const aiTools: Record<string, { description: string, inputSchema: ReturnType<typeof jsonSchema>, execute: (args: any) => Promise<any> }> = {}
+  const aiTools: Record<string, Tool> = {}
 
   for (const def of mcpToolDefinitions as any[]) {
     const filename = def._meta?.filename as string | undefined
@@ -19,7 +23,7 @@ function mcpToolsToAiTools() {
       ? z.toJSONSchema(z.object(def.inputSchema)) as Record<string, unknown>
       : { type: 'object' as const, properties: {} }
 
-    aiTools[name] = {
+    aiTools[name] = dynamicTool({
       description: def.description || '',
       inputSchema: jsonSchema(schema),
       execute: async (args: any) => {
@@ -29,15 +33,36 @@ function mcpToolsToAiTools() {
           return { error: error.statusCode ? `[${error.statusCode}] ${error.message}` : error.message || String(error) }
         }
       }
-    }
+    })
   }
 
   return aiTools
 }
 
-const applyTheme = {
+export interface ApplyThemeSettings {
+  primary?: string
+  neutral?: string
+  secondary?: string
+  success?: string
+  info?: string
+  warning?: string
+  error?: string
+  radius?: number
+  font?: string
+  blackAsPrimary?: boolean
+  icons?: string
+  customColors?: Record<string, Record<string, string>>
+  cssVariables?: { light?: Record<string, string>, dark?: Record<string, string> }
+  ui?: Record<string, any>
+}
+
+// Written as a raw JSON Schema rather than zod on purpose: the SDK's zod conversion rewrites
+// `additionalProperties` to `false` on every object, which strips the value schema off
+// `z.record()` and would tell the model that `customColors`, `cssVariables` and `ui` accept
+// no keys at all. The `jsonSchema<T>()` generic still gives us the input type.
+const applyTheme = tool({
   description: 'Apply theme settings live on the docs site. Call this when users ask to change colors, radius, font, or other theme properties. Only include properties that changed.',
-  inputSchema: jsonSchema<Record<string, any>>({
+  inputSchema: jsonSchema<ApplyThemeSettings>({
     type: 'object' as const,
     properties: {
       primary: { type: 'string', description: 'Primary color name (e.g., green, blue, red, indigo)' },
@@ -82,24 +107,32 @@ const applyTheme = {
       }
     }
   }),
-  execute: async (settings: Record<string, any>) => ({ applied: true, ...settings })
-}
+  execute: async settings => ({ applied: true, ...settings })
+})
 
-const resetTheme = {
+const resetTheme = tool({
   description: 'Reset the theme back to defaults (primary: green, neutral: slate, radius: 0.25rem, font: Public Sans). Call this when users ask to reset, revert, or restore the default theme.',
-  inputSchema: jsonSchema<Record<string, never>>({
-    type: 'object' as const,
-    properties: {}
-  }),
+  inputSchema: z.object({}),
   execute: async () => ({ reset: true })
-}
+})
 
-const getThemeGuide = {
-  description: 'Get detailed instructions for applying live theme changes. Call this ONLY when you are about to use applyTheme (e.g. user says "make it blue", "create a dark theme"). Do NOT call for documentation questions about theming — search docs instead.',
-  inputSchema: jsonSchema<Record<string, never>>({
-    type: 'object' as const,
-    properties: {}
+const getComponentTheme = tool({
+  description: 'Get the theme definition (slots, variants, compoundVariants, defaultVariants) for a specific Nuxt UI component. Call this when you need to know the available slots and customization options to suggest component-level theming.',
+  inputSchema: z.object({
+    componentName: z.string().describe(`Component name in camelCase. Available: ${componentNames.join(', ')}`)
   }),
+  execute: async ({ componentName }) => {
+    const componentTheme = (theme as Record<string, unknown>)[componentName]
+    if (!componentTheme) {
+      return { error: `Component "${componentName}" not found`, availableComponents: componentNames }
+    }
+    return { componentName, theme: componentTheme }
+  }
+})
+
+const getThemeGuide = tool({
+  description: 'Get detailed instructions for applying live theme changes. Call this ONLY when you are about to use applyTheme (e.g. user says "make it blue", "create a dark theme"). Do NOT call for documentation questions about theming — search docs instead.',
+  inputSchema: z.object({}),
   execute: async () => ({
     guide: `When users ask to change the theme, customize colors, or modify the appearance, use the \`applyTheme\` tool to apply changes live on this docs site. Only include properties that changed.
 
@@ -298,57 +331,24 @@ export default defineConfig({
 
 NEVER recommend \`appConfig.theme.*\` properties (like \`blackAsPrimary\`, \`radius\`, \`font\`) — those are internal to the docs site. Users should use CSS variables in main.css for radius, fonts, and monochrome primary.`
   })
+}) satisfies Tool
+
+const tools = {
+  ...mcpToolsToAiTools(),
+  getThemeGuide,
+  applyTheme,
+  resetTheme,
+  getComponentTheme
 }
 
-export default defineEventHandler(async (event) => {
-  const { messages, theme, framework, currentPage } = await readBody(event)
+export type DocsChatTools = InferUITools<typeof tools>
+export type DocsChatMessage = UIMessage<unknown, never, DocsChatTools>
 
-  if (!messages || !Array.isArray(messages)) {
-    throw createError({ statusCode: 400, message: 'Invalid or missing messages array.' })
-  }
-
-  // `currentPage` is interpolated verbatim into the system prompt below, so it is an
-  // indirect prompt-injection surface (a crafted /docs/... link can smuggle newlines and
-  // instructions via Vue Router's path decoding). Accept it only when it is a plain docs
-  // path with no control characters; otherwise drop it.
-  const safeCurrentPage = typeof currentPage === 'string'
-    && currentPage.length <= 128
-    && !/[\r\n]/.test(currentPage)
-    && /^\/docs\/[\w/-]*$/.test(currentPage)
-    ? currentPage
-    : null
-
-  const componentNames = theme ? Object.keys(theme) : []
-
-  const getComponentTheme = {
-    description: 'Get the theme definition (slots, variants, compoundVariants, defaultVariants) for a specific Nuxt UI component. Call this when you need to know the available slots and customization options to suggest component-level theming.',
-    inputSchema: jsonSchema<{ componentName: string }>({
-      type: 'object' as const,
-      properties: {
-        componentName: {
-          type: 'string',
-          description: `Component name in camelCase. Available: ${componentNames.join(', ')}`
-        }
-      },
-      required: ['componentName']
-    }),
-    execute: async ({ componentName }: { componentName: string }) => {
-      if (!theme?.[componentName]) {
-        return { error: `Component "${componentName}" not found`, availableComponents: componentNames }
-      }
-      return { componentName, theme: theme[componentName] }
-    }
-  }
-
-  const mcpTools = mcpToolsToAiTools()
-
-  const abortController = new AbortController()
-  event.node.req.on('close', () => abortController.abort())
-
-  const instructions = `You are a helpful assistant for Nuxt UI, a UI library for Nuxt and Vue. Nuxt UI includes \`@nuxt/fonts\` and \`@nuxt/icon\` as built-in dependencies — never tell users to install them separately. Use your knowledge base tools to search for relevant information before answering questions.
+function buildInstructions(framework: 'nuxt' | 'vue') {
+  return `You are a helpful assistant for Nuxt UI, a UI library for Nuxt and Vue. Nuxt UI includes \`@nuxt/fonts\` and \`@nuxt/icon\` as built-in dependencies — never tell users to install them separately. Use your knowledge base tools to search for relevant information before answering questions.
 
 The user is using **${framework === 'vue' ? 'Vue' : 'Nuxt'}**. Tailor your answers accordingly — ${framework === 'vue' ? 'use the Vite plugin setup, Vue Router, and vite.config.ts instead of Nuxt-specific features like modules or app.config.ts. IMPORTANT: The Vite plugin auto-imports components and Nuxt UI composables, but Vue core APIs and VueUse must be explicitly imported — always include these in code examples (e.g. `import { ref, computed } from \'vue\'`, `import { useColorMode } from \'@vueuse/core\'`).' : 'use Nuxt modules, auto-imports, app.config.ts, and other Nuxt-specific features. Nuxt auto-imports Vue APIs (ref, computed, etc.), composables, and components — do not include these imports in code examples.'}
-${safeCurrentPage ? `\nThe user is currently viewing the documentation page at \`${safeCurrentPage}\`. Use this context to provide more relevant answers (e.g. read that page first if the question seems related), but don't limit yourself to that page if the question is broader or unrelated.\n` : ''}
+
 Guidelines:
 - For documentation questions, ALWAYS use tools to search for information. Never rely on pre-trained knowledge for Nuxt UI APIs, props, or usage.
 - For questions about how to customize themes (e.g. "how do I customize colors?", "how does theming work?"), search the documentation like any other docs question.
@@ -356,6 +356,11 @@ Guidelines:
 - If a question is unrelated to Nuxt UI (e.g. general coding, off-topic), briefly answer if you can, but don't waste tool calls searching docs for it.
 - If no relevant information is found after searching, respond with "Sorry, I couldn't find information about that in the documentation."
 - Be concise and direct in your responses.
+
+**PAGE CONTEXT:**
+- A user message may end with a \`[Context: the user is currently viewing <path>]\` marker. It is added automatically and is not something the user typed, so never mention it or repeat it back.
+- Use it to resolve vague questions ("explain this page", "how does this work?"). Only the most recent marker is relevant, earlier ones are stale.
+- When the marker names a docs path, call \`get-documentation-page\` with that exact path instead of searching first. Don't limit yourself to that page if the question is broader or unrelated.
 
 **FORMATTING RULES (CRITICAL):**
 - ABSOLUTELY NO MARKDOWN HEADINGS: Never use #, ##, ###, ####, #####, or ######
@@ -372,39 +377,88 @@ Guidelines:
 - You have up to 5 tool calls to find the answer, so be strategic: start broad, then get specific if needed.
 - Format responses in a conversational way, not as documentation sections.
     `
+}
 
-  const result = streamText({
-    model: gateway('anthropic/claude-sonnet-5'),
-    maxOutputTokens: 8000,
-    abortSignal: abortController.signal,
-    providerOptions: {
-      anthropic: {
-        thinking: {
-          type: 'adaptive',
-          display: 'summarized'
-        },
-        effort: 'low'
-      } satisfies AnthropicLanguageModelOptions,
-      gateway: {
-        caching: 'auto'
-      }
-    },
-    instructions,
-    messages: await convertToModelMessages(messages),
-    experimental_transform: smoothStream(),
-    stopWhen: isStepCount(6),
-    tools: {
-      ...mcpTools,
-      getThemeGuide,
-      applyTheme,
-      resetTheme,
-      getComponentTheme
-    },
-    onError: (error) => {
-      console.error('streamText error:', error)
+// Static per framework so the cached prompt prefix stays stable across requests.
+const instructions = {
+  nuxt: buildInstructions('nuxt'),
+  vue: buildInstructions('vue')
+}
+
+const anthropicOptions = {
+  thinking: {
+    type: 'adaptive',
+    display: 'summarized'
+  },
+  effort: 'low'
+} satisfies AnthropicLanguageModelOptions
+
+export default defineEventHandler(async (event) => {
+  const { messages, framework, currentPage } = await readBody(event)
+
+  if (!messages || !Array.isArray(messages)) {
+    throw createError({ statusCode: 400, message: 'Invalid or missing messages array.' })
+  }
+
+  // `currentPage` reaches the model as a marker on the last user message, so it is an
+  // indirect prompt-injection surface (a crafted /docs/... link can smuggle newlines and
+  // instructions via Vue Router's path decoding). Accept it only when it is a plain docs
+  // path with no control characters; otherwise drop it.
+  const safeCurrentPage = typeof currentPage === 'string'
+    && currentPage.length <= 128
+    && !/[\r\n]/.test(currentPage)
+    && /^\/docs\/[\w/-]*$/.test(currentPage)
+    ? currentPage
+    : null
+
+  // Page context belongs to the turn it was sent with, not to the thread: it is appended
+  // here and never persisted client-side, so a stale path can't leak into a later answer.
+  const uiMessages = messages.map((message: UIMessage, index: number) => {
+    if (!safeCurrentPage || index !== messages.length - 1 || message.role !== 'user') {
+      return message
+    }
+
+    return {
+      ...message,
+      parts: [...(message.parts || []), { type: 'text' as const, text: `[Context: the user is currently viewing ${safeCurrentPage}]` }]
     }
   })
 
-  const stream = toUIMessageStream({ stream: result.stream })
-  return createUIMessageStreamResponse({ stream })
+  const abortController = new AbortController()
+  event.node.req.on('close', () => abortController.abort())
+
+  const agent = new ToolLoopAgent({
+    model: 'anthropic/claude-sonnet-5',
+    instructions: framework === 'vue' ? instructions.vue : instructions.nuxt,
+    maxOutputTokens: 8000,
+    stopWhen: isStepCount(6),
+    tools,
+    providerOptions: {
+      anthropic: anthropicOptions,
+      gateway: {
+        caching: 'auto',
+        user: getChatUser(event),
+        tags: ['docs-chat'],
+        // Same tier as the primary so the adaptive thinking options stay supported.
+        models: ['anthropic/claude-sonnet-4.6']
+      } satisfies GatewayProviderOptions
+    }
+  })
+
+  return createAgentUIStreamResponse({
+    agent,
+    uiMessages,
+    abortSignal: abortController.signal,
+    experimental_transform: smoothStream(),
+    consumeSseStream: consumeStream,
+    onError: (error) => {
+      console.error('[api/ai] stream error:', error)
+
+      if (APICallError.isInstance(error) && error.statusCode === 429) {
+        return 'You have reached the message limit for now. Please try again later.'
+      }
+
+      return 'An error occurred.'
+    }
+  })
 })

--- a/docs/server/api/chat.post.ts
+++ b/docs/server/api/chat.post.ts
@@ -1,13 +1,20 @@
 import { streamText, convertToModelMessages, toUIMessageStream, createUIMessageStreamResponse } from 'ai'
-import { gateway } from '@ai-sdk/gateway'
+import type { GatewayProviderOptions } from '@ai-sdk/gateway'
 
 export default defineEventHandler(async (event) => {
   const { messages } = await readBody(event)
 
   const result = streamText({
-    model: gateway('anthropic/claude-haiku-4.5'),
+    model: 'anthropic/claude-haiku-4.5',
     instructions: 'You are a helpful assistant for Nuxt UI, a UI library for Nuxt and Vue.',
-    messages: await convertToModelMessages(messages)
+    messages: await convertToModelMessages(messages),
+    providerOptions: {
+      gateway: {
+        caching: 'auto',
+        user: getChatUser(event),
+        tags: ['docs-chat-example']
+      } satisfies GatewayProviderOptions
+    }
   })
 
   const stream = toUIMessageStream({ stream: result.stream })

--- a/docs/server/api/completion.post.ts
+++ b/docs/server/api/completion.post.ts
@@ -1,5 +1,5 @@
 import { streamText, createTextStreamResponse } from 'ai'
-import { gateway } from '@ai-sdk/gateway'
+import type { GatewayProviderOptions } from '@ai-sdk/gateway'
 
 export default defineEventHandler(async (event) => {
   const { prompt, mode, language } = await readBody(event)
@@ -51,10 +51,17 @@ CRITICAL RULES:
   }
 
   const result = streamText({
-    model: gateway('anthropic/claude-haiku-4.5'),
+    model: 'anthropic/claude-haiku-4.5',
     instructions,
     prompt,
-    maxOutputTokens
+    maxOutputTokens,
+    providerOptions: {
+      gateway: {
+        caching: 'auto',
+        user: getChatUser(event),
+        tags: ['docs-completion']
+      } satisfies GatewayProviderOptions
+    }
   })
 
   return createTextStreamResponse({ stream: result.textStream })

--- a/docs/server/utils/chatUser.ts
+++ b/docs/server/utils/chatUser.ts
@@ -7,7 +7,12 @@ const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
 
 /**
  * Anonymous, per-browser identifier passed to the AI Gateway as `user` so usage can be
- * attributed and rate limited per visitor from the Gateway dashboard.
+ * attributed and grouped in the Gateway dashboard.
+ *
+ * Attribution only, not an abuse control. The cookie is client-controlled, so a caller can
+ * drop it and get a fresh id on every request, and signing it wouldn't help since the id can
+ * still be rotated. Gateway per-user limits keyed on this only bound honest traffic. Real
+ * throttling has to be enforced server-side on something the caller can't rotate.
  */
 export function getChatUser(event: H3Event): string {
   const existing = getCookie(event, COOKIE_NAME)

--- a/docs/server/utils/chatUser.ts
+++ b/docs/server/utils/chatUser.ts
@@ -1,0 +1,29 @@
+import type { H3Event } from 'h3'
+
+const COOKIE_NAME = 'nuxt-ui-chat-user'
+const COOKIE_MAX_AGE = 60 * 60 * 24 * 365
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
+
+/**
+ * Anonymous, per-browser identifier passed to the AI Gateway as `user` so usage can be
+ * attributed and rate limited per visitor from the Gateway dashboard.
+ */
+export function getChatUser(event: H3Event): string {
+  const existing = getCookie(event, COOKIE_NAME)
+  if (existing && UUID_RE.test(existing)) {
+    return existing
+  }
+
+  const id = crypto.randomUUID()
+
+  setCookie(event, COOKIE_NAME, id, {
+    maxAge: COOKIE_MAX_AGE,
+    httpOnly: true,
+    secure: !import.meta.dev,
+    sameSite: 'lax',
+    path: '/'
+  })
+
+  return id
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -321,9 +321,6 @@ importers:
       '@ai-sdk/gateway':
         specifier: ^4.0.28
         version: 4.0.28(zod@4.4.3)
-      '@ai-sdk/mcp':
-        specifier: ^2.0.16
-        version: 2.0.16(zod@4.4.3)
       '@ai-sdk/vue':
         specifier: ^4.0.37
         version: 4.0.37(vue@3.5.40(typescript@6.0.3))(zod@4.4.3)
@@ -609,12 +606,6 @@ packages:
 
   '@ai-sdk/gateway@4.0.28':
     resolution: {integrity: sha512-ee9TsNO3mkgHDWmTmJ8Fvltr6PFh52zhrV2+FaKJY3F3iu7kWZi5tCRJCR1HVhhlpj6lHniUb28nLQdPHkA/1Q==}
-    engines: {node: '>=22'}
-    peerDependencies:
-      zod: ^3.25.76 || ^4.1.8
-
-  '@ai-sdk/mcp@2.0.16':
-    resolution: {integrity: sha512-jC2r+StEuk8uIldfP4j8nBwOEBJ2TRwy/bz71SHMZ3NG6PSbvRPXGfyoHHR6JTm1O5GcIww0f6B8LznzkrseDA==}
     engines: {node: '>=22'}
     peerDependencies:
       zod: ^3.25.76 || ^4.1.8
@@ -9180,13 +9171,6 @@ snapshots:
       '@ai-sdk/provider': 4.0.3
       '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
       '@vercel/oidc': 3.2.0
-      zod: 4.4.3
-
-  '@ai-sdk/mcp@2.0.16(zod@4.4.3)':
-    dependencies:
-      '@ai-sdk/provider': 4.0.3
-      '@ai-sdk/provider-utils': 5.0.12(zod@4.4.3)
-      pkce-challenge: 5.0.1
       zod: 4.4.3
 
   '@ai-sdk/provider-utils@5.0.12(zod@4.4.3)':


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Reworks the docs AI assistant endpoint. Nothing was stale, it was already idiomatic AI SDK v7 with no deprecated calls, so this is about structure, payload size and cost attribution.

**Stop posting the whole theme on every message.** The client was sending `#build/ui` (~118 components, ~400KB) in the body of every chat message, and the server only used it for `Object.keys()` plus one lookup in `getComponentTheme`. The server now imports the theme directly, same as `transformMDC.ts` already does.

**`ToolLoopAgent` + `createAgentUIStreamResponse`** replaces the manual convert/stream/wrap plumbing. It also validates incoming UI messages against the tool schemas, which we weren't doing at all before (only an `Array.isArray` check on a public endpoint). The agent is built per request since the framework variant and the gateway user id vary.

**Typed tools end to end.** Theme tools use `tool()` and MCP-derived ones use `dynamicTool()`, so `useChat<DocsChatMessage>` gets real types and `applyTheme` input is no longer `any` on the client. `isToolUIPart` and `getToolName` already handle dynamic parts so rendering is unchanged, and existing saved conversations still validate.

`applyTheme` deliberately keeps a hand written JSON Schema instead of zod. The SDK's zod conversion rewrites `additionalProperties` to `false` on every object, which strips the value schema off `z.record()` and would tell the model that `customColors`, `cssVariables` and `ui` accept no keys at all. The `jsonSchema<T>()` generic still gives us the input type. There's a comment on it so nobody "cleans it up" later.

**Page context is now per turn.** `currentPage` was interpolated into the system prompt, so the cached prefix broke on every navigation. It's appended to the last user message instead, never persisted, so a stale path can't leak into a later answer. The prompt also tells the model to call `get-documentation-page` with that exact path rather than searching first.

**Gateway attribution** on all three AI endpoints: an anonymous uuid cookie as `user`, plus `tags`, so usage can be grouped and traced in the Gateway dashboard. `/api/ai` had no attribution at all. Worth being precise about what this is: attribution, not an abuse control. The cookie is client-controlled and can be rotated, so dashboard per-user limits keyed on it only bound honest traffic. Real throttling needs a server-side limiter keyed on something the caller can't rotate, and that isn't in this PR. The fallback model is `claude-sonnet-4.6` rather than haiku, since haiku doesn't support the adaptive thinking options we send.

Stream errors log `name`, `message` and `statusCode` only. Provider errors carry the full outgoing prompt in `requestBodyValues` plus the raw `responseBody`, so logging the error object put visitor chat content into the server logs.

Also drops `@ai-sdk/mcp`, which was never imported anywhere, and the `gateway()` wrapper in favour of plain model strings.

Follow-ups not in here: Anthropic tool search with `deferLoading`, `contextManagement` for long theming sessions, data parts for the live theme preview, and `zeroDataRetention`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

