### PR TITLE
fix(Editor): ignore updates without document changes

### DIFF
--- a/src/runtime/components/Editor.vue
+++ b/src/runtime/components/Editor.vue
@@ -249,7 +249,7 @@ const editor = useEditor({
     }
   },
   onUpdate: ({ editor, transaction, appendedTransactions }) => {
-    if (!transaction.docChanged && !appendedTransactions.some(transaction => transaction.docChanged)) {
+    if (!transaction.docChanged && !appendedTransactions.some(tr => tr.docChanged)) {
       return
     }
 

--- a/src/runtime/components/Editor.vue
+++ b/src/runtime/components/Editor.vue
@@ -248,8 +248,8 @@ const editor = useEditor({
       editor.view.dispatch(editor.state.tr)
     }
   },
-  onUpdate: ({ editor, transaction }) => {
-    if (!transaction.docChanged) {
+  onUpdate: ({ editor, transaction, appendedTransactions }) => {
+    if (!transaction.docChanged && !appendedTransactions.some(transaction => transaction.docChanged)) {
       return
     }
 

--- a/src/runtime/components/Editor.vue
+++ b/src/runtime/components/Editor.vue
@@ -248,7 +248,11 @@ const editor = useEditor({
       editor.view.dispatch(editor.state.tr)
     }
   },
-  onUpdate: ({ editor }) => {
+  onUpdate: ({ editor, transaction }) => {
+    if (!transaction.docChanged) {
+      return
+    }
+
     let value
     try {
       if (contentType.value === 'html') {

--- a/test/components/Editor.spec.ts
+++ b/test/components/Editor.spec.ts
@@ -31,7 +31,7 @@ describe('Editor', () => {
     const wrapper = await mountSuspended(Editor, {
       props: {
         contentType: 'markdown',
-        modelValue: '## Demand & Service Level Decisions',
+        modelValue: '# Building Modern Interfaces with Nuxt UI',
         placeholder: 'Write something...'
       }
     })

--- a/test/components/Editor.spec.ts
+++ b/test/components/Editor.spec.ts
@@ -37,7 +37,7 @@ describe('Editor', () => {
     })
     const editor = wrapper.vm.editor!
 
-    editor.view.dispatch(editor.state.tr.setMeta('test', true))
+    editor.setEditable(false)
 
     expect(wrapper.emitted('update:modelValue')).toBeUndefined()
 

--- a/test/components/Editor.spec.ts
+++ b/test/components/Editor.spec.ts
@@ -26,4 +26,21 @@ describe('Editor', () => {
 
     wrapper.unmount()
   })
+
+  it('does not update the model when the document is unchanged', async () => {
+    const wrapper = await mountSuspended(Editor, {
+      props: {
+        contentType: 'markdown',
+        modelValue: '## Demand & Service Level Decisions',
+        placeholder: 'Write something...'
+      }
+    })
+    const editor = wrapper.vm.editor!
+
+    editor.view.dispatch(editor.state.tr.setMeta('test', true))
+
+    expect(wrapper.emitted('update:modelValue')).toBeUndefined()
+
+    wrapper.unmount()
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

None.

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

TipTap can emit an `update` event without changing the document, such as when the editor's editable state changes. Serializing those events caused the Editor to emit redundant `update:modelValue` events and could rewrite equivalent Markdown with different formatting.

The Editor now emits a model update only when the root transaction or one of its appended transactions changes the document. This preserves updates produced by appended transactions while ignoring state-only updates.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
