### PR TITLE
fix(module): keep app config `ui` optional when augmenting `nuxt/schema`

### DIFF
--- a/src/templates.ts
+++ b/src/templates.ts
@@ -342,6 +342,15 @@ declare module '@nuxt/schema' {
   }
 }
 
+// nuxt/schema re-exports @nuxt/schema but only bridges CustomAppConfig, not
+// AppConfigInput, so augment it here too to keep ui optional when a user
+// augments nuxt/schema themselves (the surface defineAppConfig reads).
+declare module 'nuxt/schema' {
+  interface AppConfigInput {
+    ui?: AppConfigUI
+  }
+}
+
 export {}
 `
     }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6791

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

Adding a `.d.ts` that augments `nuxt/schema` with an `AppConfigInput` interface makes the `ui` key in `app.config.ts` required instead of optional.

`nuxt/schema` re-exports `@nuxt/schema` and bridges `CustomAppConfig` back into its own module identity, but not `AppConfigInput`. Once a user declares `AppConfigInput` on `nuxt/schema`, our optional `ui?` override (declared on `@nuxt/schema`) no longer reaches that surface, and the required `ui` inherited from `CustomAppConfig` shows through instead. Augmenting `nuxt/schema` too keeps `ui` optional on the surface `defineAppConfig` reads.

### 📝 Checklist

- [x] I have linked an issue or discussion.
