### PR TITLE
fix(Icon): render bundled icons during Vue SSR

### DIFF
--- a/src/runtime/vue/components/Icon.vue
+++ b/src/runtime/vue/components/Icon.vue
@@ -7,7 +7,7 @@ type CustomizeFn = Exclude<IconProps['customize'], boolean | null | undefined>
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { Icon as IconifyIcon } from '@iconify/vue'
+import { Icon as IconifyIcon, iconLoaded } from '@iconify/vue'
 import { useAppConfig } from '#imports'
 
 const props = defineProps<IconProps>()
@@ -32,12 +32,20 @@ const mode = computed(() => {
 const size = computed(() => props.size || appConfig.icon?.size)
 
 const customize = computed(() => resolveCustomizeFn(props.customize, appConfig.icon?.customize))
+
+const icon = computed(() => typeof props.name === 'string' ? props.name.replace(/^i-/, '') : '')
+
+// `@iconify/vue` only resolves icon data inside `setup()` when `ssr` is set, otherwise it waits for
+// `onMounted`, which never runs during `renderToString`. Opt in for icons already in the in-memory
+// store (bundled through `icon.clientBundle`) so the others keep loading from the API on mount.
+const ssr = computed(() => !!icon.value && iconLoaded(icon.value))
 </script>
 
 <template>
   <IconifyIcon
     v-if="typeof name === 'string'"
-    :icon="name.replace(/^i-/, '')"
+    :icon="icon"
+    :ssr="ssr"
     :mode="mode"
     :width="size"
     :height="size"

--- a/test/components/Icon.spec.ts
+++ b/test/components/Icon.spec.ts
@@ -1,0 +1,15 @@
+import { describe, it, expect } from 'vitest'
+import { createSSRApp, h } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { addIcon } from '@iconify/vue'
+import Icon from '../../src/runtime/vue/components/Icon.vue'
+
+describe('Icon', () => {
+  it('renders a bundled icon during SSR', async () => {
+    addIcon('lucide:rocket', { body: '<path d="M0 0h24v24H0z"/>' })
+
+    const html = await renderToString(createSSRApp({ render: () => h(Icon, { name: 'i-lucide-rocket', mode: 'svg' }) }))
+
+    expect(html).toContain('<path d="M0 0h24v24H0z"/>')
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6839

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`@iconify/vue`'s `Icon` only resolves icon data inside `setup()` when its `ssr` prop is set. Without it resolution moves to `onMounted`, which never runs under `renderToString`, so in a Vue SSR build every icon comes out as the empty fallback `<svg></svg>` and only fills in after hydration. `icon.clientBundle` doesn't change that: the data sits in Iconify's in-memory store before the first render, the component just never reads it there.

Setting `ssr` unconditionally would be worse, since for an icon that isn't bundled `Icon` starts an API request from `setup()` that the server render can't await. So it's set only when `iconLoaded()` reports the data is already in the store, which is the bundled case. Server and client agree on that, both run the same `init(addIcon)` from the icons plugin, so hydration stays clean.

Checked with a `vite build --ssr` of the Vue playground rendering `<UIcon name="i-lucide-search" />`: `<svg ...></svg>` before, the full icon body after. The added test renders the Vue `Icon` through `vue/server-renderer` and fails without the change.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.