### PR TITLE
fix(theme): blank top-level `base` in `applyUnstyled`

### DIFF
--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -95,6 +95,18 @@ export function applyUnstyled(result: any, unstyled?: boolean): any {
     ? Object.fromEntries(Object.keys(value as Record<string, unknown>).map(slot => [slot, '']))
     : ''
 
+  // Copy before reassigning: object-shaped themes are the shared module export
+  // (function-shaped ones produce a fresh object per call), and blanking the
+  // shared object in place would blank every later read — the Vue dev server
+  // re-generates themes as component detection grows.
+  result = { ...result }
+
+  // Single-element components have no `slots`: their classes live in a
+  // top-level `base` string (or array, when parts are conditional).
+  if (result.base) {
+    result.base = ''
+  }
+
   if (result.slots) {
     result.slots = Object.fromEntries(Object.keys(result.slots).map(slot => [slot, '']))
   }

--- a/test/utils/theme.spec.ts
+++ b/test/utils/theme.spec.ts
@@ -26,6 +26,28 @@ describe('applyUnstyled', () => {
     }
   })
 
+  it('blanks a top-level base', () => {
+    // Single-element components (e.g. Skeleton) have no `slots`, their theme
+    // is a top-level `base` string or array.
+    const stringBase = { base: 'animate-pulse rounded-md bg-elevated' }
+    expect(applyUnstyled(stringBase, true)).toEqual({ base: '' })
+    expect(stringBase.base).toBe('animate-pulse rounded-md bg-elevated')
+
+    expect(applyUnstyled({ base: ['flex', 'transition-colors'] }, true)).toEqual({ base: '' })
+  })
+
+  it('does not mutate the input theme', () => {
+    // Object-shaped themes are shared module exports: blanking in place would
+    // blank every later read within the same process.
+    const input = theme()
+    const snapshot = JSON.parse(JSON.stringify(input))
+
+    const result = applyUnstyled(input, true)
+
+    expect(result).not.toBe(input)
+    expect(input).toEqual(snapshot)
+  })
+
   it('returns the theme untouched when unstyled is falsy', () => {
     const input = theme()
     expect(applyUnstyled(input, false)).toBe(input)


### PR DESCRIPTION
### 🔗 Linked issue

Relates to #6551

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`applyUnstyled` only blanks `slots`, `variants` and `compoundVariants`. Themes come in two shapes: multi-element components put their classes under `slots`, single-element ones are a top-level `base` string (or array). There's no `base` branch, so with `theme.unstyled` enabled the 37 base-shaped themes (`skeleton`, `kbd`, `container`, `main`, the prose elements, ...) come out identical to the original and keep every class, while everything slots-shaped is blanked. The docs promise the option removes the default classes from all components at once, so this is a plain hole.

While in there, `applyUnstyled` no longer mutates the theme it receives: object-shaped themes are the shared module export (function-shaped ones produce a fresh object per call), so blanking in place corrupts every later read within the same process.

Covered by unit tests for both fixes. #6731 blanks unused component themes through this same function, so it picks this up on its next `v4` merge.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
