### PR TITLE
fix(PinInput): emit blur whenever focus leaves the group

### DIFF
--- a/src/runtime/components/PinInput.vue
+++ b/src/runtime/components/PinInput.vue
@@ -119,11 +119,21 @@ function onComplete(value: string[] | number[]) {
   emitFormChange()
 }
 
-function onBlur(event: FocusEvent) {
-  if (!event.relatedTarget) {
-    emits('blur', event)
-    emitFormBlur()
+function onFocusOut(event: FocusEvent) {
+  if (event.relatedTarget && (event.currentTarget as HTMLElement).contains(event.relatedTarget as Node)) {
+    return
   }
+
+  emits('blur', event)
+  emitFormBlur()
+}
+
+function onFocusIn(event: FocusEvent) {
+  if (event.relatedTarget && (event.currentTarget as HTMLElement).contains(event.relatedTarget as Node)) {
+    return
+  }
+
+  emitFormFocus()
 }
 
 function autoFocus() {
@@ -177,6 +187,8 @@ defineExpose({
     :class="ui.root({ class: [props.ui?.root, props.class] })"
     @update:model-value="emitFormInput()"
     @complete="onComplete"
+    @focusout="onFocusOut"
+    @focusin="onFocusIn"
   >
     <template v-for="(ids, index) in looseToNumber(props.length)" :key="ids">
       <PinInputInput
@@ -185,8 +197,6 @@ defineExpose({
         data-slot="base"
         :class="ui.base({ class: props.ui?.base })"
         :disabled="disabled"
-        @blur="onBlur"
-        @focus="emitFormFocus"
       />
       <span
         v-if="shouldInsertSeparator(index as number)"

--- a/src/runtime/components/PinInput.vue
+++ b/src/runtime/components/PinInput.vue
@@ -53,6 +53,7 @@ export interface PinInputProps<T extends PinInputType = 'text'> extends Pick<Pin
 export type PinInputEmits<T extends PinInputType = 'text'> = PinInputRootEmits<T> & {
   change: [event: Event]
   blur: [event: Event]
+  focus: [event: Event]
 }
 
 export interface PinInputSlots {
@@ -133,6 +134,7 @@ function onFocusIn(event: FocusEvent) {
     return
   }
 
+  emits('focus', event)
   emitFormFocus()
 }
 

--- a/test/components/PinInput.spec.ts
+++ b/test/components/PinInput.spec.ts
@@ -56,13 +56,26 @@ describe('PinInput', () => {
       expect(wrapper.emitted()).toMatchObject({ change: [[{ type: 'change' }]] })
     })
 
+    test('blur event when focus leaves the group, not between pins', async () => {
+      const wrapper = mount(PinInput)
+      const pins = wrapper.findAll('input[aria-label^="pin input"]')
+
+      pins[0]!.element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: pins[1]!.element }))
+      await flushPromises()
+      expect(wrapper.emitted('blur')).toBeUndefined()
+
+      pins[1]!.element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: document.body }))
+      await flushPromises()
+      expect(wrapper.emitted('blur')).toHaveLength(1)
+    })
+
     test('blur event', async () => {
       const wrapper = mount(PinInput)
       const lastPin = wrapper.find('input[aria-label="pin input 5 of 0"]')
-      lastPin.trigger('blur')
+      lastPin.element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: null }))
       await flushPromises()
 
-      expect(wrapper.emitted()).toMatchObject({ blur: [[{ type: 'blur' }]] })
+      expect(wrapper.emitted()).toMatchObject({ blur: [[{ type: 'focusout' }]] })
     })
   })
 
@@ -108,12 +121,12 @@ describe('PinInput', () => {
       const lastPin = wrapper.find('input[aria-label="pin input 5 of 5"]')
 
       await input.vm.$emit('update:modelValue', ['1', '2', '3', '4'])
-      lastPin.trigger('blur')
+      lastPin.element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: document.body }))
       await flushPromises()
       expect(wrapper.text()).toContain('Error message')
 
       await input.vm.$emit('update:modelValue', ['1', '2', '3', '4', '5'])
-      lastPin.trigger('blur')
+      lastPin.element.dispatchEvent(new FocusEvent('focusout', { bubbles: true, relatedTarget: document.body }))
       await flushPromises()
       expect(wrapper.text()).not.toContain('Error message')
     })

--- a/test/components/PinInput.spec.ts
+++ b/test/components/PinInput.spec.ts
@@ -77,6 +77,19 @@ describe('PinInput', () => {
 
       expect(wrapper.emitted()).toMatchObject({ blur: [[{ type: 'focusout' }]] })
     })
+
+    test('focus event when focus enters the group, not between pins', async () => {
+      const wrapper = mount(PinInput)
+      const pins = wrapper.findAll('input[aria-label^="pin input"]')
+
+      pins[0]!.element.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: null }))
+      await flushPromises()
+      expect(wrapper.emitted()).toMatchObject({ focus: [[{ type: 'focusin' }]] })
+
+      pins[1]!.element.dispatchEvent(new FocusEvent('focusin', { bubbles: true, relatedTarget: pins[0]!.element }))
+      await flushPromises()
+      expect(wrapper.emitted('focus')).toHaveLength(1)
+    })
   })
 
   describe('form integration', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6856

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The `!event.relatedTarget` guard swallowed every blur toward a focusable element, so tabbing or clicking away never emitted `blur` or validated. Same fix as #6855: `focusin`/`focusout` on the root with a relatedTarget check. Moving between pins stays silent, leaving the group always emits.

The old blur tests synthesized `relatedTarget: null` events, the one case that worked. They now dispatch the real shape and are red on `v4`, plus a new test for the guard.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
