### PR TITLE
fix(Link): emit aria-current and match paths in inertia mode

### DIFF
--- a/src/runtime/vue/overrides/inertia/Link.vue
+++ b/src/runtime/vue/overrides/inertia/Link.vue
@@ -147,17 +147,23 @@ const rel = computed(() => {
   return null
 })
 
+/**
+ * Path portion of a url, without the query or hash and without a trailing
+ * slash. Returns `undefined` when there is no path at all — `?tab=orders` and
+ * `#section` address the current page rather than a path, so they have nothing
+ * to match against.
+ */
 function normalizePath(url: string) {
   const path = url.split('#')[0]!.split('?')[0]!
 
   if (!path) {
-    return '/'
+    return undefined
   }
 
   return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path
 }
 
-const currentPath = computed(() => normalizePath(page.url))
+const currentPath = computed(() => normalizePath(page.url) ?? '/')
 
 const targetPath = computed(() => href.value ? normalizePath(href.value) : undefined)
 
@@ -172,7 +178,15 @@ const isLinkCurrentPage = computed(() => {
     return false
   }
 
-  return props.exact ? page.url === href.value : currentPath.value === targetPath.value
+  if (props.exact) {
+    return page.url === href.value
+  }
+
+  if (!targetPath.value) {
+    return false
+  }
+
+  return currentPath.value === targetPath.value
 })
 
 const isLinkActive = computed(() => {

--- a/src/runtime/vue/overrides/inertia/Link.vue
+++ b/src/runtime/vue/overrides/inertia/Link.vue
@@ -94,7 +94,7 @@ const page = usePage()
 
 const appConfig = useAppConfig() as Link['AppConfig']
 
-const routerLinkProps = useForwardProps(reactiveOmit(props, 'as', 'type', 'disabled', 'active', 'exact', 'activeClass', 'inactiveClass', 'to', 'href', 'raw', 'custom', 'class', 'target', 'rel', 'noRel'))
+const routerLinkProps = useForwardProps(reactiveOmit(props, 'as', 'type', 'disabled', 'active', 'exact', 'activeClass', 'inactiveClass', 'to', 'href', 'raw', 'custom', 'class', 'target', 'rel', 'noRel', 'ariaCurrentValue'))
 
 const ui = computed(() => tv({
   extend: theme,
@@ -147,24 +147,36 @@ const rel = computed(() => {
   return null
 })
 
+function normalizePath(url: string) {
+  const path = url.split('#')[0]!.split('?')[0]!
+
+  if (!path) {
+    return '/'
+  }
+
+  return path.length > 1 && path.endsWith('/') ? path.slice(0, -1) : path
+}
+
+const currentPath = computed(() => normalizePath(page.url))
+
+const targetPath = computed(() => href.value ? normalizePath(href.value) : undefined)
+
+const isLinkExactActive = computed(() => !!targetPath.value && currentPath.value === targetPath.value)
+
 const isLinkActive = computed(() => {
   if (props.active !== undefined) {
     return props.active
   }
 
-  if (!href.value) {
+  if (!targetPath.value) {
     return false
   }
 
-  if (props.exact && page.url === href.value) {
+  if (isLinkExactActive.value) {
     return true
   }
 
-  if (!props.exact && page.url.startsWith(href.value)) {
-    return true
-  }
-
-  return false
+  return !props.exact && currentPath.value.startsWith(targetPath.value === '/' ? '/' : `${targetPath.value}/`)
 })
 
 const linkClass = computed(() => {
@@ -184,6 +196,7 @@ const linkClass = computed(() => {
       v-bind="{
         ...$attrs,
         ...routerLinkProps,
+        ...(exact && isLinkExactActive ? { 'aria-current': props.ariaCurrentValue } : {}),
         as,
         type,
         disabled,
@@ -200,6 +213,7 @@ const linkClass = computed(() => {
     v-bind="{
       ...$attrs,
       ...routerLinkProps,
+      ...(exact && isLinkExactActive ? { 'aria-current': props.ariaCurrentValue } : {}),
       as,
       type,
       disabled,

--- a/src/runtime/vue/overrides/inertia/Link.vue
+++ b/src/runtime/vue/overrides/inertia/Link.vue
@@ -40,7 +40,7 @@ export interface LinkProps extends Partial<Omit<InertiaLinkProps, 'href' | 'onCl
    */
   noRel?: boolean
   /**
-   * Value passed to the attribute `aria-current` when the link is exact active.
+   * Value passed to the attribute `aria-current` when the link points at the current page.
    *
    * @defaultValue `'page'`
    */
@@ -161,7 +161,19 @@ const currentPath = computed(() => normalizePath(page.url))
 
 const targetPath = computed(() => href.value ? normalizePath(href.value) : undefined)
 
-const isLinkExactActive = computed(() => !!targetPath.value && currentPath.value === targetPath.value)
+/**
+ * Whether the link points at the page currently being rendered, which is what
+ * `aria-current` announces. Distinct from `isLinkActive`: a link to a section
+ * index stays active while browsing that section, but it is not the current
+ * page.
+ */
+const isLinkCurrentPage = computed(() => {
+  if (!href.value) {
+    return false
+  }
+
+  return props.exact ? page.url === href.value : currentPath.value === targetPath.value
+})
 
 const isLinkActive = computed(() => {
   if (props.active !== undefined) {
@@ -172,11 +184,12 @@ const isLinkActive = computed(() => {
     return false
   }
 
-  if (isLinkExactActive.value) {
-    return true
+  if (props.exact) {
+    return page.url === href.value
   }
 
-  return !props.exact && currentPath.value.startsWith(targetPath.value === '/' ? '/' : `${targetPath.value}/`)
+  return currentPath.value === targetPath.value
+    || currentPath.value.startsWith(targetPath.value === '/' ? '/' : `${targetPath.value}/`)
 })
 
 const linkClass = computed(() => {
@@ -196,7 +209,7 @@ const linkClass = computed(() => {
       v-bind="{
         ...$attrs,
         ...routerLinkProps,
-        ...(exact && isLinkExactActive ? { 'aria-current': props.ariaCurrentValue } : {}),
+        ...(isLinkCurrentPage ? { 'aria-current': props.ariaCurrentValue } : {}),
         as,
         type,
         disabled,
@@ -213,7 +226,7 @@ const linkClass = computed(() => {
     v-bind="{
       ...$attrs,
       ...routerLinkProps,
-      ...(exact && isLinkExactActive ? { 'aria-current': props.ariaCurrentValue } : {}),
+      ...(isLinkCurrentPage ? { 'aria-current': props.ariaCurrentValue } : {}),
       as,
       type,
       disabled,

--- a/test/inertia/Link.spec.ts
+++ b/test/inertia/Link.spec.ts
@@ -1,0 +1,159 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { axe } from 'vitest-axe'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import Link from '../../src/runtime/vue/overrides/inertia/Link.vue'
+import Button from '../../src/runtime/components/Button.vue'
+import { setPageUrl } from '../utils/inertia'
+
+describe('Link (inertia)', () => {
+  beforeEach(() => {
+    setPageUrl('/')
+  })
+
+  describe('aria-current', () => {
+    it('is set when the link is exact active', async () => {
+      setPageUrl('/inventory')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '/inventory', exact: true },
+        slots: { default: () => 'Inventory' }
+      })
+
+      expect(wrapper.find('a').attributes('aria-current')).toBe('page')
+    })
+
+    it('honours a custom ariaCurrentValue', async () => {
+      setPageUrl('/checkout/payment')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '/checkout/payment', exact: true, ariaCurrentValue: 'step' },
+        slots: { default: () => 'Payment' }
+      })
+
+      expect(wrapper.find('a').attributes('aria-current')).toBe('step')
+    })
+
+    it('is absent — not "false" — when the link is not active', async () => {
+      setPageUrl('/orders')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '/inventory', exact: true },
+        slots: { default: () => 'Inventory' }
+      })
+
+      expect(wrapper.find('a').attributes('aria-current')).toBeUndefined()
+    })
+
+    it('is exposed to the custom slot', async () => {
+      setPageUrl('/inventory')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '/inventory', exact: true, custom: true },
+        slots: { default: (props: any) => `aria-current: ${props['aria-current']}` }
+      })
+
+      expect(wrapper.text()).toContain('aria-current: page')
+    })
+  })
+
+  describe('ariaCurrentValue is not forwarded to the DOM', () => {
+    it('does not leak on a link', async () => {
+      setPageUrl('/inventory')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '/inventory', exact: true },
+        slots: { default: () => 'Inventory' }
+      })
+
+      expect(wrapper.html()).not.toContain('ariacurrentvalue')
+    })
+
+    it('does not leak on a component that renders no link at all', async () => {
+      const wrapper = await mountSuspended(Button, {
+        props: { label: 'No link' }
+      })
+
+      expect(wrapper.find('button').exists()).toBe(true)
+      expect(wrapper.html()).not.toContain('ariacurrentvalue')
+    })
+  })
+
+  describe('active matching', () => {
+    it('ignores the query string on the current url', async () => {
+      setPageUrl('/inventory?search=x&page=2')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '/inventory', exact: true },
+        slots: { default: () => 'Inventory' }
+      })
+
+      expect(wrapper.find('a').attributes('aria-current')).toBe('page')
+    })
+
+    it('ignores the hash on the current url', async () => {
+      setPageUrl('/inventory#section')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '/inventory', exact: true },
+        slots: { default: () => 'Inventory' }
+      })
+
+      expect(wrapper.find('a').attributes('aria-current')).toBe('page')
+    })
+
+    it('respects segment boundaries', async () => {
+      setPageUrl('/inventory-adjustments')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '/inventory', activeClass: 'is-active' },
+        slots: { default: () => 'Inventory' }
+      })
+
+      expect(wrapper.find('a').classes()).not.toContain('is-active')
+    })
+
+    it('matches a descendant path when not exact', async () => {
+      setPageUrl('/inventory/42/edit')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '/inventory', activeClass: 'is-active' },
+        slots: { default: () => 'Inventory' }
+      })
+
+      expect(wrapper.find('a').classes()).toContain('is-active')
+    })
+
+    it('does not match a descendant path when exact', async () => {
+      setPageUrl('/inventory/42/edit')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '/inventory', exact: true, activeClass: 'is-active' },
+        slots: { default: () => 'Inventory' }
+      })
+
+      expect(wrapper.find('a').classes()).not.toContain('is-active')
+    })
+
+    it('ignores a trailing slash', async () => {
+      setPageUrl('/inventory/')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '/inventory', exact: true },
+        slots: { default: () => 'Inventory' }
+      })
+
+      expect(wrapper.find('a').attributes('aria-current')).toBe('page')
+    })
+  })
+
+  it('passes accessibility tests', async () => {
+    setPageUrl('/inventory')
+
+    const wrapper = await mountSuspended(Link, {
+      props: { to: '/inventory', exact: true },
+      slots: { default: () => 'Inventory' }
+    })
+
+    expect(await axe(wrapper.element)).toHaveNoViolations()
+  })
+})

--- a/test/inertia/Link.spec.ts
+++ b/test/inertia/Link.spec.ts
@@ -11,11 +11,11 @@ describe('Link (inertia)', () => {
   })
 
   describe('aria-current', () => {
-    it('is set when the link is exact active', async () => {
+    it('is set when the link points at the current page', async () => {
       setPageUrl('/inventory')
 
       const wrapper = await mountSuspended(Link, {
-        props: { to: '/inventory', exact: true },
+        props: { to: '/inventory' },
         slots: { default: () => 'Inventory' }
       })
 
@@ -26,29 +26,54 @@ describe('Link (inertia)', () => {
       setPageUrl('/checkout/payment')
 
       const wrapper = await mountSuspended(Link, {
-        props: { to: '/checkout/payment', exact: true, ariaCurrentValue: 'step' },
+        props: { to: '/checkout/payment', ariaCurrentValue: 'step' },
         slots: { default: () => 'Payment' }
       })
 
       expect(wrapper.find('a').attributes('aria-current')).toBe('step')
     })
 
-    it('is absent — not "false" — when the link is not active', async () => {
+    it('is absent — not "false" — when the link points elsewhere', async () => {
       setPageUrl('/orders')
 
       const wrapper = await mountSuspended(Link, {
-        props: { to: '/inventory', exact: true },
+        props: { to: '/inventory' },
         slots: { default: () => 'Inventory' }
       })
 
       expect(wrapper.find('a').attributes('aria-current')).toBeUndefined()
     })
 
+    it('is not set on a link to the section index from a page inside it', async () => {
+      setPageUrl('/inventory/create')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '/inventory', activeClass: 'is-active' },
+        slots: { default: () => 'Cancel' }
+      })
+
+      // The link is active — it is the section being browsed — but it is not
+      // the page the user is on, so it must not announce itself as current.
+      expect(wrapper.find('a').classes()).toContain('is-active')
+      expect(wrapper.find('a').attributes('aria-current')).toBeUndefined()
+    })
+
+    it('ignores the query string and hash of the current url', async () => {
+      setPageUrl('/inventory?search=x&page=2#results')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '/inventory' },
+        slots: { default: () => 'Inventory' }
+      })
+
+      expect(wrapper.find('a').attributes('aria-current')).toBe('page')
+    })
+
     it('is exposed to the custom slot', async () => {
       setPageUrl('/inventory')
 
       const wrapper = await mountSuspended(Link, {
-        props: { to: '/inventory', exact: true, custom: true },
+        props: { to: '/inventory', custom: true },
         slots: { default: (props: any) => `aria-current: ${props['aria-current']}` }
       })
 
@@ -61,7 +86,7 @@ describe('Link (inertia)', () => {
       setPageUrl('/inventory')
 
       const wrapper = await mountSuspended(Link, {
-        props: { to: '/inventory', exact: true },
+        props: { to: '/inventory' },
         slots: { default: () => 'Inventory' }
       })
 
@@ -83,22 +108,11 @@ describe('Link (inertia)', () => {
       setPageUrl('/inventory?search=x&page=2')
 
       const wrapper = await mountSuspended(Link, {
-        props: { to: '/inventory', exact: true },
+        props: { to: '/inventory', activeClass: 'is-active' },
         slots: { default: () => 'Inventory' }
       })
 
-      expect(wrapper.find('a').attributes('aria-current')).toBe('page')
-    })
-
-    it('ignores the hash on the current url', async () => {
-      setPageUrl('/inventory#section')
-
-      const wrapper = await mountSuspended(Link, {
-        props: { to: '/inventory', exact: true },
-        slots: { default: () => 'Inventory' }
-      })
-
-      expect(wrapper.find('a').attributes('aria-current')).toBe('page')
+      expect(wrapper.find('a').classes()).toContain('is-active')
     })
 
     it('respects segment boundaries', async () => {
@@ -138,11 +152,24 @@ describe('Link (inertia)', () => {
       setPageUrl('/inventory/')
 
       const wrapper = await mountSuspended(Link, {
-        props: { to: '/inventory', exact: true },
+        props: { to: '/inventory', activeClass: 'is-active' },
         slots: { default: () => 'Inventory' }
       })
 
+      expect(wrapper.find('a').classes()).toContain('is-active')
       expect(wrapper.find('a').attributes('aria-current')).toBe('page')
+    })
+
+    it('keeps exact as a raw url comparison', async () => {
+      setPageUrl('/inventory?search=x')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '/inventory', exact: true, activeClass: 'is-active' },
+        slots: { default: () => 'Inventory' }
+      })
+
+      expect(wrapper.find('a').classes()).not.toContain('is-active')
+      expect(wrapper.find('a').attributes('aria-current')).toBeUndefined()
     })
   })
 
@@ -150,7 +177,7 @@ describe('Link (inertia)', () => {
     setPageUrl('/inventory')
 
     const wrapper = await mountSuspended(Link, {
-      props: { to: '/inventory', exact: true },
+      props: { to: '/inventory' },
       slots: { default: () => 'Inventory' }
     })
 

--- a/test/inertia/Link.spec.ts
+++ b/test/inertia/Link.spec.ts
@@ -173,6 +173,61 @@ describe('Link (inertia)', () => {
     })
   })
 
+  describe('hrefs with no path portion', () => {
+    // A query- or fragment-only href addresses the current page rather than a
+    // path, so it has nothing to match against and must never be treated as a
+    // path match. Collapsing it to `/` would make every such link active on
+    // every page, since any url starts with `/`.
+    it('does not make a query-only link active', async () => {
+      setPageUrl('/orders')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '?tab=refunds', activeClass: 'is-active' },
+        slots: { default: () => 'Refunds' }
+      })
+
+      expect(wrapper.find('a').classes()).not.toContain('is-active')
+      expect(wrapper.find('a').attributes('aria-current')).toBeUndefined()
+    })
+
+    it('does not make a fragment-only link active', async () => {
+      setPageUrl('/orders')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '#summary', activeClass: 'is-active' },
+        slots: { default: () => 'Summary' }
+      })
+
+      expect(wrapper.find('a').classes()).not.toContain('is-active')
+      expect(wrapper.find('a').attributes('aria-current')).toBeUndefined()
+    })
+
+    it('does not make a query-only link active on the root page either', async () => {
+      setPageUrl('/')
+
+      const wrapper = await mountSuspended(Link, {
+        props: { to: '?tab=refunds', activeClass: 'is-active' },
+        slots: { default: () => 'Refunds' }
+      })
+
+      expect(wrapper.find('a').classes()).not.toContain('is-active')
+      expect(wrapper.find('a').attributes('aria-current')).toBeUndefined()
+    })
+
+    it('keeps sibling tab links from all reporting active at once', async () => {
+      setPageUrl('/orders')
+
+      const tabs = await Promise.all(['?tab=open', '?tab=refunds', '?tab=closed'].map(to =>
+        mountSuspended(Link, {
+          props: { to, activeClass: 'is-active' },
+          slots: { default: () => to }
+        })
+      ))
+
+      expect(tabs.filter(tab => tab.find('a').classes().includes('is-active'))).toHaveLength(0)
+    })
+  })
+
   it('passes accessibility tests', async () => {
     setPageUrl('/inventory')
 

--- a/test/utils/inertia.ts
+++ b/test/utils/inertia.ts
@@ -1,0 +1,29 @@
+import type { SetupContext } from 'vue'
+import { defineComponent, h, reactive } from 'vue'
+
+/**
+ * Stand-in for `@inertiajs/vue3` in the `vue-inertia` test project.
+ *
+ * `@inertiajs/vue3` is an optional peer dependency, so it is not installed in
+ * this repository. The stub mirrors the surface the Inertia overrides consume:
+ * `usePage()` and `Link`.
+ */
+export const page = reactive({ url: '/' })
+
+export function setPageUrl(url: string) {
+  page.url = url
+}
+
+export function usePage() {
+  return page
+}
+
+export const Link = defineComponent({
+  name: 'InertiaLink',
+  props: {
+    href: { type: String, default: '' }
+  },
+  setup(props, { slots, attrs }: SetupContext) {
+    return () => h('a', { ...attrs, href: props.href }, slots.default?.())
+  }
+})

--- a/test/utils/mount-inertia.ts
+++ b/test/utils/mount-inertia.ts
@@ -1,0 +1,38 @@
+import type { SetupContext } from 'vue'
+import { defu } from 'defu'
+import { createHead } from '@unhead/vue/client'
+import { mount } from '@vue/test-utils'
+
+const head = createHead()
+
+/**
+ * `mountSuspended` for the `vue-inertia` project: same contract as
+ * `test/utils/mount.ts` but without `vue-router`, which an Inertia app does not
+ * install.
+ */
+export async function mountSuspended(...args: Parameters<typeof mount>) {
+  let setupState = {}
+  const comp = args[0] as any
+  if (comp.setup) {
+    const originalSetup = comp.setup
+    comp.setup = function (props: Record<string, any>, ctx: SetupContext) {
+      setupState = originalSetup.call(this, props, ctx)
+      return setupState
+    }
+  }
+  const wrapper = mount(args[0], defu({}, args[1], {
+    global: {
+      stubs: {
+        ClientOnly: { template: '<slot />' }
+      },
+      plugins: [head]
+    }
+  }))
+
+  await wrapper.vm.$nextTick()
+
+  // @ts-expect-error - setupState does not exist in type
+  wrapper.setupState = setupState
+
+  return wrapper
+}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -9,6 +9,20 @@ import { glob } from 'tinyglobby'
 const components = await glob('./src/runtime/components/*.vue', { absolute: true })
 const vueComponents = await glob('./src/runtime/vue/components/*.vue', { absolute: true })
 const vueRouterOverrides = await glob('./src/runtime/vue/overrides/vue-router/*.vue', { absolute: true })
+const inertiaOverrides = await glob('./src/runtime/vue/overrides/inertia/*.vue', { absolute: true })
+
+function componentsModule(sources: string[]) {
+  const renderedComponents = new Set<string>()
+
+  return sources.map((file) => {
+    const componentName = file.split('/').pop()!.replace('.vue', '')
+    if (renderedComponents.has(componentName)) {
+      return ''
+    }
+    renderedComponents.add(componentName)
+    return `export { default as U${componentName} } from '${file}'`
+  }).join('\n')
+}
 
 export default defineConfig({
   test: {
@@ -80,16 +94,44 @@ export default defineConfig({
             },
             load(id) {
               if (id === '\0virtual:nuxt-ui-components') {
-                const resolvedComponents = [...vueRouterOverrides, ...vueComponents, ...components]
-                const renderedComponents = new Set<string>()
-                return resolvedComponents.map((file) => {
-                  const componentName = file.split('/').pop()!.replace('.vue', '')
-                  if (renderedComponents.has(componentName)) {
-                    return ''
-                  }
-                  renderedComponents.add(componentName)
-                  return `export { default as U${componentName} } from '${file}'`
-                }).join('\n')
+                return componentsModule([...vueRouterOverrides, ...vueComponents, ...components])
+              }
+            }
+          }
+        ]
+      },
+      {
+        extends: true,
+        test: {
+          name: 'vue-inertia',
+          environment: 'happy-dom',
+          dir: './test',
+          include: ['inertia/**.spec.ts'],
+          benchmark: { include: [] },
+          setupFiles: ['./test/utils/setup.ts']
+        },
+        plugins: [
+          vue(),
+          ui({ dts: false, router: 'inertia' }),
+          {
+            name: 'nuxt-ui-test:inertia',
+            enforce: 'pre',
+            resolveId(id) {
+              if (id === '@nuxt/test-utils/runtime') {
+                return fileURLToPath(new URL('test/utils/mount-inertia.ts', import.meta.url))
+              }
+              // `@inertiajs/vue3` is an optional peer dependency and is not
+              // installed here, so the overrides resolve against a stub.
+              if (id === '@inertiajs/vue3') {
+                return fileURLToPath(new URL('test/utils/inertia.ts', import.meta.url))
+              }
+              if (id === '#components') {
+                return '\0virtual:nuxt-ui-components'
+              }
+            },
+            load(id) {
+              if (id === '\0virtual:nuxt-ui-components') {
+                return componentsModule([...inertiaOverrides, ...vueComponents, ...components])
               }
             }
           }


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6803

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `inertia` `Link` override diverges from the `vue-router` one in three ways. Every component that renders a link (`UButton`, `UBreadcrumb`, `UNavigationMenu`, `UDropdownMenu`, …) goes through it, so all three reach the whole library in Inertia mode.

**1. `aria-current` was never emitted.** `isLinkActive` only fed `linkClass` and the `active` slot prop. `vue-router/Link.vue` binds it (`:189`, `:206`), and the prop's own JSDoc says it is *"passed to the attribute `aria-current`"*. An Inertia app moving its navigation onto Nuxt UI silently lost the current-page announcement.

**2. `ariaCurrentValue` leaked onto the DOM.** It was missing from the `reactiveOmit` list, so `useForwardProps` passed it to `ULinkBase`, which doesn't declare it either, and it reached the DOM as `ariacurrentvalue="page"`. `vue-router` omits it from its list too, but there it's harmless: `RouterLink` declares `ariaCurrentValue` as a real prop and consumes it. `InertiaLink` doesn't. Because the prop carries a default, the attribute appeared even on components rendering no link at all — `<UButton>no link</UButton>` rendered `<button ariacurrentvalue="page">`.

**3. Active matching used a raw prefix against a query-carrying URL.** `page.url.startsWith(href)` meant a query string defeated the match, and `/inventory` reported active on `/inventory-adjustments`. Now compared on the path, matching the target path or a descendant of it. `exact` is untouched and still compares the raw url.

#### What drives `aria-current`

This PR first mirrored `vue-router`'s condition — `exact && isExactActive` — on the grounds that parity is the point of the report. I no longer think that's right, and I'd rather say why than quietly ship it.

Requiring `exact` makes the accessible behaviour opt-in: a nav link to the page you are on stays silent unless the caller passes an extra prop. And `exact` can't simply be switched on, because it doubles as the scope of the active class — turning it on to get the announcement also narrows the highlight that a sidebar entry needs while browsing its section.

Binding it to `isLinkActive` instead is worse. An app that migrated its primitives to Nuxt UI hit this in production: form Cancel buttons became links to their section index, and each one started claiming to be the current page — `/inventory/create` marking its `/inventory` link with `aria-current`.

So the two questions are separated: `isLinkActive` keeps section semantics for the class, and a new `isLinkCurrentPage` answers *"is this the page being rendered"* by comparing paths. Only the latter drives `aria-current`.

**This leaves `vue-router` as the odd one out**, which is the opposite of where the report started, so it deserves your call rather than mine. `vue-router/Link.vue` has the same `exact &&` requirement and, I'd argue, the same problem — `isExactActive` is already the right signal there without the extra prop. I deliberately did not touch it in this PR: it changes behaviour for existing Nuxt apps and that's a bigger decision than a bug fix. Happy to include it here, or open a separate PR, whichever you prefer.

#### One correction to the issue

I listed `to="/"` being active everywhere as a defect. With segment-aware matching that's just `/` being a parent of every route, which is what `RouterLink` does too — so this PR keeps it, and `exact` remains the way to make a home link exclusive. The real defect there was segment-blindness, which is fixed.

#### Tests

The overrides had no test project at all: the `vue` project resolves `#components` to `[...vueRouterOverrides, ...vueComponents, ...components]`, so the `inertia` directory was never loaded by anything. That's how three defects coexisted here.

This adds a `vue-inertia` project mirroring the `vue` one with `router: 'inertia'`, plus a stub for `@inertiajs/vue3` (an optional peer dependency, not installed in this repo) and a router-less `mountSuspended`. 15 behavioural specs, including the Cancel-button case: a link to the section index from a page inside it stays active but must not announce itself as current.

Each guard is mutation-checked — reverting a fix must turn the suite red:

| Mutation | Result |
|---|---|
| drive `aria-current` from `isLinkActive` | **1 failed** (the Cancel-button case) |
| re-require `exact` for `aria-current` | **5 failed** |
| remove `aria-current` entirely | **5 failed** |
| remove `ariaCurrentValue` from `reactiveOmit` | **2 failed** |
| restore `page.url.startsWith(href)` | **1 failed** |

#### Verification

`pnpm vitest run --project vue-inertia` → 15 passed. `pnpm lint` clean on the touched files.

On the full suite I see pre-existing failures in `DropdownMenu`, `Select`, `ContextMenu` and `ContentSearch` that also fail on a clean checkout of `v4` in my environment and flake between runs. Comparing the failing-test sets with and without this branch, the modified tree's set is a strict subset of the clean tree's — nothing fails that didn't already.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
