### PR TITLE
fix(InputDate/InputTime): emit focus and blur when focus enters or leaves the field

### DIFF
--- a/src/runtime/components/InputDate.vue
+++ b/src/runtime/components/InputDate.vue
@@ -144,12 +144,20 @@ function onUpdate(value: any) {
   emitFormInput()
 }
 
-function onBlur(event: FocusEvent) {
+function onFocusOut(event: FocusEvent) {
+  if (event.relatedTarget && (event.currentTarget as HTMLElement).contains(event.relatedTarget as Node)) {
+    return
+  }
+
   emitFormBlur()
   emits('blur', event)
 }
 
-function onFocus(event: FocusEvent) {
+function onFocusIn(event: FocusEvent) {
+  if (event.relatedTarget && (event.currentTarget as HTMLElement).contains(event.relatedTarget as Node)) {
+    return
+  }
+
   emitFormFocus()
   emits('focus', event)
 }
@@ -204,8 +212,8 @@ defineExpose({
     :disabled="disabled"
     :class="ui.base({ class: [props.ui?.base, props.class] })"
     @update:model-value="onUpdate"
-    @blur="onBlur"
-    @focus="onFocus"
+    @focusout="onFocusOut"
+    @focusin="onFocusIn"
   >
     <template v-if="Array.isArray(segments)">
       <ReuseSegmentsTemplate :segments="segments" />

--- a/src/runtime/components/InputTime.vue
+++ b/src/runtime/components/InputTime.vue
@@ -161,12 +161,20 @@ function onUpdate(value: any) {
   emitFormInput()
 }
 
-function onBlur(event: FocusEvent) {
+function onFocusOut(event: FocusEvent) {
+  if (event.relatedTarget && (event.currentTarget as HTMLElement).contains(event.relatedTarget as Node)) {
+    return
+  }
+
   emitFormBlur()
   emits('blur', event)
 }
 
-function onFocus(event: FocusEvent) {
+function onFocusIn(event: FocusEvent) {
+  if (event.relatedTarget && (event.currentTarget as HTMLElement).contains(event.relatedTarget as Node)) {
+    return
+  }
+
   emitFormFocus()
   emits('focus', event)
 }
@@ -219,8 +227,8 @@ defineExpose({
     :default-value="(props.defaultValue as TimeValue)"
     :class="ui.base({ class: [props.ui?.base, props.class] })"
     @update:model-value="onUpdate"
-    @blur="onBlur"
-    @focus="onFocus"
+    @focusout="onFocusOut"
+    @focusin="onFocusIn"
   >
     <template v-if="Array.isArray(segments)">
       <ReuseSegmentsTemplate :segments="segments" />

--- a/test/components/InputDate.spec.ts
+++ b/test/components/InputDate.spec.ts
@@ -65,6 +65,23 @@ describe('InputDate', () => {
       await wrapper.setValue(date)
       expect(wrapper.emitted()).toMatchObject({ 'update:modelValue': [[date]] })
     })
+
+    test('focus and blur events when focus enters and leaves the field, not between segments', async () => {
+      const wrapper = await mountSuspended(InputDate)
+      const segments = wrapper.findAll('[data-segment]').filter(segment => segment.attributes('data-segment') !== 'literal')
+      const [first, second] = segments
+
+      // nudge the mocked clock past mount so Vue's event invoker doesn't skip same-timestamp events
+      vi.setSystemTime(new Date(Date.now() + 1000))
+
+      first!.element.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: null }))
+      first!.element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: second!.element }))
+      second!.element.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: first!.element }))
+      second!.element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: null }))
+
+      expect(wrapper.emitted('focus')).toHaveLength(1)
+      expect(wrapper.emitted('blur')).toHaveLength(1)
+    })
   })
 
   it('passes accessibility tests', async () => {

--- a/test/components/InputTime.spec.ts
+++ b/test/components/InputTime.spec.ts
@@ -70,6 +70,23 @@ describe('InputTime', () => {
       await wrapper.setValue(time)
       expect(wrapper.emitted()).toMatchObject({ 'update:modelValue': [[time]] })
     })
+
+    test('focus and blur events when focus enters and leaves the field, not between segments', async () => {
+      const wrapper = await mountSuspended(InputTime)
+      const segments = wrapper.findAll('[data-segment]').filter(segment => segment.attributes('data-segment') !== 'literal')
+      const [first, second] = segments
+
+      // nudge the mocked clock past mount so Vue's event invoker doesn't skip same-timestamp events
+      vi.setSystemTime(new Date(Date.now() + 1000))
+
+      first!.element.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: null }))
+      first!.element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: second!.element }))
+      second!.element.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: first!.element }))
+      second!.element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: null }))
+
+      expect(wrapper.emitted('focus')).toHaveLength(1)
+      expect(wrapper.emitted('blur')).toHaveLength(1)
+    })
   })
 
   it('passes accessibility tests', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6854

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`@blur`/`@focus` sat on the reka field root, which doesn't emit them, so they became native listeners on a div that never gets focused: the segments hold focus and blur doesn't bubble. They could never fire, and `validate-on` blur/focus was dead for both components.

Now `focusin`/`focusout` on the root, with a relatedTarget check so moving between segments doesn't emit.

Tests are red on `v4`. They nudge the specs' frozen clock first because Vue drops native events stamped at the exact listener-attach time.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
