### PR TITLE
fix(CommandPalette): keep astral characters intact when truncating search results

### DIFF
--- a/src/runtime/utils/search.ts
+++ b/src/runtime/utils/search.ts
@@ -18,13 +18,21 @@ function truncateHTMLFromStart(html: string, maxLength: number) {
   let totalLength = 0
   let insideTag = false
 
-  // Iterate through the HTML string in reverse order
-  for (let i = html.length - 1; i >= 0; i--) {
-    if (html[i] === '>') {
+  // Iterate through the HTML string in reverse order, one code point at a time.
+  // Indexing by UTF-16 code unit would slice an astral character (emoji, most
+  // CJK extension blocks) in half when the truncation boundary lands between
+  // its surrogates, emitting an unpaired surrogate that renders as `�`.
+  // `<` and `>` are always single code units, so tag tracking is unaffected.
+  const chars = Array.from(html)
+
+  for (let i = chars.length - 1; i >= 0; i--) {
+    const char = chars[i]!
+
+    if (char === '>') {
       insideTag = true
-    } else if (html[i] === '<') {
+    } else if (char === '<') {
       insideTag = false
-      truncated = html[i] + truncated
+      truncated = char + truncated
       continue
     }
 
@@ -33,7 +41,7 @@ function truncateHTMLFromStart(html: string, maxLength: number) {
     }
 
     if (totalLength <= maxLength) {
-      truncated = html[i] + truncated
+      truncated = char + truncated
     } else {
       // If we've reached the max length, we break out of the loop
       // to prevent further processing of the string
@@ -94,7 +102,10 @@ export function highlight<T>(item: T & { matches?: FuseResult<T>['matches'] }, s
 
     const markIndex = content.indexOf('<mark>')
     if (markIndex !== -1) {
-      content = truncateHTMLFromStart(content, content.length - markIndex)
+      // Measure the budget in code points too, so it stays in the same units as
+      // the counter inside `truncateHTMLFromStart`. Identical to `.length` for
+      // BMP-only content.
+      content = truncateHTMLFromStart(content, Array.from(content.slice(markIndex)).length)
     }
 
     return content

--- a/test/utils/search.spec.ts
+++ b/test/utils/search.spec.ts
@@ -60,4 +60,41 @@ describe('highlight', () => {
     expect(highlight({ label: 'foo', matches: [] }, 'foo', 'label')).toBeUndefined()
     expect(highlight({ label: 'foo' }, 'foo', 'label')).toBeUndefined()
   })
+
+  describe('truncation from the start', () => {
+    // Matches a high surrogate not followed by a low one, or a low surrogate not
+    // preceded by a high one — i.e. half of an astral character.
+    const LONE_SURROGATE = /[\uD800-\uDBFF](?![\uDC00-\uDFFF])|(?:[^\uD800-\uDBFF]|^)[\uDC00-\uDFFF]/
+
+    function highlightAfterFiller(filler: string, count: number) {
+      const value = filler.repeat(count) + 'match'
+      const index = value.indexOf('match')
+
+      return highlight({ label: value, matches: [{ key: 'label', value, indices: [[index, index + 4]] }] }, 'match', 'label')
+    }
+
+    it('never splits an astral character, at any truncation boundary', () => {
+      // Truncating by UTF-16 code unit used to slice the pair in half whenever the
+      // boundary landed between its surrogates — from 7 emoji onward, and every
+      // length after that.
+      const split = Array.from({ length: 40 }, (_, i) => i + 1)
+        .filter(count => LONE_SURROGATE.test(highlightAfterFiller('\u{1F600}', count) ?? ''))
+
+      expect(split).toEqual([])
+    })
+
+    it('keeps emoji before the match intact', () => {
+      const result = highlightAfterFiller('\u{1F600}', 20)
+
+      expect(result).toContain('<mark>match</mark>')
+      expect(result).not.toContain('�')
+      expect(result?.replace(/^\.\.\./, '')).not.toMatch(LONE_SURROGATE)
+    })
+
+    it('still truncates a long prefix down to an ellipsis', () => {
+      const result = highlightAfterFiller('a', 50)
+
+      expect(result).toMatch(/^\.\.\.a+<mark>match<\/mark>$/)
+    })
+  })
 })


### PR DESCRIPTION
### 🔗 Linked issue

None open — filing this directly as it's a small, self-contained bug.

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description

`truncateHTMLFromStart` in `src/runtime/utils/search.ts` walks the highlighted snippet in reverse **one UTF-16 code unit at a time** (`html[i]`). An astral character — emoji, most CJK extension blocks, many symbols — occupies two code units. When the truncation boundary lands between them, the surrogate pair is sliced in half and the output carries an unpaired surrogate, which renders as `�`.

This is user-visible in `CommandPalette` and `useContentSearch`, where indexed content is more likely to contain emoji than a hand-written command label: a search result whose match sits after an emoji gets a `�` at the truncation point.

**Reproduction** — sweeping filler lengths 1–40 of `😀` before the match, lone surrogates appear from filler length **7 onward and for every length after**:

```
n=10, before: "...\uDE00😀😀😀😀😀😀<mark>match</mark>"
n=10, after:  "😀😀😀😀😀😀😀😀😀😀<mark>match</mark>"
```

**Not a security issue.** A lone surrogate can only render as a broken glyph or U+FFFD — it cannot manufacture HTML syntax, and no raw `<`, `>`, `&`, `"` or `'` appears outside the `<mark>` tags the highlighter inserts itself. This is a correctness and appearance bug.

### 🔧 The fix

Two hunks:

1. **`truncateHTMLFromStart`** — iterate with `Array.from(html)` so a surrogate pair is never split. The `insideTag` logic is untouched, since `<` and `>` are always single code units.
2. **The caller** — measure the length budget in code points too, so it stays in the same units as the counter inside the function.

Worth calling out explicitly for review: hunk 2 is a consistency fix, not required to remove the lone surrogates — hunk 1 alone is sufficient. It does mean an emoji now counts as **one** character against the truncation budget rather than two, so emoji-containing snippets truncate slightly later than before. That seems closer to the intent of a visible-length budget, but happy to drop hunk 2 if you'd rather keep the diff minimal.

Behaviour for BMP-only content is byte-identical, which is why all pre-existing tests pass untouched.

### ✅ Verification

Added three tests to `test/utils/search.spec.ts`:

- `never splits an astral character, at any truncation boundary` — the 1–40 sweep, asserting no lone surrogate at any length
- `keeps emoji before the match intact`
- `still truncates a long prefix down to an ellipsis` — guards against over-correcting into "never truncate"

Verified the first two **fail against unmodified `search.ts`** (`expected [ 7, 8, 9, … ] to deeply equal []`) and pass with the fix. The third passes both before and after by design.

```
test/utils/search.spec.ts            13 passed   (10 pre-existing, 3 new)
test/utils/ (both projects)         138 passed
CommandPalette + DashboardSearch +
ChatPalette + DashboardSearchButton 146 passed
eslint src/runtime/utils/search.ts test/utils/search.spec.ts   clean
```

### 📝 Checklist

- [x] I have linked an issue or discussion (n/a — none open)
- [x] I have added tests (if applicable)
