### PR TITLE
fix(Table): make rows with a select event keyboard accessible

### DIFF
--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -477,7 +477,7 @@ function onRowSelect(e: Event, row: TableRow<T>) {
     return
   }
   const target = e.target as HTMLElement
-  const isInteractive = target.closest('button') || target.closest('a')
+  const isInteractive = target.closest('a, button, input, select, textarea')
   if (isInteractive) {
     return
   }

--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -549,7 +549,6 @@ defineExpose({
       :data-selectable="!!props.onSelect || !!props.onHover || !!props.onContextmenu"
       :data-expanded="row.getIsExpanded()"
       :data-pinned="row.getIsPinned() || undefined"
-      :role="props.onSelect ? 'button' : undefined"
       :tabindex="props.onSelect ? 0 : undefined"
       data-slot="tr"
       :class="ui.tr({
@@ -560,6 +559,7 @@ defineExpose({
       })"
       :style="[resolveValue(tableApi.options.meta?.style?.tr, row), style]"
       @click="onRowSelect($event, row)"
+      @keydown.enter.space="onRowSelect($event, row)"
       @pointerenter="onRowHover($event, row)"
       @pointerleave="onRowHover($event, null)"
       @contextmenu="onRowContextmenu($event, row)"

--- a/src/runtime/components/Table.vue
+++ b/src/runtime/components/Table.vue
@@ -473,7 +473,7 @@ function valueUpdater<T extends Updater<any>>(updaterOrValue: T, ref: Ref) {
 }
 
 function onRowSelect(e: Event, row: TableRow<T>) {
-  if (!props.onSelect) {
+  if (!props.onSelect || (e as KeyboardEvent).repeat) {
     return
   }
   const target = e.target as HTMLElement

--- a/test/components/Table.spec.ts
+++ b/test/components/Table.spec.ts
@@ -9,6 +9,13 @@ import Table from '../../src/runtime/components/Table.vue'
 import type { TableColumn, TableRow } from '../../src/runtime/components/Table.vue'
 import theme from '#build/ui/table'
 
+async function triggerKeydown(element: Element, init: KeyboardEventInit) {
+  const event = new KeyboardEvent('keydown', { bubbles: true, cancelable: true, ...init })
+  element.dispatchEvent(event)
+  await flushPromises()
+  return event
+}
+
 describe('Table', () => {
   const loadingColors = Object.keys(theme.variants.loadingColor) as any
   const loadingAnimations = Object.keys(theme.variants.loadingAnimation) as any
@@ -240,11 +247,13 @@ describe('Table', () => {
     expect(row.attributes('tabindex')).toBe('0')
     expect(row.attributes('role')).toBeUndefined()
 
-    await row.trigger('keydown', { key: 'Enter' })
+    const enterEvent = await triggerKeydown(row.element, { key: 'Enter' })
     expect(onSelect).toHaveBeenCalledTimes(1)
+    expect(enterEvent.defaultPrevented).toBe(true)
 
-    await row.trigger('keydown', { key: ' ' })
+    const spaceEvent = await triggerKeydown(row.element, { key: ' ' })
     expect(onSelect).toHaveBeenCalledTimes(2)
+    expect(spaceEvent.defaultPrevented).toBe(true)
   })
 
   it('does not call select on repeated keydown', async () => {
@@ -281,14 +290,19 @@ describe('Table', () => {
     })
 
     const checkbox = wrapper.find<HTMLInputElement>('tbody tr input')
-    await checkbox.trigger('keydown', { key: ' ' })
+    const checkboxEvent = await triggerKeydown(checkbox.element, { key: ' ' })
+    expect(checkboxEvent.defaultPrevented).toBe(false)
+
+    const buttonEvent = await triggerKeydown(wrapper.find('tbody tr button').element, { key: ' ' })
+    expect(buttonEvent.defaultPrevented).toBe(false)
+
+    const linkEvent = await triggerKeydown(wrapper.find('tbody tr a').element, { key: 'Enter' })
+    expect(linkEvent.defaultPrevented).toBe(false)
+
     await checkbox.trigger('click')
     expect(checkbox.element.checked).toBe(true)
 
-    await wrapper.find('tbody tr button').trigger('keydown', { key: ' ' })
     await wrapper.find('tbody tr button').trigger('click')
-
-    await wrapper.find('tbody tr a').trigger('keydown', { key: 'Enter' })
     await wrapper.find('tbody tr a').trigger('click')
 
     expect(onSelect).not.toHaveBeenCalled()

--- a/test/components/Table.spec.ts
+++ b/test/components/Table.spec.ts
@@ -237,11 +237,29 @@ describe('Table', () => {
     })
 
     const row = wrapper.find('tbody tr')
+    expect(row.attributes('tabindex')).toBe('0')
+    expect(row.attributes('role')).toBeUndefined()
+
     await row.trigger('keydown', { key: 'Enter' })
     expect(onSelect).toHaveBeenCalledTimes(1)
 
     await row.trigger('keydown', { key: ' ' })
     expect(onSelect).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not call select on repeated keydown', async () => {
+    const onSelect = vi.fn()
+    const wrapper = await mountSuspended(Table, {
+      props: { ...props, onSelect }
+    })
+
+    const row = wrapper.find('tbody tr')
+    await row.trigger('keydown', { key: 'Enter', repeat: true })
+    await row.trigger('keydown', { key: ' ', repeat: true })
+    expect(onSelect).not.toHaveBeenCalled()
+
+    await row.trigger('keydown', { key: 'Enter' })
+    expect(onSelect).toHaveBeenCalledTimes(1)
   })
 
   it('reactive columns', async () => {

--- a/test/components/Table.spec.ts
+++ b/test/components/Table.spec.ts
@@ -262,6 +262,41 @@ describe('Table', () => {
     expect(onSelect).toHaveBeenCalledTimes(1)
   })
 
+  it('does not call select from nested controls', async () => {
+    const onSelect = vi.fn()
+    const wrapper = await mountSuspended(Table, {
+      props: {
+        ...props,
+        columns: [{
+          id: 'controls',
+          header: 'Controls',
+          cell: () => [
+            h('input', { 'type': 'checkbox', 'aria-label': 'Select row' }),
+            h('button', { type: 'button' }, 'Edit'),
+            h('a', { href: '#' }, 'Details')
+          ]
+        }] as any,
+        onSelect
+      }
+    })
+
+    const checkbox = wrapper.find<HTMLInputElement>('tbody tr input')
+    await checkbox.trigger('keydown', { key: ' ' })
+    await checkbox.trigger('click')
+    expect(checkbox.element.checked).toBe(true)
+
+    await wrapper.find('tbody tr button').trigger('keydown', { key: ' ' })
+    await wrapper.find('tbody tr button').trigger('click')
+
+    await wrapper.find('tbody tr a').trigger('keydown', { key: 'Enter' })
+    await wrapper.find('tbody tr a').trigger('click')
+
+    expect(onSelect).not.toHaveBeenCalled()
+
+    await wrapper.find('tbody tr').trigger('keydown', { key: 'Enter' })
+    expect(onSelect).toHaveBeenCalledTimes(1)
+  })
+
   it('reactive columns', async () => {
     const wrapper = await mountSuspended({
       components: { Table },

--- a/test/components/Table.spec.ts
+++ b/test/components/Table.spec.ts
@@ -1,5 +1,5 @@
 import { h, ref, computed } from 'vue'
-import { describe, it, expect } from 'vitest'
+import { describe, it, expect, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { flushPromises } from '@vue/test-utils'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
@@ -212,6 +212,36 @@ describe('Table', () => {
         'empty-table-header': { enabled: false }
       }
     })).toHaveNoViolations()
+  })
+
+  it('passes accessibility tests with select event', async () => {
+    const wrapper = await mountSuspended(Table, {
+      props: {
+        ...props,
+        columns: columns as any,
+        caption: 'Table caption',
+        onSelect: () => {}
+      }
+    })
+    expect(await axe(wrapper.element, {
+      rules: {
+        'empty-table-header': { enabled: false }
+      }
+    })).toHaveNoViolations()
+  })
+
+  it('calls select on Enter and Space', async () => {
+    const onSelect = vi.fn()
+    const wrapper = await mountSuspended(Table, {
+      props: { ...props, onSelect }
+    })
+
+    const row = wrapper.find('tbody tr')
+    await row.trigger('keydown', { key: 'Enter' })
+    expect(onSelect).toHaveBeenCalledTimes(1)
+
+    await row.trigger('keydown', { key: ' ' })
+    expect(onSelect).toHaveBeenCalledTimes(2)
   })
 
   it('reactive columns', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6837

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

With `@select` bound, every row gets `tabindex="0"` and `role="button"`, but the only handler on the row is `@click`. A keyboard user can focus a row and pressing Enter or Space does nothing.

The row now also listens for `keydown.enter.space` and calls the same `onRowSelect` as a click. That handler already calls `preventDefault`, so Space doesn't scroll the page, and it already returns early when the event comes from a button or a link inside the row, so a selection checkbox or an actions menu keeps its own keys.

`role="button"` is dropped. It replaced the implicit `role="row"`, and with a selection column axe reports nested-interactive on every row because the checkbox then sits inside something announced as a button. Rows stay focusable through `tabindex`, so keyboard access is unaffected.

Two tests: an axe run with `@select` bound, which currently reports one violation per row, and one checking that Enter and Space reach the handler.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
