### PR TITLE
docs(timeline): make the alternating layout example RTL-aware

### DIFF
--- a/docs/app/components/content/examples/timeline/TimelineAlternatingLayoutExample.vue
+++ b/docs/app/components/content/examples/timeline/TimelineAlternatingLayoutExample.vue
@@ -28,7 +28,7 @@ const items: TimelineItem[] = [{
   <UTimeline
     :items="items"
     :default-value="2"
-    :ui="{ item: 'even:flex-row-reverse even:-translate-x-[calc(100%-2rem)] even:text-right' }"
-    class="translate-x-[calc(50%-1rem)]"
+    :ui="{ item: 'even:flex-row-reverse even:-translate-x-[calc(100%-2rem)] rtl:even:translate-x-[calc(100%-2rem)] even:text-end' }"
+    class="translate-x-[calc(50%-1rem)] rtl:-translate-x-[calc(50%-1rem)]"
   />
 </template>


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6828

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The alternating layout recipe positions items with physical utilities — `translate-x-[calc(50%-1rem)]`, `even:-translate-x-[calc(100%-2rem)]`, `even:text-right`. Percentage translates are direction-agnostic, so under `dir="rtl"` the container shifts the wrong way, the spine drifts off-axis and the zigzag collapses (reproduced against the docs app; matches the video in #6828).

The component itself is fine — the theme already uses logical properties — so this is a recipe fix: add `rtl:` counterparts with mirrored signs and replace `text-right` with the logical `text-end`. LTR output is unchanged; in RTL the timeline mirrors correctly. Happy to attach before/after screenshots.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
