### PR TITLE
chore: narrow tailwind source scope in docs and playgrounds

### DIFF
--- a/docs/app/assets/css/main.css
+++ b/docs/app/assets/css/main.css
@@ -1,6 +1,11 @@
-@import "tailwindcss" theme(static) source("../../../..");
+@import "tailwindcss" theme(static) source(none);
 @import "@nuxt/ui";
 
+/* Scoped to what the docs render: the site and the library source, which `--uiDev`
+   resolves components and theme from. A repo-root source also put `test`,
+   `playgrounds` and `skills` on the CSS watcher. */
+@source "../../..";
+@source "../../../../src";
 @source "../../../content/**/*";
 
 @theme static {

--- a/playgrounds/nuxt/app/assets/css/main.css
+++ b/playgrounds/nuxt/app/assets/css/main.css
@@ -1,5 +1,11 @@
-@import "tailwindcss" theme(static) source("../../../../..");
+@import "tailwindcss" theme(static) source(none);
 @import "@nuxt/ui";
+
+/* Scoped to this playground and the library source, which `--uiDev` resolves
+   components and theme from. A repo-root source also put `docs` and `test` on
+   the CSS watcher. */
+@source "../../..";
+@source "../../../../../src";
 
 @theme static {
   --font-sans: 'Public Sans', sans-serif;

--- a/playgrounds/vue/src/assets/css/main.css
+++ b/playgrounds/vue/src/assets/css/main.css
@@ -1,5 +1,12 @@
-@import "tailwindcss" theme(static) source("../../../../..");
+@import "tailwindcss" theme(static) source(none);
 @import "@nuxt/ui";
+
+/* Scoped to this playground, the Nuxt playground's `app` that `vite.config.ts`
+   borrows components and composables from, and the library source, which
+   `--uiDev` resolves components and theme from. */
+@source "../../..";
+@source "../../../../nuxt/app";
+@source "../../../../../src";
 
 @theme static {
   --font-sans: 'Public Sans', sans-serif;


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The docs and both playgrounds pointed `source()` at the repo root, so every CSS rebuild scanned the whole monorepo and the Tailwind watcher covered it too. Editing anything in `test/`, `playgrounds/` or `skills/` triggered a docs CSS re-scan.

Replaced the repo-root `source()` with `source(none)` plus explicit `@source` directives covering only what each entry actually renders. The Vue playground needs three, since its `vite.config.ts` borrows components and composables from `playgrounds/nuxt/app`.

| entry | files scanned | bytes read | watch roots |
| --- | --- | --- | --- |
| `docs` | 1743 → 1386 | 5.83 → 4.39 MB | repo root + 9 dirs → `docs`, `src` |
| `playgrounds/nuxt` | 1743 → 778 | 5.83 → 2.51 MB | repo root + 9 dirs → `playgrounds/nuxt`, `src` |
| `playgrounds/vue` | 1695 → 736 | 5.78 → 2.47 MB | repo root + 9 dirs → `playgrounds/vue`, `playgrounds/nuxt`, `src` |

Both playgrounds were scanning all of `docs/app` and `docs/content` for nothing, which is why they gain the most.

`src` has to stay in scope: `--uiDev` resolves components and theme from source, and `src/theme/*.ts` is not covered by the library's own `@source './components'`.

`theme(static)` is unchanged, the docs theme picker swaps colors at runtime and needs every variable emitted.

#### Verifying nothing is missing

A narrowed source drops classes silently, so this is checked three ways.

Prerendered the docs and pulled every class off every rendered element, 190 pages including all the component pages, 1995 distinct classes. Classes styled before and unstyled after: **0**. This is the check that matters, it catches classes built at runtime that no source scan can see and that the repo-root config may have been covering by accident from `test/`.

At the source level, each narrowed config scans **exactly the same files** under its own tree and `src` as before, 0 dropped and 0 added, and emits **0 new classes**. Every dropped class is owned only by out-of-scope paths (`test/`, `playgrounds/`, `docs/` for the playgrounds, `.github/`, `skills/`, `cli/`, `CHANGELOG.md`). Samples: `px-[1.234rem]` and `[&>input]:text-lg` are test fixtures, `min-h-screen` and `bg-(--chip-light)` are playgrounds only.

On the dev server, appending a probe class to a file under `test/` produces no CSS at all, while the same probe in `docs/app` shows up. Under the old config the scanner picks up both.

Worth noting for anyone reproducing this: comparing the built CSS with `diff <(tr '}' '}\n' < a.css | sort -u) ...` does not work. `tr` truncates set2 to set1's length, so `tr '}' '}\n'` is a no-op. A brace-aware diff also gives false positives, since Tailwind merges selectors that share declarations and removing one class rewrites the rule its neighbours live in. Comparing the set of emitted classes is the reliable form.

#### Not blocked on tailwindlabs/tailwindcss#20406

That bug only fires for an `@source` whose base sits inside an auto source root, and `source(none)` removes the auto root, so the narrowing already takes effect on the pinned 4.3.3. Confirmed by the watch roots above.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
