### PR TITLE
fix(Tree): use logical padding for indentation

### DIFF
--- a/docs/app/components/content/examples/table/TableTreeDataExample.vue
+++ b/docs/app/components/content/examples/table/TableTreeDataExample.vue
@@ -94,7 +94,7 @@ const columns: TableColumn<Payment>[] = [{
       'div',
       {
         style: {
-          paddingLeft: `${row.depth}rem`
+          paddingInlineStart: `${row.depth}rem`
         },
         class: 'flex items-center gap-2'
       },

--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -281,7 +281,7 @@ defineExpose({
             :disabled="item.disabled || props.disabled"
             data-slot="link"
             :class="ui.link({ class: [props.ui?.link, item.ui?.link, item.class], selected: isSelected, disabled: item.disabled || props.disabled })"
-            :style="!nested && level > 1 ? { paddingLeft: flattenedPaddingFormula(level) } : undefined"
+            :style="!nested && level > 1 ? { paddingInlineStart: flattenedPaddingFormula(level) } : undefined"
           >
             <slot
               :name="((item.slot || 'item') as keyof TreeSlots<T>)"


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6812

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The tree data example sets the row indent as an inline `padding-left`, so nested rows stay indented from the left under `dir="rtl"` instead of mirroring. Using `padding-inline-start` keeps the same result in LTR and flips it in RTL.

`Tree` has the same physical padding in its flattened mode, where the value already comes from the logical `ms-*`/`ps-*` classes the nested mode uses, so I switched that one as well. It was the last physical padding left in `src` after #6724.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
