### PR TITLE
docs(mcp): add `x-mcp-tools` header to specify available tools

### DIFF
--- a/docs/content/docs/1.getting-started/6.integrations/1.icons/1.nuxt.md
+++ b/docs/content/docs/1.getting-started/6.integrations/1.icons/1.nuxt.md
@@ -35,7 +35,7 @@ props:
 ::
 
 ::note
-You can use any name from the <https://iconify.design> collection. Browse them easily on <https://icones.js.org> or search directly from your AI assistant using the [`search_icons`](/docs/getting-started/ai/mcp#available-tools) MCP tool.
+You can use any name from the <https://iconify.design> collection. Browse them easily on <https://icones.js.org> or search directly from your AI assistant using the [`search-icons`](/docs/getting-started/ai/mcp#available-tools) MCP tool.
 ::
 
 ### Component props

--- a/docs/content/docs/1.getting-started/6.integrations/1.icons/2.vue.md
+++ b/docs/content/docs/1.getting-started/6.integrations/1.icons/2.vue.md
@@ -29,7 +29,7 @@ props:
 ::
 
 ::note
-You can use any name from the <https://iconify.design> collection. Browse them easily on <https://icones.js.org> or search directly from your AI assistant using the [`search_icons`](/docs/getting-started/ai/mcp#available-tools) MCP tool.
+You can use any name from the <https://iconify.design> collection. Browse them easily on <https://icones.js.org> or search directly from your AI assistant using the [`search-icons`](/docs/getting-started/ai/mcp#available-tools) MCP tool.
 ::
 
 ::warning

--- a/docs/content/docs/1.getting-started/7.ai/1.mcp.md
+++ b/docs/content/docs/1.getting-started/7.ai/1.mcp.md
@@ -28,33 +28,47 @@ The Nuxt UI MCP server provides the following tools organized by category:
 
 ### Search Tools
 
-- **`search_components`**: Search components by name, description, or category. With no params, lists all components
-- **`search_composables`**: Search composables by name or description. With no params, lists all composables
-- **`search_icons`**: Search for icons across Iconify collections (defaults to `lucide`). Returns icon names in the `i-{prefix}-{name}` format used by Nuxt UI
+- **`search-components`**: Search components by name, description, or category. With no params, lists all components
+- **`search-composables`**: Search composables by name or description. With no params, lists all composables
+- **`search-icons`**: Search for icons across Iconify collections (defaults to `lucide`). Returns icon names in the `i-{prefix}-{name}` format used by Nuxt UI
 
 ### Component Tools
 
-- **`get_component`**: Retrieves component documentation and details. Supports a `sections` parameter (`usage`, `examples`, `api`, `theme`, `changelog`) to fetch only specific parts and reduce response size
-- **`get_component_metadata`**: Retrieves detailed metadata for a component including props, slots, and events (lightweight, no documentation content)
+- **`get-component`**: Retrieves component documentation and details. Supports a `sections` parameter (`usage`, `examples`, `api`, `theme`, `changelog`) to fetch only specific parts and reduce response size
+- **`get-component-metadata`**: Retrieves detailed metadata for a component including props, slots, and events (lightweight, no documentation content)
 
 ### Documentation Tools
 
-- **`search_documentation`**: Search documentation pages by title, description, or section. With no params, lists all pages. Use `section` to filter (e.g., `"getting-started"`, `"components"`)
-- **`get_documentation_page`**: Retrieves documentation page content by URL path. Supports a `headings` parameter to fetch only specific h2 sections (e.g., `["Usage", "API"]`) and reduce response size
+- **`search-documentation`**: Search documentation pages by title, description, or section. With no params, lists all pages. Use `section` to filter (e.g., `"getting-started"`, `"components"`)
+- **`get-documentation-page`**: Retrieves documentation page content by URL path. Supports a `headings` parameter to fetch only specific h2 sections (e.g., `["Usage", "API"]`) and reduce response size
 
 ### Template Tools
 
-- **`list_templates`**: Lists all available Nuxt UI templates with optional framework filtering
-- **`get_template`**: Retrieves template details and setup instructions
+- **`list-templates`**: Lists all available Nuxt UI templates with optional framework filtering
+- **`get-template`**: Retrieves template details and setup instructions
 
 ### Example Tools
 
-- **`list_examples`**: Lists all available UI examples and code demonstrations
-- **`get_example`**: Retrieves specific UI example implementation code and details
+- **`list-examples`**: Lists all available UI examples and code demonstrations
+- **`get-example`**: Retrieves specific UI example implementation code and details
 
 ### Migration Tools
 
-- **`get_migration_guide`**: Retrieves version-specific migration guides and upgrade instructions
+- **`get-migration-guide`**: Retrieves version-specific migration guides and upgrade instructions
+
+## Limit available tools
+
+Set the optional `X-MCP-Tools` HTTP header to a comma-separated list of tool names to expose only the tools your assistant needs. This helps to reduce the context defined in your assistant.
+
+Use the exact kebab-case MCP tool names, for example:
+
+```
+{
+  "X-MCP-Tools": "search-components,get-component"
+}
+```
+
+No header exposes all tools, an empty header exposes no tools, and an unknown tool name returns a configuration error.
 
 ## Available Prompts
 
@@ -319,11 +333,16 @@ For more details, see [Adding MCP servers for GitHub Copilot CLI](https://docs.g
   "servers": {
     "nuxt-ui": {
       "type": "http",
-      "url": "https://ui.nuxt.com/mcp"
+      "url": "https://ui.nuxt.com/mcp",
+      "headers": {
+        "X-MCP-Tools": "search-components,get-component" // Optional: Limit available tools to reduce context
+      }
     }
   }
 }
 ```
+
+Remove the `headers` entry to make all Nuxt UI MCP tools available.
 
 ### Windsurf
 

--- a/docs/content/docs/1.getting-started/7.ai/1.mcp.md
+++ b/docs/content/docs/1.getting-started/7.ai/1.mcp.md
@@ -62,7 +62,7 @@ Set the optional `X-MCP-Tools` HTTP header to a comma-separated list of tool nam
 
 Use the exact kebab-case MCP tool names, for example:
 
-```
+```json
 {
   "X-MCP-Tools": "search-components,get-component"
 }
@@ -74,9 +74,9 @@ No header exposes all tools, an empty header exposes no tools, and an unknown to
 
 The Nuxt UI MCP server provides guided prompts for common workflows:
 
-- **`find_component_for_usecase`**: Find the best component for your specific use case
-- **`implement_component_with_props`**: Generate complete component implementation with proper props
-- **`setup_project_with_template`**: Get guided setup instructions for project templates
+- **`find-component-for-usecase`**: Find the best component for your specific use case
+- **`implement-component-with-props`**: Generate complete component implementation with proper props
+- **`setup-project-with-template`**: Get guided setup instructions for project templates
 
 You're able to access these resources with tools like Claude Code by using `/`.
 
@@ -335,7 +335,7 @@ For more details, see [Adding MCP servers for GitHub Copilot CLI](https://docs.g
       "type": "http",
       "url": "https://ui.nuxt.com/mcp",
       "headers": {
-        "X-MCP-Tools": "search-components,get-component" // Optional: Limit available tools to reduce context
+        "X-MCP-Tools": "search-components,get-component"
       }
     }
   }

--- a/docs/content/docs/2.components/icon.md
+++ b/docs/content/docs/2.components/icon.md
@@ -21,7 +21,7 @@ props:
 ::
 
 ::note
-You can use any name from the <https://iconify.design> collection. Browse them easily on <https://icones.js.org> or search directly from your AI assistant using the [`search_icons`](/docs/getting-started/ai/mcp#available-tools) MCP tool.
+You can use any name from the <https://iconify.design> collection. Browse them easily on <https://icones.js.org> or search directly from your AI assistant using the [`search-icons`](/docs/getting-started/ai/mcp#available-tools) MCP tool.
 ::
 
 ::framework-only

--- a/docs/server/mcp/index.ts
+++ b/docs/server/mcp/index.ts
@@ -1,0 +1,58 @@
+import { defineMcpHandler, getMcpTools } from '@nuxtjs/mcp-toolkit/server'
+
+export default defineMcpHandler({
+  async tools(event) {
+    const tools = await getMcpTools({ event })
+    const requestedTools = getHeader(event, 'x-mcp-tools')
+
+    if (requestedTools === undefined) {
+      return tools
+    }
+
+    const requestedToolNames = getRequestedToolNames(requestedTools)
+    const availableToolNames = getAvailableToolNames(tools)
+
+    const unknownNames = requestedToolNames.filter(requestedToolName => !availableToolNames.has(requestedToolName))
+    if (unknownNames.length) {
+      throw createError({
+        statusCode: 400,
+        statusMessage: `Unknown MCP tool${unknownNames.length > 1 ? 's' : ''}: ${unknownNames.join(', ')}`
+      })
+    }
+
+    return tools.filter(tool => requestedToolNames.includes(getToolName(tool) || ''))
+  }
+})
+
+function getAvailableToolNames(tools: Awaited<ReturnType<typeof getMcpTools>>) {
+  const names = new Set<string>()
+
+  for (const tool of tools) {
+    const name = getToolName(tool)
+    if (name) {
+      names.add(name)
+    }
+  }
+
+  return names
+}
+
+function getToolName(tool: Awaited<ReturnType<typeof getMcpTools>>[number]) {
+  if (tool.name) {
+    return tool.name
+  }
+
+  const filename = tool._meta?.filename
+
+  if (typeof filename !== 'string') {
+    return
+  }
+
+  return filename.replace('.ts', '').toLowerCase()
+}
+
+function getRequestedToolNames(requestedTools: string) {
+  return Array.from(
+    new Set<string>(requestedTools.split(',').map((name: string) => name.trim()).filter((name: string) => Boolean(name)))
+  )
+}

--- a/docs/server/mcp/index.ts
+++ b/docs/server/mcp/index.ts
@@ -1,58 +1,29 @@
-import { defineMcpHandler, getMcpTools } from '@nuxtjs/mcp-toolkit/server'
+import { defineMcpHandler, getMcpTools, listMcpTools } from '@nuxtjs/mcp-toolkit/server'
 
 export default defineMcpHandler({
   async tools(event) {
-    const tools = await getMcpTools({ event })
+    const tools = await getMcpTools({ event, orphansOnly: true })
     const requestedTools = getHeader(event, 'x-mcp-tools')
 
     if (requestedTools === undefined) {
       return tools
     }
 
-    const requestedToolNames = getRequestedToolNames(requestedTools)
-    const availableToolNames = getAvailableToolNames(tools)
+    // `listMcpTools` resolves the names clients see in `tools/list`, index-aligned with `getMcpTools`
+    const toolNames = (await listMcpTools({ event, orphansOnly: true })).map(tool => tool.name)
+    const requestedToolNames = new Set(requestedTools.split(',').map(name => name.trim()).filter(Boolean))
 
-    const unknownNames = requestedToolNames.filter(requestedToolName => !availableToolNames.has(requestedToolName))
+    const unknownNames = [...requestedToolNames].filter(name => !toolNames.includes(name))
     if (unknownNames.length) {
       throw createError({
         statusCode: 400,
-        statusMessage: `Unknown MCP tool${unknownNames.length > 1 ? 's' : ''}: ${unknownNames.join(', ')}`
+        message: `Unknown MCP tool${unknownNames.length > 1 ? 's' : ''}: ${unknownNames.join(', ')}`
       })
     }
 
-    return tools.filter(tool => requestedToolNames.includes(getToolName(tool) || ''))
+    return tools.filter((_, index) => {
+      const name = toolNames[index]
+      return name !== undefined && requestedToolNames.has(name)
+    })
   }
 })
-
-function getAvailableToolNames(tools: Awaited<ReturnType<typeof getMcpTools>>) {
-  const names = new Set<string>()
-
-  for (const tool of tools) {
-    const name = getToolName(tool)
-    if (name) {
-      names.add(name)
-    }
-  }
-
-  return names
-}
-
-function getToolName(tool: Awaited<ReturnType<typeof getMcpTools>>[number]) {
-  if (tool.name) {
-    return tool.name
-  }
-
-  const filename = tool._meta?.filename
-
-  if (typeof filename !== 'string') {
-    return
-  }
-
-  return filename.replace('.ts', '').toLowerCase()
-}
-
-function getRequestedToolNames(requestedTools: string) {
-  return Array.from(
-    new Set<string>(requestedTools.split(',').map((name: string) => name.trim()).filter((name: string) => Boolean(name)))
-  )
-}

--- a/docs/server/mcp/tools/get-example.ts
+++ b/docs/server/mcp/tools/get-example.ts
@@ -24,7 +24,7 @@ export default defineMcpTool({
       const err = error as { statusCode?: number, response?: { status?: number } }
       const status = err?.statusCode ?? err?.response?.status
       if (status === 404) {
-        throw createError({ statusCode: 404, message: `Example '${exampleName}' not found. Use the list_examples tool to see all available examples.` })
+        throw createError({ statusCode: 404, message: `Example '${exampleName}' not found. Use the list-examples tool to see all available examples.` })
       }
       throw error
     }

--- a/docs/server/mcp/tools/get-template.ts
+++ b/docs/server/mcp/tools/get-template.ts
@@ -30,7 +30,7 @@ export default defineMcpTool({
     )
 
     if (!template) {
-      throw createError({ statusCode: 404, message: `Template "${templateName}" not found. Use the list_templates tool to see all available templates.` })
+      throw createError({ statusCode: 404, message: `Template "${templateName}" not found. Use the list-templates tool to see all available templates.` })
     }
 
     return template


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org)
-->

### 🔗 Linked issue

<!-- If it resolves an open issue, please link the issue here. For example "Resolves #123" -->
fix #6761

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
Hello 👋,

This PR introduces a new header for the MCP API that allows users to limit the available tools exposed to their assistant. By setting the `X-MCP-Tools` HTTP header to a comma-separated list of tool names, users can reduce the tool context sent to their assistant.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
