### PR TITLE
chore: add CLAUDE.md importing AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,3 @@
+<!-- Claude Code only auto-loads CLAUDE.md, so this imports the shared agent instructions. -->
+
+@AGENTS.md


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Claude Code only auto-loads `CLAUDE.md`, it never picks up `AGENTS.md` ([docs](https://code.claude.com/docs/en/memory)). Since we only have `AGENTS.md`, none of our conventions were actually reaching it: semantic colors, `data-slot` on the root, the `useComponentProps` precedence chain, the `Soon` badge rule, all of it was silently ignored unless someone attached the file by hand.

This adds a one line `CLAUDE.md` that imports `AGENTS.md`, so both stay in sync with a single source of truth. A symlink would work too but breaks on Windows, so the import is safer here.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
