### PR TITLE
fix(Theme): merge `class` from `props` with the component class

### DIFF
--- a/src/runtime/composables/useComponentProps.ts
+++ b/src/runtime/composables/useComponentProps.ts
@@ -54,7 +54,7 @@ function propIsDefined(vnode: VNode | null | undefined, prop: string): boolean {
  * defaults. The component's tv() `defaultVariants` are intentionally left out
  * of the proxy fallback — they continue to drive `tv()`-internal class
  * resolution (the original semantics) without leaking into prop reads. The
- * `ui` prop is deep-merged (explicit slot classes override theme slot classes)
+ * `ui` and `class` props are merged (explicit classes override theme classes)
  * instead of being replaced.
  */
 export function useComponentProps<T extends object>(name: string, props: T): T {
@@ -83,6 +83,16 @@ export function useComponentProps<T extends object>(name: string, props: T): T {
         const themeUi = themeEntry?.ui
         if (!raw && !themeUi) return raw
         return defu(raw ?? {}, themeUi ?? {})
+      }
+
+      // Like `ui`, `class` is merged instead of replaced so a component passing
+      // its own `class` still gets the theme classes. The explicit class comes
+      // last to win `twMerge`'s last-in-wins resolution.
+      if (prop === 'class') {
+        const themeClass = themeEntry?.class
+        if (themeClass === undefined) return raw
+        if (raw === undefined) return themeClass
+        return [themeClass, raw]
       }
 
       if (vm && propIsDefined(vm.vnode, prop)) return raw

--- a/test/components/Theme.spec.ts
+++ b/test/components/Theme.spec.ts
@@ -402,6 +402,40 @@ describe('Theme', () => {
     expect(wrapper.find('button').classes()).toContain('rounded-full')
   })
 
+  // A `class` inside `:props` is merged with the component's own `class` instead
+  // of being replaced by it, otherwise any component setting a class would lose
+  // the theme class entirely.
+  test(':props class merges with an explicit class on the component', async () => {
+    const wrapper = await mountSuspended({
+      components: { Theme, Button },
+      template: `
+        <Theme :props="{ button: { class: 'rounded-full' } }">
+          <Button label="Themed" class="hidden lg:inline-flex" />
+        </Theme>
+      `
+    })
+
+    const classes = wrapper.find('button').classes()
+    expect(classes).toContain('rounded-full')
+    expect(classes).toContain('hidden')
+    expect(classes).toContain('lg:inline-flex')
+  })
+
+  test(':props class is overridden by a conflicting explicit class', async () => {
+    const wrapper = await mountSuspended({
+      components: { Theme, Button },
+      template: `
+        <Theme :props="{ button: { class: 'rounded-full' } }">
+          <Button label="Themed" class="rounded-none" />
+        </Theme>
+      `
+    })
+
+    const classes = wrapper.find('button').classes()
+    expect(classes).toContain('rounded-none')
+    expect(classes).not.toContain('rounded-full')
+  })
+
   // Boolean values supplied via `:props` must reach a Reka primitive root through
   // `useForwardProps`. This is the path where Vue's auto-casting of unset Boolean
   // props would otherwise turn the proxy result into `false` and silently swallow


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`class` inside `<UTheme :props>` was treated like any other prop, so as soon as a component set its own `class` the explicit value won and the theme class was dropped entirely:

```vue
<UTheme :props="{ button: { class: 'rounded-full' } }">
  <!-- rounded-full applies -->
  <UButton icon="i-lucide-plus" />
  <!-- rounded-full is lost -->
  <UButton icon="i-lucide-x" class="lg:hidden" />
</UTheme>
```

`class` is now merged like `ui`, with the explicit class last so `twMerge` still resolves conflicts in its favor (`class="rounded-none"` on the component keeps overriding a themed `rounded-full`).

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
