### PR TITLE
fix(locale): correct slide placeholder casing in lb

### DIFF
--- a/src/runtime/locale/lb.ts
+++ b/src/runtime/locale/lb.ts
@@ -24,7 +24,7 @@ export default defineLocale<Messages>({
     },
     carousel: {
       dots: 'Wielt Dia fir ze weisen',
-      goto: 'Gitt op d\'Slide {Slide}',
+      goto: 'Gitt op d\'Slide {slide}',
       next: 'Näch.',
       prev: 'Präz.'
     },


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`lb.ts` had `carousel.goto: 'Gitt op d\'Slide {Slide}'` with a capital `S`.

`Carousel.vue` passes `t('carousel.goto', { slide: index + 1 })` and `translate()` matches the token case-sensitively, falling back to re-emitting it as-is. So in Luxembourgish every carousel dot got the aria-label `Gitt op d'Slide {Slide}` instead of the slide number.

Checked the other 61 locales, this was the only placeholder mismatch.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
