### PR TITLE
docs(ComponentCode): fix number input after clearing

### DIFF
--- a/docs/app/components/content/ComponentCode.vue
+++ b/docs/app/components/content/ComponentCode.vue
@@ -447,7 +447,7 @@ const { data: ast } = useAsyncData(codeKey, async () => {
             </USelect>
             <UInput
               v-else
-              :type="option.type?.includes('number') && typeof getComponentProp(option.name) === 'number' ? 'number' : 'text'"
+              :type="option.type?.includes('number') && typeof get(props.props, option.name) === 'number' ? 'number' : 'text'"
               :model-value="getComponentProp(option.name)"
               color="neutral"
               variant="soft"

--- a/docs/app/components/content/ComponentCode.vue
+++ b/docs/app/components/content/ComponentCode.vue
@@ -189,10 +189,13 @@ const options = computed(() => {
             chip: key.toLowerCase().endsWith('color') ? { color: variant } : undefined
           }))
 
+    const type = props?.cast?.[key] ?? prop?.type
+
     return {
       name: key,
       label: key,
-      type: props?.cast?.[key] ?? prop?.type,
+      // Determined from the original value so clearing a number input doesn't turn it into a text one
+      inputType: type?.includes('number') && typeof get(props.props, key) === 'number' ? 'number' : 'text',
       items
     }
   })
@@ -447,7 +450,7 @@ const { data: ast } = useAsyncData(codeKey, async () => {
             </USelect>
             <UInput
               v-else
-              :type="option.type?.includes('number') && typeof get(props.props, option.name) === 'number' ? 'number' : 'text'"
+              :type="option.inputType"
               :model-value="getComponentProp(option.name)"
               color="neutral"
               variant="soft"


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

* [ ] 📖 Documentation (updates to the documentation or readme)
* [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
* [ ] 👌 Enhancement (improving an existing functionality)
* [ ] ✨ New feature (a non-breaking change that adds functionality)
* [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
* [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Fixes number inputs in the documentation component playground becoming unusable after their value is cleared.

The input type was determined using the current `componentProps` value. When a number input was cleared, its value was no longer a number, causing the input type to switch from `number` to `text`.

This change determines the input type from the original `props.props` value instead, so number inputs remain numeric after being cleared while preserving the existing behavior for props that can accept both strings and numbers.

### 📝 Checklist

* [ ] I have linked an issue or discussion.
* [ ] I have updated the documentation accordingly.
