### PR TITLE
docs: cut build memory by externalizing icons JSON and dropping sourcemaps

### DIFF
--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -220,9 +220,17 @@ export default defineNuxtConfig({
     }
   },
 
+  // The SSR bundle's sourcemaps cost hundreds of MB of heap during the build and are
+  // never used, the server output is not debugged from a browser.
+  sourcemap: {
+    server: false,
+    client: false
+  },
+
   compatibilityDate: '2026-01-14',
 
   nitro: {
+    sourceMap: false,
     experimental: {
       asyncContext: true
     },
@@ -351,6 +359,13 @@ export default defineNuxtConfig({
   },
 
   icon: {
+    // The local server bundle inlines every installed collection as a JS object literal,
+    // 22MB across `logos`, `vscode-icons`, `ph` and `tabler`. Rollup builds an AST for all
+    // of it while bundling the Nitro server, which alone puts the build over Node's default
+    // heap. Importing the JSON from `node_modules` instead skips that entirely.
+    serverBundle: {
+      externalizeIconsJson: true
+    },
     customCollections: [{
       prefix: 'custom',
       dir: resolve('./app/assets/icons')

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -212,19 +212,19 @@ export default defineNuxtConfig({
     '/getting-started/shortcuts': { redirect: { to: '/composables/define-shortcuts', statusCode: 301 }, prerender: false }
   },
 
+  // The SSR bundle's sourcemaps cost hundreds of MB of heap during the build and are
+  // never used, the server output is not debugged from a browser.
+  sourcemap: {
+    server: false,
+    client: false
+  },
+
   experimental: {
     defaults: {
       nuxtLink: {
         externalRelAttribute: 'noopener'
       }
     }
-  },
-
-  // The SSR bundle's sourcemaps cost hundreds of MB of heap during the build and are
-  // never used, the server output is not debugged from a browser.
-  sourcemap: {
-    server: false,
-    client: false
   },
 
   compatibilityDate: '2026-01-14',

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -28,6 +28,15 @@ export default defineNuxtConfig({
   $production: {
     site: {
       url: 'https://ui.nuxt.com'
+    },
+    // Sourcemaps for the SSR bundle and for the Nitro server are built and never used,
+    // and they cost hundreds of MB of heap while bundling. Build only, so `nuxt dev`
+    // keeps Nuxt's defaults and stays debuggable.
+    sourcemap: {
+      server: false
+    },
+    nitro: {
+      sourceMap: false
     }
   },
 
@@ -212,13 +221,6 @@ export default defineNuxtConfig({
     '/getting-started/shortcuts': { redirect: { to: '/composables/define-shortcuts', statusCode: 301 }, prerender: false }
   },
 
-  // The SSR bundle's sourcemaps cost hundreds of MB of heap during the build and are
-  // never used, the server output is not debugged from a browser.
-  sourcemap: {
-    server: false,
-    client: false
-  },
-
   experimental: {
     defaults: {
       nuxtLink: {
@@ -230,7 +232,6 @@ export default defineNuxtConfig({
   compatibilityDate: '2026-01-14',
 
   nitro: {
-    sourceMap: false,
     experimental: {
       asyncContext: true
     },


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`pnpm docs:build` runs out of heap on Node's default limit (4288 MB here). This removes the two largest sources of waste. It does not fully close the gap, see below.

**Where the memory goes.** A `--heap-prof` of the build attributes 4.4 GB of sampled allocations almost entirely to rollup bundling the Nitro server: 1300 MB in `node-entry.js` (`NodeBase`, `ObjectEntity`, `buildPropertyMaps`), 448 MB in `parseAst.js` (`literalString`, `identifier`, `property`) and 769 MB in `node:internal/encoding` `decode`. The crash lands after prerendering completes, during `Building Nuxt Nitro server`.

**`icon.serverBundle.externalizeIconsJson`.** The default local server bundle inlines every installed collection as a JS object literal: 22 MB across six chunks, `logos` alone 7 MB. Rollup builds an AST for all of it. `@nuxt/icon` has this option for exactly this case ("This would likely improve the performance of bundling") and it imports the JSON from `node_modules` instead. Removes all 22 MB from the bundle and 770 MB of allocations. Verified icons still resolve: 0 `failed to load icon` warnings across a 2847-route prerender.

**Sourcemaps.** The SSR bundle's sourcemaps are built and never used. `sourcemap.server` defaults to true, and `nitro.sourceMap` is separate and also defaults on, so both are needed.

**Result.** The heap needed drops from 5120-6144 MB to 4352-4608 MB, measured by bisecting `--max-old-space-size` on the full build. Node's default here is 4288 MB, so it still OOMs by roughly 100-300 MB.

**Ruled out**, each with a full build: `nuxt-og-image` (disabled, still OOM), prerender route volume (2044 → 1274 via `/_ipx/**` and → 1541 via `/api/component-*`, still OOM), `nitro.prerender.concurrency: 2`, `nuxt-component-meta` payload (`metaFields` all false shrinks `component-meta.mjs` 2.05 MB → 0.08 MB, still OOM), `nitro.minify: false`, and the client bundle (largest chunk 0.75 MB, no inlined worker blob).

The remainder looks intrinsic: Nitro runs two full rollup passes in one process, a prerender bundle and then the server bundle, over 22 MB of chunks and 83 MB of traced externals. Worth an upstream issue with this profile rather than more config.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
