### PR TITLE
fix(Modal): emit transition events from overlay when `scrollable`

### DIFF
--- a/src/runtime/components/Modal.vue
+++ b/src/runtime/components/Modal.vue
@@ -153,10 +153,10 @@ const ui = computed(() => tv({ extend: theme, ...(appConfig.ui?.modal || {}) })(
         data-slot="content"
         :class="ui.content({ class: [!slots.default && props.class, props.ui?.content] })"
         v-bind="contentProps"
-        @enter="emits('enter')"
-        @after-enter="emits('after:enter')"
-        @leave="emits('leave')"
-        @after-leave="emits('after:leave')"
+        @enter="!props.scrollable && emits('enter')"
+        @after-enter="!props.scrollable && emits('after:enter')"
+        @leave="!props.scrollable && emits('leave')"
+        @after-leave="!props.scrollable && emits('after:leave')"
         v-on="contentEvents"
       >
         <VisuallyHidden v-if="(!props.title && !slots.title) || (!props.description && !slots.description) || !!slots.content">
@@ -229,7 +229,14 @@ const ui = computed(() => tv({ extend: theme, ...(appConfig.ui?.modal || {}) })(
     <DialogPortal v-bind="portalProps" :force-mount="(portalProps.disabled && props.unmountOnHide === false) || undefined">
       <FieldGroupReset>
         <template v-if="props.scrollable">
-          <DialogOverlay data-slot="overlay" :class="ui.overlay({ class: props.ui?.overlay })">
+          <DialogOverlay
+            data-slot="overlay"
+            :class="ui.overlay({ class: props.ui?.overlay })"
+            @enter="emits('enter')"
+            @after-enter="emits('after:enter')"
+            @leave="emits('leave')"
+            @after-leave="emits('after:leave')"
+          >
             <ReuseContentTemplate />
           </DialogOverlay>
         </template>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6758

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With `scrollable`, the content is nested inside the overlay and both run a 200ms leave animation. Reka's presence dispatches `after-leave` from the node's `animationend`, so when the overlay animation ends first its presence unmounts the whole subtree and the content's `after-leave` never fires.

Bind the transition events on `DialogOverlay` when `scrollable` since it's the last node to unmount and dispatches the same presence events, and guard the `DialogContent` listeners to avoid double emits.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
