### PR TITLE
fix(AuthForm): type submit payload with the schema output

### DIFF
--- a/src/runtime/components/AuthForm.vue
+++ b/src/runtime/components/AuthForm.vue
@@ -13,7 +13,7 @@ import type { SelectMenuProps } from './SelectMenu.vue'
 import type { PinInputProps } from './PinInput.vue'
 import type { IconProps } from './Icon.vue'
 import type { LinkPropsKeys } from './Link.vue'
-import type { FormSchema, FormSubmitEvent, InferInput } from '../types/form'
+import type { FormData, FormSchema, FormSubmitEvent, InferInput } from '../types/form'
 import type { FormHTMLAttributes } from '../types/html'
 import type { NonUnion } from '../types/utils'
 import type { ComponentConfig } from '../types/tv'
@@ -151,7 +151,7 @@ const state = reactive<FormStateType>((_props.fields as TypedAuthFormField[] || 
   return acc
 }, {} as FormStateType))
 
-defineEmits<AuthFormEmits<typeof state>>()
+defineEmits<AuthFormEmits<FormData<T>>>()
 const slots = defineSlots<AuthFormSlots<typeof state, F>>()
 
 const props = useComponentProps<AuthFormProps<T, F>>('authForm', _props)

--- a/test/components/AuthForm.spec.ts
+++ b/test/components/AuthForm.spec.ts
@@ -1,10 +1,12 @@
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, test } from 'vitest'
 import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
+import * as z from 'zod'
 import AuthForm from '../../src/runtime/components/AuthForm.vue'
-import type { FormSchema } from '../../src/runtime/types/form'
+import type { FormSchema, FormSubmitEvent } from '../../src/runtime/types/form'
 import type { AuthFormProps } from '../../src/runtime/components/AuthForm.vue'
 import { renderEach } from '../component-render'
+import { expectEmitPayloadType } from '../utils/types'
 
 describe('AuthForm', () => {
   const fields = [{
@@ -89,5 +91,18 @@ describe('AuthForm', () => {
     })
 
     expect(await axe(wrapper.element)).toHaveNoViolations()
+  })
+
+  test('should have the correct types', () => {
+    const schema = z.object({
+      email: z.string(),
+      rememberMe: z.boolean().default(false)
+    })
+
+    // with a schema default
+    expectEmitPayloadType('submit', () => AuthForm({
+      schema,
+      fields: [{ name: 'email', type: 'text' }, { name: 'rememberMe', type: 'checkbox' }]
+    })).toEqualTypeOf<[FormSubmitEvent<{ email: string, rememberMe: boolean }>]>()
   })
 })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6814

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`AuthForm` types its `submit` emit from the local `state`, which follows the schema input, while the `onSubmit` prop it forwards to `Form` follows the schema output. A field like `rememberMe: z.boolean().default(false)` makes those differ (optional going in, required coming out), and the two signatures get intersected in the template, so a handler typed with the output is rejected:

```
Type '(payload: FormSubmitEvent<{ email: string; rememberMe: boolean; }>) => Promise<void>' is not assignable to type '(((() => void) | ((event: FormSubmitEvent<{ email: string; rememberMe: boolean; }>) => void)) & ((payload: FormSubmitEvent<{ email: string; rememberMe?: boolean | undefined; }>) => any)) | undefined'.
  ...
      Target signature provides too few arguments. Expected 1 or more, but got 0.
```

What the form submits is the transformed data, so the output is the right type here. Typing the emit with `FormData<T>` lines it up with the prop and the error goes away. Schemas without defaults or transforms are unaffected, their input and output are identical.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.