### PR TITLE
fix(Icon): render bundled icons during SSR in Vue

### DIFF
--- a/src/runtime/vue/components/Icon.vue
+++ b/src/runtime/vue/components/Icon.vue
@@ -7,7 +7,7 @@ type CustomizeFn = Exclude<IconProps['customize'], boolean | null | undefined>
 
 <script setup lang="ts">
 import { computed } from 'vue'
-import { Icon as IconifyIcon } from '@iconify/vue'
+import { Icon as IconifyIcon, iconLoaded } from '@iconify/vue'
 import { useAppConfig } from '#imports'
 
 const props = defineProps<IconProps>()
@@ -32,16 +32,19 @@ const mode = computed(() => {
 const size = computed(() => props.size || appConfig.icon?.size)
 
 const customize = computed(() => resolveCustomizeFn(props.customize, appConfig.icon?.customize))
+
+const iconName = computed(() => typeof props.name === 'string' ? props.name.replace(/^i-/, '') : '')
 </script>
 
 <template>
   <IconifyIcon
     v-if="typeof name === 'string'"
-    :icon="name.replace(/^i-/, '')"
+    :icon="iconName"
     :mode="mode"
     :width="size"
     :height="size"
     :customise="customize"
+    :ssr="iconLoaded(iconName)"
   />
   <component :is="name" v-else />
 </template>

--- a/src/runtime/vue/components/Icon.vue
+++ b/src/runtime/vue/components/Icon.vue
@@ -34,6 +34,10 @@ const size = computed(() => props.size || appConfig.icon?.size)
 const customize = computed(() => resolveCustomizeFn(props.customize, appConfig.icon?.customize))
 
 const iconName = computed(() => typeof props.name === 'string' ? props.name.replace(/^i-/, '') : '')
+
+// `@iconify/vue` only resolves icon data in `setup()` when `ssr` is set. Only opt in for icons
+// already in memory (bundled) so the others keep loading from the API on mount.
+const ssr = computed(() => iconLoaded(iconName.value))
 </script>
 
 <template>
@@ -44,7 +48,7 @@ const iconName = computed(() => typeof props.name === 'string' ? props.name.repl
     :width="size"
     :height="size"
     :customise="customize"
-    :ssr="iconLoaded(iconName)"
+    :ssr="ssr"
   />
   <component :is="name" v-else />
 </template>

--- a/src/runtime/vue/components/Icon.vue
+++ b/src/runtime/vue/components/Icon.vue
@@ -33,17 +33,17 @@ const size = computed(() => props.size || appConfig.icon?.size)
 
 const customize = computed(() => resolveCustomizeFn(props.customize, appConfig.icon?.customize))
 
-const iconName = computed(() => typeof props.name === 'string' ? props.name.replace(/^i-/, '') : '')
+const icon = computed(() => typeof props.name === 'string' ? props.name.replace(/^i-/, '') : '')
 
 // `@iconify/vue` only resolves icon data in `setup()` when `ssr` is set. Only opt in for icons
 // already in memory (bundled) so the others keep loading from the API on mount.
-const ssr = computed(() => iconLoaded(iconName.value))
+const ssr = computed(() => iconLoaded(icon.value))
 </script>
 
 <template>
   <IconifyIcon
     v-if="typeof name === 'string'"
-    :icon="iconName"
+    :icon="icon"
     :mode="mode"
     :width="size"
     :height="size"

--- a/test/components/Icon.spec.ts
+++ b/test/components/Icon.spec.ts
@@ -37,8 +37,11 @@ describe('Icon', () => {
   })
 
   it('falls back to an empty svg on the client when the icon is unknown', async () => {
+    // null loader on a dedicated prefix so the lookup stays offline instead of hitting the Iconify API
+    setCustomIconLoader(() => null, 'mock-missing')
+
     const wrapper = await mountSuspended(Icon, {
-      props: { name: 'i-mock-missing-icon', mode: 'svg' }
+      props: { name: 'i-mock-missing:icon', mode: 'svg' }
     })
 
     expect(wrapper.html()).toContain('<svg')

--- a/test/components/Icon.spec.ts
+++ b/test/components/Icon.spec.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it, vi } from 'vitest'
+import { h, createSSRApp } from 'vue'
+import { renderToString } from 'vue/server-renderer'
+import { mountSuspended } from '@nuxt/test-utils/runtime'
+import { addIcon, setCustomIconLoader } from '@iconify/vue'
+import Icon from '../../src/runtime/vue/components/Icon.vue'
+
+function renderIconToString(name: string) {
+  return renderToString(createSSRApp({ render: () => h(Icon, { name, mode: 'svg' }) }))
+}
+
+describe('Icon', () => {
+  it('outputs the real icon body when server-rendering a preloaded icon', async () => {
+    addIcon('mock:server-icon', {
+      body: '<path d="M2 2h20v20H2z" />',
+      width: 24,
+      height: 24
+    })
+
+    const html = await renderIconToString('i-mock-server-icon')
+
+    expect(html).toContain('<path')
+  })
+
+  it('keeps working on the client for a preloaded icon', async () => {
+    addIcon('mock:client-icon', {
+      body: '<path d="M2 2h20v20H2z" />',
+      width: 24,
+      height: 24
+    })
+
+    const wrapper = await mountSuspended(Icon, {
+      props: { name: 'i-mock-client-icon', mode: 'svg' }
+    })
+
+    expect(wrapper.html()).toContain('<path')
+  })
+
+  it('falls back to an empty svg on the client when the icon is unknown', async () => {
+    const wrapper = await mountSuspended(Icon, {
+      props: { name: 'i-mock-missing-icon', mode: 'svg' }
+    })
+
+    expect(wrapper.html()).toContain('<svg')
+    expect(wrapper.html()).not.toContain('<path')
+  })
+
+  it('never asks the loader for an icon that is not preloaded during SSR', async () => {
+    // isolated prefix so a load queued by another test's `onMounted` can't bleed into this assertion
+    const fetchIcon = vi.fn(() => new Promise<never>(() => {}))
+    setCustomIconLoader(fetchIcon, 'mock-ssr-remote')
+
+    await renderIconToString('i-mock-ssr-remote:icon')
+    // the loader call is scheduled through `setTimeout`, give it a chance to run before checking
+    await new Promise(resolve => setTimeout(resolve))
+
+    expect(fetchIcon).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
### 🔗 Linked issue

Fixes #6839

### ❓ Type of change

- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)

### 📚 Description
The Vue Icon.vue component never forwards ssr to @iconify/vue. Without it, icon data is only resolved on onMounted, which doesn't run during renderToString, so bundled icons (icon.clientBundle) still come out as empty <svg> on the server and only show up after hydration.

SSR is enabled only when iconLoaded() says the icon is already in memory, otherwise we'd fire an API call from setup() during the server render for icons that aren't bundled.

Tested this on my own app (Laravel + Inertia), and added a spec covering both cases (bundled icon renders during SSR, unbundled one doesn't trigger a load from setup()), plus a couple of CSR checks to make sure normal mounting still works.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
