### PR TITLE
chore(deps): allow `typescript` v7 as peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -245,7 +245,7 @@
     "joi": "^18.0.0",
     "superstruct": "^2.0.0",
     "tailwindcss": "^4.0.0",
-    "typescript": "^5.6.3 || ^6.0.0",
+    "typescript": "^5.6.3 || ^6.0.0 || ^7.0.0",
     "valibot": "^1.0.0",
     "vue-router": "^4.5.0 || ^5.0.0",
     "yup": "^1.7.0",


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6811

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`typescript` is a required peer, so npm hard-fails with ERESOLVE on any project that has already moved to `typescript@7`. Same shape as #6258 for TypeScript 6, where the peer was widened the same way in #6267.

Peer range only. `tsc` 7.0.2 and `tsc` 6.0.3 report the same diagnostics over `src`, and the built declarations type-check under 7 with no new errors. The devDependency and the `pnpm-workspace.yaml` override stay on 6 because `vue-tsc` needs the compiler API and `typescript@7` only exports `{ version, versionMajorMinor }` from its main entry, so `pnpm typecheck` cannot run on 7 yet.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
