### PR TITLE
docs(mcp): resolve examples by their prerendered name

### DIFF
--- a/docs/server/mcp/tools/get-example.ts
+++ b/docs/server/mcp/tools/get-example.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod'
+import { camelCase } from 'scule'
 
 export default defineMcpTool({
   description: 'Retrieves specific UI example implementation code and details',
@@ -12,13 +13,14 @@ export default defineMcpTool({
     exampleName: z.string().describe('The name of the example (PascalCase)')
   },
   inputExamples: [
-    { exampleName: 'ButtonBasic' },
-    { exampleName: 'ModalOverlay' }
+    { exampleName: 'TabsExample' },
+    { exampleName: 'AccordionBodySlotExample' }
   ],
   cache: '30m',
   async handler({ exampleName }) {
     try {
-      const result = await $fetch<{ code: string }>(`/api/component-example/${exampleName}.json`)
+      // Examples are prerendered under their camelCase name, the dynamic route accepts any case
+      const result = await $fetch<{ code: string }>(`/api/component-example/${camelCase(exampleName)}.json`)
       return result.code
     } catch (error: unknown) {
       const err = error as { statusCode?: number, response?: { status?: number } }


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `get-example` MCP tool returns a 404 for every example in production, including names that `list-examples` itself advertises:

```
get-example { exampleName: "AccordionBodySlotExample" }
[404] Example 'AccordionBodySlotExample' not found. Use the list-examples tool to see all available examples.
```

Examples are prerendered under their camelCase name, `/api/component-example/accordionBodySlotExample.json` (this is the form the docs app fetches, which is what triggers the prerender). The tool requested the name as given, so a PascalCase name fell through to the dynamic route, and that route reads the example from the build directory with `readFileSync`, which is not part of the serverless bundle. Every lookup failed.

Requesting the camelCase name resolves the prerendered file in production and still works in development, where the dynamic route pascal-cases the parameter itself. Accepts `TabsExample`, `tabs-example` and `tabsExample` alike.

Also replaces the `inputExamples` with names that exist, `ButtonBasic` and `ModalOverlay` never did.

One known gap remains: examples that no documentation page references are never prerendered, so they stay unavailable in production while `list-examples` still advertises them (`UseOverlayModalExample` is the one I found). Fixing that means either prerendering every example route or bundling the example contents into the server build, both beyond the scope of this fix.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
