### PR TITLE
docs: fix broken links and outdated content

### DIFF
--- a/.github/contributing/documentation.md
+++ b/.github/contributing/documentation.md
@@ -127,6 +127,14 @@ links:
 ---
 ```
 
+Optional `keywords` feed the docs search and the MCP `search-components` tool. Use alternate names from other ecosystems, not words already in the title or description:
+
+```yaml
+keywords:
+  - segmented control
+  - button group
+```
+
 For Reka UI based components, add the Reka UI link:
 
 ```yaml

--- a/docs/content/blog/how-to-build-an-ai-chat.md
+++ b/docs/content/blog/how-to-build-an-ai-chat.md
@@ -36,7 +36,7 @@ Check out the [`Nuxt`](https://github.com/nuxt-ui-templates/chat) and [`Vue`](ht
 
 Before we start, make sure you have:
 
-- Node.js 20+ installed
+- Node.js 20.19+ or 22.12+ installed
 - A [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) API key (provides access to multiple AI providers through a single endpoint)
 
 ## Project setup
@@ -191,7 +191,7 @@ This section covers integrating AI on the server. The following API endpoints ha
 
 ### Creating a chat
 
-First, create the endpoint that initializes a new chat and saves the first message to the database. This uses the [`UIMessage`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/ui-message) type from the AI SDK:
+First, create the endpoint that initializes a new chat and saves the first message to the database. This uses the [`UIMessage`](https://ai-sdk.dev/docs/reference/ai-sdk-core/ui-message) type from the AI SDK:
 
 ::code-tree-intersection
 ```ts [server/api/chats.post.ts]
@@ -404,7 +404,7 @@ export default defineEventHandler(async (event) => {
 ```
 ::
 
-## Wire up the UI
+## Wiring up the UI
 
 Nuxt UI provides purpose-built components for AI chat interfaces: [`UChatPrompt`](/docs/components/chat-prompt) for the input area and [`UChatMessages`](/docs/components/chat-messages) for displaying the conversation.
 
@@ -509,7 +509,7 @@ html.dark .shiki span {
 
 ## Creating the chat page
 
-The chat page is where the actual conversation happens. It integrates the AI SDK's [`Chat`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/chat) class and [`DefaultChatTransport`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/default-chat-transport) for real-time streaming.
+The chat page is where the actual conversation happens. It integrates the AI SDK's [`Chat`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat) class and [`DefaultChatTransport`](https://ai-sdk.dev/docs/ai-sdk-ui/transport#default-transport) for real-time streaming.
 
 ::code-tree-intersection
 :::code-collapse
@@ -641,7 +641,7 @@ The [`useChat`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat) composable
 - Stopping generation with `stop()`
 - Regenerating responses with `regenerate()`
 
-The `onData` callback receives [custom data events](https://ai-sdk.dev/docs/ai-sdk-ui/streaming-data) from the server (like `data-chat-title`), allowing you to react to server-side events during streaming.
+The `onData` callback receives [custom data events](https://ai-sdk.dev/docs/ai-sdk-ui/streaming-data) from the server (like `data-chat-title`), so you can react to server-side events during streaming.
 
 **UChatMessages Component**
 
@@ -1141,7 +1141,9 @@ Then, in the Vercel dashboard:
 - Enable **AI Gateway** and add credits so requests can be processed.
 - Add a **Turso** database from the Vercel Marketplace and connect it to your project (it will provision the database and add the required environment variables automatically).
 
-> Note: On Vercel, you **don’t need to manually add `AI_GATEWAY_API_KEY`** — Vercel handles the gateway configuration for deployments. Keep using `.env` locally for development.
+::note
+On Vercel you don't need to manually add `AI_GATEWAY_API_KEY`. Vercel handles the gateway configuration for deployments. Keep using `.env` locally for development.
+::
 
 ::note{to="https://vercel.com/docs/ai-gateway" target="_blank"}
 Learn more about setting up AI Gateway in the **Vercel AI Gateway documentation**.
@@ -1161,7 +1163,7 @@ The combination of Nuxt's full-stack capabilities, Nuxt UI's purpose-built chat 
 
 **Resources:**
 
-- [Nuxt UI Chat Components](https://ui.nuxt.com/components/chat)
+- [Nuxt UI Chat Components](https://ui.nuxt.com/docs/components/chat)
 - [NuxtHub Database](https://hub.nuxt.com/docs/features/database)
 - [AI SDK Documentation](https://ai-sdk.dev)
 - [AI Gateway Documentation](https://vercel.com/docs/ai-gateway)

--- a/docs/content/blog/how-to-build-an-ai-chat.md
+++ b/docs/content/blog/how-to-build-an-ai-chat.md
@@ -36,7 +36,7 @@ Check out the [`Nuxt`](https://github.com/nuxt-ui-templates/chat) and [`Vue`](ht
 
 Before we start, make sure you have:
 
-- Node.js 20.19+ or 22.12+ installed
+- Node.js 22.19+ or 24.11+ installed
 - A [Vercel AI Gateway](https://vercel.com/docs/ai-gateway) API key (provides access to multiple AI providers through a single endpoint)
 
 ## Project setup
@@ -509,7 +509,7 @@ html.dark .shiki span {
 
 ## Creating the chat page
 
-The chat page is where the actual conversation happens. It integrates the AI SDK's [`Chat`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat) class and [`DefaultChatTransport`](https://ai-sdk.dev/docs/ai-sdk-ui/transport#default-transport) for real-time streaming.
+The chat page is where the actual conversation happens. It integrates the AI SDK's [`useChat`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat) composable and [`DefaultChatTransport`](https://ai-sdk.dev/docs/ai-sdk-ui/transport#default-transport) for real-time streaming.
 
 ::code-tree-intersection
 :::code-collapse

--- a/docs/content/blog/how-to-build-an-ai-chat.md
+++ b/docs/content/blog/how-to-build-an-ai-chat.md
@@ -532,7 +532,7 @@ if (!chatData.value) {
 
 const input = ref('')
 
-// Initialize the Chat class from AI SDK
+// Initialize the useChat composable from AI SDK
 const { messages, status, error, sendMessage, regenerate, stop } = useChat({
   id: chatData.value.id,
   messages: chatData.value.messages,
@@ -632,7 +632,7 @@ onMounted(() => {
 
 Here's a breakdown of the key parts:
 
-**The Chat Class**
+**The `useChat` composable**
 
 The [`useChat`](https://ai-sdk.dev/docs/reference/ai-sdk-ui/use-chat) composable from `@ai-sdk/vue` manages the entire conversation state. It handles:
 - Message history with `messages`
@@ -810,7 +810,7 @@ if (!chatData.value) {
 
 const input = ref('')
 
-// Initialize the Chat class from AI SDK
+// Initialize the useChat composable from AI SDK
 const { messages, status, error, sendMessage, regenerate, stop } = useChat({
   id: chatData.value.id,
   messages: chatData.value.messages,

--- a/docs/content/community.yml
+++ b/docs/content/community.yml
@@ -26,7 +26,7 @@ items:
     to: 'https://www.raycast.com/HugoRCD/nuxt'
     target: '_blank'
     user:
-      name: 'HugoRDC'
+      name: 'HugoRCD'
       to: 'https://github.com/HugoRCD'
       target: '_blank'
       avatar:

--- a/docs/content/docs/1.getting-started/1.index.md
+++ b/docs/content/docs/1.getting-started/1.index.md
@@ -90,7 +90,7 @@ Nuxt UI takes advantage of [Tailwind Variants](https://www.tailwind-variants.org
 
 ### Ecosystem integration
 
-Nuxt UI is SSR compatible and integrates seamlessly with the Nuxt ecosystem (these features also work in Vue with additional configuration):
+Nuxt UI is SSR compatible and integrates seamlessly with the ecosystem:
 
 ::framework-only
 #nuxt

--- a/docs/content/docs/1.getting-started/1.index.md
+++ b/docs/content/docs/1.getting-started/1.index.md
@@ -58,6 +58,8 @@ If you are migrating from v2, you can read more in this **migration guide**.
 
 ## Core technologies
 
+Nuxt UI is built on three foundations: Reka UI for behavior and accessibility, Tailwind CSS for styling, and Tailwind Variants for composing variants.
+
 ### Reka UI
 
 Nuxt UI is built on top of [Reka UI](https://reka-ui.com/) as a foundation for the components:
@@ -90,11 +92,23 @@ Nuxt UI takes advantage of [Tailwind Variants](https://www.tailwind-variants.org
 
 Nuxt UI is SSR compatible and integrates seamlessly with the Nuxt ecosystem (these features also work in Vue with additional configuration):
 
-- [**Icons**](/docs/getting-started/integrations/icons): Access 200,000+ icons from Iconify
+::framework-only
+#nuxt
+:::div
+- [**Icons**](/docs/getting-started/integrations/icons/nuxt): Access 200,000+ icons from Iconify
 - [**Fonts**](/docs/getting-started/integrations/fonts): Plug-and-play web font optimization and configuration
-- [**Color Mode**](/docs/getting-started/integrations/color-mode): Dark and Light mode with auto detection
-- [**i18n**](/docs/getting-started/integrations/i18n): Internationalize your components with 50+ languages
+- [**Color Mode**](/docs/getting-started/integrations/color-mode/nuxt): Dark and Light mode with auto detection
+- [**i18n**](/docs/getting-started/integrations/i18n/nuxt): Internationalize your components with 50+ languages
 - [**Content**](/docs/getting-started/integrations/content): Beautiful typography out of the box
+:::
+
+#vue
+:::div
+- [**Icons**](/docs/getting-started/integrations/icons/vue): Access 200,000+ icons from Iconify
+- [**Color Mode**](/docs/getting-started/integrations/color-mode/vue): Dark and Light mode with auto detection
+- [**i18n**](/docs/getting-started/integrations/i18n/vue): Internationalize your components with 50+ languages
+:::
+::
 
 ### Vue compatibility (Nuxt optional)
 

--- a/docs/content/docs/1.getting-started/2.installation/1.nuxt.md
+++ b/docs/content/docs/1.getting-started/2.installation/1.nuxt.md
@@ -493,7 +493,7 @@ Use the [`prose`](#prose) option instead.
 
 ### `content`
 
-Use the `content` option to force the import of the Nuxt UI `Prose` and `Content` components even if `@nuxt/content` is not installed.
+Use the `content` option to force the import of the Nuxt UI prose and content components even if `@nuxt/content` is not installed.
 
 - Default: `false`{lang="ts-type"}
 

--- a/docs/content/docs/1.getting-started/2.installation/1.nuxt.md
+++ b/docs/content/docs/1.getting-started/2.installation/1.nuxt.md
@@ -394,7 +394,7 @@ This strips **structural** classes too (positioning, transitions, flex/grid), no
 
 Use the `theme.defaultVariants` option to override the default `color` and `size` variants for components.
 
-This only affects components whose own default is `primary` or `md`. Components that ship a different default are left untouched, like Avatar with `color: 'neutral'` or Separator with `size: 'xs'`.
+Only defaults that are exactly `primary` or `md` are replaced, so Avatar keeps `color: 'neutral'` and Separator keeps `size: 'xs'`.
 
 - Default: `{ color: 'primary', size: 'md' }`{lang="ts-type"}
 
@@ -493,7 +493,7 @@ Use the [`prose`](#prose) option instead.
 
 ### `content`
 
-Use the `content` option to force the import of the Nuxt UI `Prose` and `Content` components, such as `ContentNavigation`, `ContentSearch`, `ContentSearchButton`, `ContentSurround` and `ContentToc`, even if `@nuxt/content` is not installed.
+Use the `content` option to force the import of the Nuxt UI `Prose` and `Content` components even if `@nuxt/content` is not installed.
 
 - Default: `false`{lang="ts-type"}
 

--- a/docs/content/docs/1.getting-started/2.installation/1.nuxt.md
+++ b/docs/content/docs/1.getting-started/2.installation/1.nuxt.md
@@ -104,7 +104,7 @@ It's recommended to install the [Tailwind CSS IntelliSense](https://marketplace.
 ```
 
 ::note{to="/docs/components/app"}
-The `App` component provides global configurations and is required for **Toast**, **Tooltip** components to work as well as **Programmatic Overlays**.
+The `App` component sets up global config and is required for **Toast**, **Tooltip** and **programmatic overlays**.
 ::
 
 ::
@@ -394,6 +394,8 @@ This strips **structural** classes too (positioning, transitions, flex/grid), no
 
 Use the `theme.defaultVariants` option to override the default `color` and `size` variants for components.
 
+This only affects components whose own default is `primary` or `md`. Components that ship a different default are left untouched, like Avatar with `color: 'neutral'` or Separator with `size: 'xs'`.
+
 - Default: `{ color: 'primary', size: 'md' }`{lang="ts-type"}
 
 ```ts [nuxt.config.ts] {4-11}
@@ -491,7 +493,7 @@ Use the [`prose`](#prose) option instead.
 
 ### `content`
 
-Use the `content` option to force the import of Nuxt UI `<Prose>` and `<UContent>` components even if `@nuxt/content` is not installed.
+Use the `content` option to force the import of the Nuxt UI `Prose` and `Content` components, such as `ContentNavigation`, `ContentSearch`, `ContentSearchButton`, `ContentSurround` and `ContentToc`, even if `@nuxt/content` is not installed.
 
 - Default: `false`{lang="ts-type"}
 

--- a/docs/content/docs/1.getting-started/2.installation/2.vue.md
+++ b/docs/content/docs/1.getting-started/2.installation/2.vue.md
@@ -605,7 +605,7 @@ export default defineConfig({
 
 ### `icon`
 
-Use the `icon` option to set default props for the [Icon](/docs/components/icon) component (`size`, `mode`, `customize`) and to configure build-time icon bundling through `clientBundle`.
+Use the `icon` option to set default props for the [Icon](/docs/components/icon) component (`size`, `mode`, `customize`) and to configure build-time icon bundling through `clientBundle`. Bundling of Nuxt UI's own icons is enabled by default when their collection is installed. Set `clientBundle: false` to opt out.
 
 - Default: `{}`{lang="ts-type"}
 

--- a/docs/content/docs/1.getting-started/2.installation/2.vue.md
+++ b/docs/content/docs/1.getting-started/2.installation/2.vue.md
@@ -562,8 +562,6 @@ export default defineConfig({
 
 Use the `ui` option to provide configuration for Nuxt UI. This is the Vue equivalent of the `ui` key in Nuxt's `app.config.ts`.
 
-- Default: `{}`{lang="ts-type"}
-
 ```ts [vite.config.ts] {9-14}
 import { defineConfig } from 'vite'
 import vue from '@vitejs/plugin-vue'
@@ -745,7 +743,7 @@ This strips **structural** classes too (positioning, transitions, flex/grid), no
 
 Use the `theme.defaultVariants` option to override the default `color` and `size` variants for components.
 
-This only affects components whose own default is `primary` or `md`. Components that ship a different default are left untouched, like Avatar with `color: 'neutral'` or Separator with `size: 'xs'`.
+Only defaults that are exactly `primary` or `md` are replaced, so Avatar keeps `color: 'neutral'` and Separator keeps `size: 'xs'`.
 
 - Default: `{ color: 'primary', size: 'md' }`{lang="ts-type"}
 

--- a/docs/content/docs/1.getting-started/2.installation/2.vue.md
+++ b/docs/content/docs/1.getting-started/2.installation/2.vue.md
@@ -956,7 +956,7 @@ export default defineConfig({
 ```
 
 ::note
-By default, only `@nuxt/ui` and `@compodium/examples` are scanned. Use this option when your external packages contain Vue components that use Nuxt UI.
+By default, only `@nuxt/ui` is scanned. Use this option when your external packages contain Vue components that use Nuxt UI.
 ::
 
 ### `root` :badge{label="4.9+" class="align-text-top"}

--- a/docs/content/docs/1.getting-started/2.installation/2.vue.md
+++ b/docs/content/docs/1.getting-started/2.installation/2.vue.md
@@ -140,7 +140,7 @@ These declaration files are only written when Vite runs. The default `create-vue
 ::
 
 ::tip
-Internally, Nuxt UI relies on custom alias to resolve the theme types. If you're using TypeScript, you should add an alias to your `tsconfig` to enable auto-completion in your `vite.config.ts`.
+Internally, Nuxt UI relies on custom aliases to resolve the theme types. If you're using TypeScript, add these aliases to your `tsconfig` files to enable auto-completion in your `vite.config.ts`.
 
 ```json [tsconfig.node.json]
 {
@@ -268,7 +268,7 @@ Import the CSS file in your entrypoint.
 
 :::code-group{sync="vite"}
 
-```ts [src/main.ts]{1}
+```ts [src/main.ts (Vite)]{1}
 import './assets/css/main.css'
 
 import { createApp } from 'vue'
@@ -560,7 +560,9 @@ export default defineConfig({
 
 ### `ui`
 
-Use the `ui` option to provide configuration for Nuxt UI.
+Use the `ui` option to provide configuration for Nuxt UI. This is the Vue equivalent of the `ui` key in Nuxt's `app.config.ts`.
+
+- Default: `{}`{lang="ts-type"}
 
 ```ts [vite.config.ts] {9-14}
 import { defineConfig } from 'vite'
@@ -581,6 +583,57 @@ export default defineConfig({
   ]
 })
 ```
+
+### `dts`
+
+Use the `dts` option to enable or disable the generation of declaration files for auto-imported components and composables.
+
+- Default: `true`{lang="ts-type"}
+
+```ts [vite.config.ts] {9}
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import ui from '@nuxt/ui/vite'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    ui({
+      dts: false
+    })
+  ]
+})
+```
+
+### `icon`
+
+Use the `icon` option to set default props for the [Icon](/docs/components/icon) component (`size`, `mode`, `customize`) and to configure build-time icon bundling through `clientBundle`.
+
+- Default: `{}`{lang="ts-type"}
+
+```ts [vite.config.ts] {9-14}
+import { defineConfig } from 'vite'
+import vue from '@vitejs/plugin-vue'
+import ui from '@nuxt/ui/vite'
+
+export default defineConfig({
+  plugins: [
+    vue(),
+    ui({
+      icon: {
+        mode: 'svg',
+        clientBundle: {
+          scan: true
+        }
+      }
+    })
+  ]
+})
+```
+
+::note{to="/docs/getting-started/integrations/icons/vue#collections"}
+Learn more about icon collections and client bundling in the **Icons** documentation.
+::
 
 ### `colorMode`
 
@@ -691,6 +744,8 @@ This strips **structural** classes too (positioning, transitions, flex/grid), no
 ### `theme.defaultVariants`
 
 Use the `theme.defaultVariants` option to override the default `color` and `size` variants for components.
+
+This only affects components whose own default is `primary` or `md`. Components that ship a different default are left untouched, like Avatar with `color: 'neutral'` or Separator with `size: 'xs'`.
 
 - Default: `{ color: 'primary', size: 'md' }`{lang="ts-type"}
 
@@ -901,7 +956,7 @@ export default defineConfig({
 ```
 
 ::note
-By default, only `@nuxt/ui` is scanned. Use this option when your external packages contain Vue components that use Nuxt UI.
+By default, only `@nuxt/ui` and `@compodium/examples` are scanned. Use this option when your external packages contain Vue components that use Nuxt UI.
 ::
 
 ### `root` :badge{label="4.9+" class="align-text-top"}

--- a/docs/content/docs/1.getting-started/3.migration/1.v4.md
+++ b/docs/content/docs/1.getting-started/3.migration/1.v4.md
@@ -12,7 +12,7 @@ links:
 Nuxt UI v4 marks a major milestone: **Nuxt UI and Nuxt UI Pro are now unified into a single, fully open-source and free library**. You now have access to 125+ production-ready components, all available in the `@nuxt/ui` package.
 
 ::note
-Nuxt UI v4 requires **Nuxt 4** due to some dependencies. Make sure to upgrade to Nuxt 4 before migrating to Nuxt UI v4.
+Nuxt UI v4 requires **Nuxt 4.1 or later** due to some dependencies. Make sure to upgrade before migrating to Nuxt UI v4.
 ::
 
 This guide provides step-by-step instructions to migrate your application from v3 to v4.
@@ -387,7 +387,7 @@ export default defineNuxtConfig({
 ```
 ::
 
-2. The `useChat` composable API changed — `input` and `handleSubmit` were removed in favor of `sendMessage`, and `messages` is now a ref you set directly:
+2. The `useChat` composable API changed: `input` and `handleSubmit` were removed in favor of `sendMessage`, and `messages` is now a ref you set directly:
 
 ```diff
 <script setup lang="ts">

--- a/docs/content/docs/1.getting-started/3.migration/2.v3.md
+++ b/docs/content/docs/1.getting-started/3.migration/2.v3.md
@@ -735,6 +735,8 @@ const groups = [{
 
 ### Changed composables
 
+Some composables changed their signature or the names of their options:
+
 - The `useToast()` composable `timeout` prop has been renamed to `duration`:
 
 ```diff
@@ -807,7 +809,7 @@ import { ModalExampleComponent } from '#components'
 -   })
 - }
 + async function openModal() {
-+   const instance = modal.open(ModalExampleComponent, {
++   const instance = modal.open({
 +     count: count.value
 +   })
 +
@@ -821,6 +823,8 @@ import { ModalExampleComponent } from '#components'
 ```
 
 ### Changed form validation
+
+Form errors changed shape, so any code reading them needs updating:
 
 - The error object property for targeting form fields has been renamed from `path` to `name`:
 

--- a/docs/content/docs/1.getting-started/4.contribution.md
+++ b/docs/content/docs/1.getting-started/4.contribution.md
@@ -31,11 +31,13 @@ The documentation lives in the `docs` folder as a Nuxt app using `@nuxt/content`
 │   ├── composables/
 │   └── ...
 ├── content/
-│   └── docs/
-│       ├── 1.getting-started
-│       ├── 2.components   # Components documentation
-│       ├── 3.composables
-│       └── 4.typography
+│   ├── blog/
+│   ├── docs/
+│   │   ├── 1.getting-started
+│   │   ├── 2.components   # Components documentation
+│   │   ├── 3.composables
+│   │   └── 4.typography
+│   └── ...            # Landing pages (index.yml, showcase.yml...)
 ```
 
 ### Module

--- a/docs/content/docs/1.getting-started/4.contribution.md
+++ b/docs/content/docs/1.getting-started/4.contribution.md
@@ -31,9 +31,11 @@ The documentation lives in the `docs` folder as a Nuxt app using `@nuxt/content`
 │   ├── composables/
 │   └── ...
 ├── content/
-│   ├── 1.getting-started
-│   ├── 2.composables
-│   └── 3.components       # Components documentation
+│   └── docs/
+│       ├── 1.getting-started
+│       ├── 2.components   # Components documentation
+│       ├── 3.composables
+│       └── 4.typography
 ```
 
 ### Module
@@ -59,6 +61,7 @@ The module code resides in the `src` folder. Here's a breakdown of its structure
 │   ├── accordion.ts       # Theme for Accordion component
 │   ├── alert.ts
 │   └── ...
+├── utils/
 └── module.ts
 ```
 
@@ -68,7 +71,7 @@ To make development easier, we've created a CLI that you can use to generate com
 
 First, you need to link the CLI to your global environment:
 
-```sh
+```bash
 npm link
 ```
 
@@ -76,7 +79,7 @@ npm link
 
 You can create new components using the following command:
 
-```sh
+```bash
 nuxt-ui make component <name> [options]
 ```
 
@@ -89,7 +92,7 @@ Available options:
 
 Example:
 
-```sh
+```bash
 # Create a basic component
 nuxt-ui make component my-component
 
@@ -111,7 +114,7 @@ When creating a new component, the CLI will automatically generate all the neces
 
 You can create new locales using the following command:
 
-```sh
+```bash
 nuxt-ui make locale --code <code>
 ```
 
@@ -119,7 +122,7 @@ The locale name and direction are filled in from [CLDR](https://cldr.unicode.org
 
 Once you have translated the messages, you can check your locale stays consistent with the others (message keys, placeholders, name and direction) by running:
 
-```sh
+```bash
 pnpm test locale --run
 ```
 
@@ -141,25 +144,25 @@ To begin local development, follow these steps:
 
 #### Clone the `nuxt/ui` repository to your local machine
 
-```sh
+```bash
 git clone -b v4 https://github.com/nuxt/ui.git
 ```
 
 #### Enable [Corepack](https://github.com/nodejs/corepack)
 
-```sh
+```bash
 corepack enable
 ```
 
 #### Install dependencies
 
-```sh
+```bash
 pnpm install
 ```
 
 #### Generate type stubs
 
-```sh
+```bash
 pnpm run dev:prepare
 ```
 
@@ -167,19 +170,19 @@ pnpm run dev:prepare
 
 - To work on the **documentation** located in the `docs` folder, run:
 
-```sh
+```bash
 pnpm run docs
 ```
 
 - To test the Nuxt components using the **playground**, run:
 
-```sh
+```bash
 pnpm run dev
 ```
 
 - To test the Vue components using the **playground**, run:
 
-```sh
+```bash
 pnpm run dev:vue
 ```
 
@@ -211,7 +214,7 @@ Since ESLint is already configured to format the code, there's no need for dupli
 
 You can use the `lint` command to check for linting errors:
 
-```sh
+```bash
 pnpm run lint # check for linting errors
 pnpm run lint:fix # fix linting errors
 ```
@@ -220,7 +223,7 @@ pnpm run lint:fix # fix linting errors
 
 We use TypeScript for type checking. You can use the `typecheck` command to check for type errors:
 
-```sh
+```bash
 pnpm run typecheck
 ```
 
@@ -228,7 +231,7 @@ pnpm run typecheck
 
 Before submitting a PR, ensure that you run the tests:
 
-```sh
+```bash
 pnpm run test
 ```
 

--- a/docs/content/docs/1.getting-started/5.theme/1.design-system.md
+++ b/docs/content/docs/1.getting-started/5.theme/1.design-system.md
@@ -133,7 +133,7 @@ When `prefers-reduced-motion` is set, overlays fade in place instead of scaling 
 
 ## Color System
 
-Nuxt UI's color system is designed around **semantic naming** rather than specific color values. This approach makes your UI more maintainable and allows for easy theme switching.
+Nuxt UI's color system is designed around **semantic naming** rather than specific color values. This approach makes your UI more maintainable and makes theme switching easy.
 
 ### Semantic colors
 

--- a/docs/content/docs/1.getting-started/5.theme/2.css-variables.md
+++ b/docs/content/docs/1.getting-started/5.theme/2.css-variables.md
@@ -6,7 +6,7 @@ navigation.icon: 'i-lucide-swatch-book'
 
 ## Colors
 
-Nuxt UI provides Tailwind CSS utility classes for each [semantic color](/docs/getting-started/theme/design-system#semantic-colors) you define, allowing you to use class names like `text-error` or `bg-success`:
+Nuxt UI provides Tailwind CSS utility classes for each [semantic color](/docs/getting-started/theme/design-system#semantic-colors) you define, so you can use class names like `text-error` or `bg-success`:
 
 ::code-preview
 [Primary]{class="text-primary text-sm px-4 py-1.5 inline-block"}
@@ -92,7 +92,7 @@ You can't use `primary: 'black'` in your [**config**](/docs/getting-started/them
 
 ## Text
 
-Nuxt UI provides Tailwind CSS utility classes for text colors, allowing you to use class names like `text-dimmed` or `text-muted`:
+Nuxt UI provides Tailwind CSS utility classes for text colors, so you can use class names like `text-dimmed` or `text-muted`:
 
 ::code-preview
 [Dimmed]{class="text-dimmed text-sm px-4 py-1.5 inline-block rounded-md"}
@@ -164,7 +164,7 @@ To change several of these variables at once, [assign a different color to `neut
 
 ## Background
 
-Nuxt UI provides Tailwind CSS utility classes for background colors, allowing you to use class names like `bg-default` or `bg-muted`:
+Nuxt UI provides Tailwind CSS utility classes for background colors, so you can use class names like `bg-default` or `bg-muted`:
 
 ::code-preview{class="[&>div>p]:flex [&>div>p]:flex-wrap [&>div>p]:gap-2"}
 [Default]{class="bg-default text-sm px-4 py-1.5 inline-block rounded-md"}
@@ -230,7 +230,7 @@ You can customize these CSS variables in your `main.css` file:
 
 ## Border
 
-Nuxt UI provides Tailwind CSS utility classes for border colors, allowing you to use class names like `border-default` or `border-muted`:
+Nuxt UI provides Tailwind CSS utility classes for border colors, so you can use class names like `border-default` or `border-muted`:
 
 ::code-preview{class="[&>div>p]:flex [&>div>p]:flex-wrap [&>div>p]:gap-2"}
 [Default]{class="border-2 border-default text-sm px-4 py-1.5 inline-block rounded-md"}
@@ -340,7 +340,7 @@ Make sure to declare these rules outside of any `@layer` so they take precedence
 
 ## Radius
 
-Nuxt UI overrides Tailwind CSS's default `rounded-*` utilities with a unified border radius system, allowing you to use regular [border radius utilities](https://tailwindcss.com/docs/border-radius) like `rounded-xs` or `rounded-2xl`:
+Nuxt UI overrides Tailwind CSS's default `rounded-*` utilities with a unified border radius system, so you can use regular [border radius utilities](https://tailwindcss.com/docs/border-radius) like `rounded-xs` or `rounded-2xl`:
 
 ::code-preview{class="[&>div>p]:flex [&>div>p]:flex-wrap [&>div>p]:gap-2"}
 [xs]{class="border-2 border-accented text-sm px-4 py-1.5 inline-block rounded-xs"}

--- a/docs/content/docs/1.getting-started/5.theme/3.components.md
+++ b/docs/content/docs/1.getting-started/5.theme/3.components.md
@@ -27,7 +27,6 @@ export default {
     body: 'p-4 sm:p-6',
     footer: 'p-4 sm:px-6'
   }
-  // variants omitted for brevity
 }
 ```
 
@@ -156,12 +155,12 @@ export default {
 ::framework-only
 #nuxt
 :::tip{to="/docs/getting-started/installation/nuxt#themedefaultvariants"}
-You can use the `theme.defaultVariants` option in your `nuxt.config.ts` to override the default values for `size` and `color` for all components at once.
+You can use the `theme.defaultVariants` option in your `nuxt.config.ts` to override the default `size` and `color` of every component that uses `md` and `primary`.
 :::
 
 #vue
 :::tip{to="/docs/getting-started/installation/vue#themedefaultvariants"}
-You can use the `theme.defaultVariants` option in your `vite.config.ts` to override the default values for `size` and `color` for all components at once.
+You can use the `theme.defaultVariants` option in your `vite.config.ts` to override the default `size` and `color` of every component that uses `md` and `primary`.
 :::
 ::
 

--- a/docs/content/docs/1.getting-started/5.theme/3.components.md
+++ b/docs/content/docs/1.getting-started/5.theme/3.components.md
@@ -20,32 +20,39 @@ Let's take the [Card](/docs/components/card) component as an example which has m
 ```ts [src/theme/card.ts]
 export default {
   slots: {
-    root: 'bg-default ring ring-default divide-y divide-default rounded-lg',
+    root: 'rounded-lg overflow-hidden',
     header: 'p-4 sm:px-6',
+    title: 'text-highlighted font-semibold',
+    description: 'mt-1 text-muted text-sm',
     body: 'p-4 sm:p-6',
     footer: 'p-4 sm:px-6'
   }
+  // variants omitted for brevity
 }
 ```
 
 ```vue [src/runtime/components/Card.vue]
 <template>
-  <div :class="ui.root({ class: [props.ui?.root, props.class] })">
-    <div :class="ui.header({ class: props.ui?.header })">
+  <Primitive :as="props.as" data-slot="root" :class="ui.root({ class: [props.ui?.root, props.class] })">
+    <div data-slot="header" :class="ui.header({ class: props.ui?.header })">
       <slot name="header" />
     </div>
 
-    <div :class="ui.body({ class: props.ui?.body })">
+    <div data-slot="body" :class="ui.body({ class: props.ui?.body })">
       <slot />
     </div>
 
-    <div :class="ui.footer({ class: props.ui?.footer })">
+    <div data-slot="footer" :class="ui.footer({ class: props.ui?.footer })">
       <slot name="footer" />
     </div>
-  </div>
+  </Primitive>
 </template>
 ```
 
+::
+
+::note
+The snippets above are abridged. The real components also carry `v-if` guards on each slot and the theme defines `variant` styles on top of the slots.
 ::
 
 Some components don't have slots, they are just composed of a single root element. In this case, the theme only defines the `base` slot like the [Container](/docs/components/container) component for example:
@@ -54,27 +61,27 @@ Some components don't have slots, they are just composed of a single root elemen
 
 ```ts [src/theme/container.ts]
 export default {
-  base: 'max-w-(--ui-container) mx-auto px-4 sm:px-6 lg:px-8'
+  base: 'w-full max-w-(--ui-container) mx-auto px-4 sm:px-6 lg:px-8'
 }
 ```
 
 ```vue [src/runtime/components/Container.vue]
 <template>
-  <div :class="container({ class: props.class })">
+  <Primitive :as="props.as" :class="ui({ class: [props.ui?.base, props.class] })">
     <slot />
-  </div>
+  </Primitive>
 </template>
 ```
 
 ::
 
-::warning
-Components without slots don't have a [`ui` prop](#ui-prop), only the [`class` prop](#class-prop) is available to override styles.
+::note
+Components without slots still have a [`ui` prop](#ui-prop). It exposes a single `base` key instead of one key per slot. [Link](/docs/components/link) and [Icon](/docs/components/icon) are the exceptions: they have no `ui` prop, so use the [`class` prop](#class-prop) to override their styles.
 ::
 
 ### Variants
 
-Components support `variants`, which allow you to dynamically adjust the styles of different `slots` based on component props.
+Components support `variants`, which dynamically adjust the styles of different `slots` based on component props.
 
 For example, the [Avatar](/docs/components/avatar) component uses a `size` variant to control its appearance:
 
@@ -189,12 +196,12 @@ export default (options: Required<ModuleOptions>) => ({
     ...(options.theme.colors || []).map((color: string) => ({
       color,
       variant: 'outline',
-      class: `ring ring-inset ring-${color}/50 text-${color} hover:bg-${color}/10 active:bg-${color}/10 disabled:bg-transparent aria-disabled:bg-transparent dark:disabled:bg-transparent dark:aria-disabled:bg-transparent focus:outline-none focus-visible:ring-2 focus-visible:ring-${color}`
+      class: `ring ring-inset ring-${color}/50 text-${color} hover:bg-${color}/10 active:bg-${color}/10 disabled:bg-transparent aria-disabled:bg-transparent dark:disabled:bg-transparent dark:aria-disabled:bg-transparent outline-${color}/25 focus-visible:outline-3 focus-visible:ring-${color}`
     })),
     {
       color: 'neutral',
       variant: 'outline',
-      class: 'ring ring-inset ring-accented text-default bg-default hover:bg-elevated active:bg-elevated disabled:bg-default aria-disabled:bg-default focus:outline-none focus-visible:ring-2 focus-visible:ring-inverted'
+      class: 'ring ring-inset ring-accented text-default bg-default hover:bg-elevated active:bg-elevated disabled:bg-default aria-disabled:bg-default outline-inverted/25 focus-visible:outline-3 focus-visible:ring-inverted'
     }
   ],
   defaultVariants: {
@@ -350,8 +357,16 @@ export default defineConfig({
 :::
 ::
 
-::tip{to="/docs/getting-started/installation/nuxt#themeunstyled"}
-To remove the default classes from all components at once, use the `theme.unstyled` option.
+::framework-only
+#nuxt
+:::tip{to="/docs/getting-started/installation/nuxt#themeunstyled"}
+To remove the default classes from all components at once, use the `theme.unstyled` option in your `nuxt.config.ts`.
+:::
+
+#vue
+:::tip{to="/docs/getting-started/installation/vue#themeunstyled"}
+To remove the default classes from all components at once, use the `theme.unstyled` option in your `vite.config.ts`.
+:::
 ::
 
 ### Theme component
@@ -409,7 +424,7 @@ The `ui` prop is resolved after the `variants`, so unlike in the global config, 
 
 ### `class` prop
 
-The `class` prop allows you to override the classes of the `root` or `base` slot. This takes priority over both global config and resolved `variants`.
+Use the `class` prop to override the classes of the `root` or `base` slot. This takes priority over both global config and resolved `variants`.
 
 ::component-code{slug="button"}
 ---

--- a/docs/content/docs/1.getting-started/6.integrations/1.icons/2.vue.md
+++ b/docs/content/docs/1.getting-started/6.integrations/1.icons/2.vue.md
@@ -16,6 +16,8 @@ Looking for the **Nuxt** version?
 
 ## Usage
 
+Nuxt UI ships an `Icon` component backed by [`@iconify/vue`](https://iconify.design/docs/icon-components/vue/), so there's no additional setup required.
+
 ### Icon component
 
 You can use the [Icon](/docs/components/icon) component with a `name` prop to display an icon:

--- a/docs/content/docs/1.getting-started/6.integrations/3.color-mode/1.nuxt.md
+++ b/docs/content/docs/1.getting-started/6.integrations/3.color-mode/1.nuxt.md
@@ -22,7 +22,7 @@ Nuxt UI automatically registers the [`@nuxtjs/color-mode`](https://github.com/nu
 
 You can use the built-in [ColorModeAvatar](/docs/components/color-mode-avatar) or [ColorModeImage](/docs/components/color-mode-image) components to display different images for light and dark mode and the [ColorModeButton](/docs/components/color-mode-button), [ColorModeSwitch](/docs/components/color-mode-switch) or [ColorModeSelect](/docs/components/color-mode-select) components to switch between light and dark modes.
 
-You can also use the [useColorMode](https://color-mode.nuxtjs.org/#usage) composable to build your own custom component:
+You can also use the [useColorMode](https://color-mode.nuxtjs.org/usage/basic) composable to build your own custom component:
 
 ```vue [ColorModeButton.vue]
 <script setup lang="ts">

--- a/docs/content/docs/1.getting-started/6.integrations/3.color-mode/2.vue.md
+++ b/docs/content/docs/1.getting-started/6.integrations/3.color-mode/2.vue.md
@@ -21,6 +21,7 @@ You can also use the [useColorMode](https://vueuse.org/core/useColorMode) compos
 
 ```vue [ColorModeButton.vue]
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useColorMode } from '@vueuse/core'
 
 const colorMode = useColorMode()
@@ -30,7 +31,7 @@ const isDark = computed({
     return colorMode.value === 'dark'
   },
   set(_isDark: boolean) {
-    colorMode.preference = _isDark ? 'dark' : 'light'
+    colorMode.value = _isDark ? 'dark' : 'light'
   }
 })
 </script>
@@ -38,8 +39,8 @@ const isDark = computed({
 <template>
   <UButton
     :icon="isDark ? 'i-lucide-moon' : 'i-lucide-sun'"
-    :color="color"
-    :variant="variant"
+    color="neutral"
+    variant="ghost"
     :aria-label="`Switch to ${isDark ? 'light' : 'dark'} mode`"
     @click="isDark = !isDark"
   />

--- a/docs/content/docs/1.getting-started/6.integrations/4.i18n/1.nuxt.md
+++ b/docs/content/docs/1.getting-started/6.integrations/4.i18n/1.nuxt.md
@@ -32,7 +32,7 @@ import { fr } from '@nuxt/ui/locale'
 ```
 
 ::tip
-Each locale has a `code` property (e.g., `en`, `en-GB`, `fr`) that determines the date/time format in components like [Calendar](/docs/components/calendar), [InputDate](/docs/components/input-date) and [InputTime](/docs/components/input-time).
+Each locale has a `code` property (e.g. `en`, `en-GB`, `fr`) that determines the date/time format in components like [Calendar](/docs/components/calendar), [InputDate](/docs/components/input-date) and [InputTime](/docs/components/input-time).
 ::
 
 ### Custom locale

--- a/docs/content/docs/1.getting-started/6.integrations/4.i18n/2.vue.md
+++ b/docs/content/docs/1.getting-started/6.integrations/4.i18n/2.vue.md
@@ -32,7 +32,7 @@ import { fr } from '@nuxt/ui/locale'
 ```
 
 ::tip
-Each locale has a `code` property (e.g., `en`, `en-GB`, `fr`) that determines the date/time format in components like [Calendar](/docs/components/calendar), [InputDate](/docs/components/input-date) and [InputTime](/docs/components/input-time).
+Each locale has a `code` property (e.g. `en`, `en-GB`, `fr`) that determines the date/time format in components like [Calendar](/docs/components/calendar), [InputDate](/docs/components/input-date) and [InputTime](/docs/components/input-time).
 ::
 
 ### Custom locale
@@ -183,7 +183,7 @@ const { locale } = useI18n()
 
 Each locale has a `dir` property which will be used by the `App` component to set the directionality of all components.
 
-In a multilingual application, you might want to set the `lang` and `dir` attributes on the `<html>` element dynamically based on the user's locale, which you can do with the [useHead](https://unhead.unjs.io/usage/composables/use-head) composable:
+In a multilingual application, you might want to set the `lang` and `dir` attributes on the `<html>` element dynamically based on the user's locale, which you can do with the [useHead](https://unhead.unjs.io/docs/head/api/composables/use-head) composable:
 
 ```vue [App.vue]
 <script setup lang="ts">

--- a/docs/content/docs/1.getting-started/6.integrations/5.content.md
+++ b/docs/content/docs/1.getting-started/6.integrations/5.content.md
@@ -42,7 +42,7 @@ export default defineNuxtConfig({
 ```
 
 ::caution
-You need to register `@nuxt/content` after `@nuxt/ui` in the `modules` array. Both `@nuxtjs/mdc` and Nuxt UI register prose components under the same names, and Nuxt keeps the first one registered, so listing `@nuxt/content` first gives you the unstyled MDC components.
+You need to register `@nuxt/content` after `@nuxt/ui` in the `modules` array, otherwise the prose components will not be available.
 ::
 
 ## Configuration

--- a/docs/content/docs/1.getting-started/6.integrations/5.content.md
+++ b/docs/content/docs/1.getting-started/6.integrations/5.content.md
@@ -42,7 +42,7 @@ export default defineNuxtConfig({
 ```
 
 ::caution
-You need to register `@nuxt/content` after `@nuxt/ui` in the `modules` array, otherwise the prose components will not be available.
+You need to register `@nuxt/content` after `@nuxt/ui` in the `modules` array. Both `@nuxtjs/mdc` and Nuxt UI register prose components under the same names, and Nuxt keeps the first one registered, so listing `@nuxt/content` first gives you the unstyled MDC components.
 ::
 
 ## Configuration
@@ -84,13 +84,15 @@ You might be using `@nuxt/content` to build a documentation. To help you with th
 
 ## Typography
 
-Nuxt UI provides its own custom implementations of all prose components for seamless integration with `@nuxt/content`. This approach ensures consistent styling, complete control over typography, and perfect alignment with the Nuxt UI design system so your content always looks and feels cohesive out of the box.
+Nuxt UI provides its own implementations of all prose components, so markdown rendered by `@nuxt/content` picks up the same theme as the rest of your components.
 
 ::note{to="/docs/typography"}
 Discover the full **Typography** system and explore all available prose components for rich, consistent content presentation.
 ::
 
 ## Utils
+
+Nuxt UI ships helpers to reshape the data returned by `@nuxt/content` into the format its components expect.
 
 ### `mapContentNavigation`
 
@@ -100,7 +102,7 @@ This util will map the navigation from `queryCollectionNavigation` and transform
 - `navigation`: The navigation tree (array of ContentNavigationItem).
 - `options` (optional):
   - `labelAttribute`: (string) Which field to use as label (`title` by default)
-  - `deep`: (number or undefined) Controls how many levels of navigation are included (`undefined` by default : includes all levels)
+  - `deep`: (number or undefined) Controls how many levels of navigation are included (`undefined` by default, includes all levels)
 
 **Example:** As shown in the breadcrumb example below, it's commonly used to transform the navigation data into the correct format.
 
@@ -109,9 +111,15 @@ This util will map the navigation from `queryCollectionNavigation` and transform
 import { mapContentNavigation } from '@nuxt/ui/utils/content'
 import { findPageBreadcrumb } from '@nuxt/content/utils'
 
-const { data: navigation } = await useAsyncData('navigation', () => queryCollectionNavigation('content'))
+const route = useRoute()
 
-const breadcrumb = computed(() => mapContentNavigation(findPageBreadcrumb(navigation?.value, page.value?.path, { indexAsChild: true })).map(({ icon, ...link }) => link), { deep: 0 })
+const { data: navigation } = await useAsyncData('navigation', () => queryCollectionNavigation('content'))
+const { data: page } = await useAsyncData(route.path, () => queryCollection('content').path(route.path).first())
+
+const breadcrumb = computed(() => mapContentNavigation(
+  findPageBreadcrumb(navigation.value, page.value?.path, { indexAsChild: true }),
+  { deep: 0 }
+).map(({ icon, ...link }) => link))
 </script>
 
 <template>

--- a/docs/content/docs/1.getting-started/7.ai/1.mcp.md
+++ b/docs/content/docs/1.getting-started/7.ai/1.mcp.md
@@ -39,8 +39,8 @@ The Nuxt UI MCP server provides the following tools organized by category:
 
 ### Documentation Tools
 
-- **`search-documentation`**: Search documentation pages by title, description, or section. With no params, lists all pages. Use `section` to filter (e.g., `"getting-started"`, `"components"`)
-- **`get-documentation-page`**: Retrieves documentation page content by URL path. Supports a `headings` parameter to fetch only specific h2 sections (e.g., `["Usage", "API"]`) and reduce response size
+- **`search-documentation`**: Search documentation pages by title, description, or section. With no params, lists all pages. Use `section` to filter (e.g. `"getting-started"`, `"components"`)
+- **`get-documentation-page`**: Retrieves documentation page content by URL path. Supports a `headings` parameter to fetch only specific h2 sections (e.g. `["Usage", "API"]`) and reduce response size
 
 ### Template Tools
 
@@ -400,5 +400,5 @@ Once configured, you can ask your AI assistant questions like:
 The AI assistant will use the MCP server to fetch structured JSON data and provide guided assistance for Nuxt UI during development.
 
 ::tip
-For component docs, the AI can use the `sections` parameter (`usage`, `examples`, `api`, `theme`, `changelog`) to fetch only relevant parts. For other pages, use the `headings` parameter with h2 titles (e.g., `["Usage", "API"]`).
+For component docs, the AI can use the `sections` parameter (`usage`, `examples`, `api`, `theme`, `changelog`) to fetch only relevant parts. For other pages, use the `headings` parameter with h2 titles (e.g. `["Usage", "API"]`).
 ::

--- a/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
+++ b/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
@@ -40,7 +40,7 @@ Nuxt UI provides specialized LLMs.txt files that you can reference in Cursor for
 1. **Direct reference**: Mention the LLMs.txt URLs when asking questions
 2. Add these specific URLs to your project context using `@docs`
 
-[Read more about Cursor Web and Docs Search](https://docs.cursor.com/en/context/@-symbols/@-docs)
+[Read more about Cursor Web and Docs Search](https://cursor.com/docs/agent/prompting)
 
 ### Windsurf
 

--- a/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
+++ b/docs/content/docs/1.getting-started/7.ai/2.llms-txt.md
@@ -40,7 +40,7 @@ Nuxt UI provides specialized LLMs.txt files that you can reference in Cursor for
 1. **Direct reference**: Mention the LLMs.txt URLs when asking questions
 2. Add these specific URLs to your project context using `@docs`
 
-[Read more about Cursor Web and Docs Search](https://cursor.com/docs/agent/prompting)
+[Read more about prompting and `@` mentions in Cursor](https://cursor.com/docs/agent/prompting)
 
 ### Windsurf
 

--- a/docs/content/docs/2.components/0.index.md
+++ b/docs/content/docs/2.components/0.index.md
@@ -94,12 +94,22 @@ Check out the **Docs template** on GitHub for a real-life example.
 
 ## Color Mode
 
-Components that integrate with [Color Mode](/docs/getting-started/integrations/color-mode) for theme switching between light, dark, and system preferences.
+::framework-only
+#nuxt
+Components that integrate with [Color Mode](/docs/getting-started/integrations/color-mode/nuxt) for theme switching between light, dark, and system preferences.
+#vue
+Components that integrate with [Color Mode](/docs/getting-started/integrations/color-mode/vue) for theme switching between light, dark, and system preferences.
+::
 
 :components-list{category="color-mode"}
 
 ## i18n
 
-Components that integrate with [i18n](/docs/getting-started/integrations/i18n) for internationalization and locale management.
+::framework-only
+#nuxt
+Components that integrate with [i18n](/docs/getting-started/integrations/i18n/nuxt) for internationalization and locale management.
+#vue
+Components that integrate with [i18n](/docs/getting-started/integrations/i18n/vue) for internationalization and locale management.
+::
 
 :components-list{category="i18n"}

--- a/docs/content/docs/2.components/alert.md
+++ b/docs/content/docs/2.components/alert.md
@@ -12,8 +12,6 @@ links:
 
 ## Usage
 
-Use the Alert component to display a callout with a title, a description and optional actions.
-
 ### Title
 
 Use the `title` prop to set the title of the Alert.

--- a/docs/content/docs/2.components/alert.md
+++ b/docs/content/docs/2.components/alert.md
@@ -1,5 +1,5 @@
 ---
-description: A callout to draw user's attention.
+description: A callout to draw the user's attention.
 category: element
 keywords:
   - notice
@@ -11,6 +11,8 @@ links:
 ---
 
 ## Usage
+
+Use the Alert component to display a callout with a title, a description and optional actions.
 
 ### Title
 

--- a/docs/content/docs/2.components/app.md
+++ b/docs/content/docs/2.components/app.md
@@ -1,6 +1,5 @@
 ---
-title: App
-description: Wraps your app to provide global configurations and more.
+description: A wrapper to provide global configuration, toasts and tooltips to your app.
 category: layout
 links:
   - label: GitHub

--- a/docs/content/docs/2.components/avatar-group.md
+++ b/docs/content/docs/2.components/avatar-group.md
@@ -2,6 +2,10 @@
 title: AvatarGroup
 description: Stack multiple avatars in a group.
 category: element
+keywords:
+  - stacked avatars
+  - faces
+  - members
 links:
   - label: GitHub
     icon: i-simple-icons-github

--- a/docs/content/docs/2.components/banner.md
+++ b/docs/content/docs/2.components/banner.md
@@ -12,8 +12,6 @@ links:
 
 ## Usage
 
-Use the Banner component to display an announcement at the very top of your app.
-
 ### Title
 
 Use the `title` prop to display a title on the Banner.

--- a/docs/content/docs/2.components/banner.md
+++ b/docs/content/docs/2.components/banner.md
@@ -1,5 +1,4 @@
 ---
-title: Banner
 description: 'Display a banner at the top of your website to inform users about important information.'
 category: element
 keywords:
@@ -12,6 +11,8 @@ links:
 ---
 
 ## Usage
+
+Use the Banner component to display an announcement at the very top of your app.
 
 ### Title
 

--- a/docs/content/docs/2.components/button.md
+++ b/docs/content/docs/2.components/button.md
@@ -1,6 +1,10 @@
 ---
 description: A button element that can act as a link or trigger an action.
 category: element
+keywords:
+  - cta
+  - action
+  - btn
 links:
   - label: GitHub
     icon: i-simple-icons-github

--- a/docs/content/docs/2.components/calendar.md
+++ b/docs/content/docs/2.components/calendar.md
@@ -162,7 +162,7 @@ props:
 ---
 ::
 
-### Number of Months
+### Number Of Months
 
 Use the `numberOfMonths` prop to change the number of months in the calendar.
 

--- a/docs/content/docs/2.components/calendar.md
+++ b/docs/content/docs/2.components/calendar.md
@@ -1,7 +1,10 @@
 ---
-title: Calendar
 description: A calendar component for selecting single dates, multiple dates or date ranges.
 category: element
+keywords:
+  - date picker
+  - datepicker
+  - schedule
 links:
   - label: Calendar
     icon: i-custom-reka-ui
@@ -159,7 +162,7 @@ props:
 ---
 ::
 
-### Number Of Months
+### Number of Months
 
 Use the `numberOfMonths` prop to change the number of months in the calendar.
 

--- a/docs/content/docs/2.components/card.md
+++ b/docs/content/docs/2.components/card.md
@@ -1,6 +1,10 @@
 ---
 description: Display content in a card with a header, body and footer.
 category: element
+keywords:
+  - panel
+  - box
+  - container
 links:
   - label: GitHub
     icon: i-simple-icons-github

--- a/docs/content/docs/2.components/carousel.md
+++ b/docs/content/docs/2.components/carousel.md
@@ -254,7 +254,7 @@ class: 'p-8 px-16'
 
 ### With thumbnails
 
-You can use the [`emblaApi`](#expose) function [scrollTo](https://www.embla-carousel.com/docs/v8/api/methods#scrollto) to display thumbnails under the carousel that navigate to a specific slide.
+You can use the [`scrollTo`](https://www.embla-carousel.com/docs/v8/api/methods#scrollto) method on [`emblaApi`](#expose) to display thumbnails under the carousel that navigate to a specific slide.
 
 ::component-example
 ---

--- a/docs/content/docs/2.components/carousel.md
+++ b/docs/content/docs/2.components/carousel.md
@@ -8,7 +8,7 @@ keywords:
   - slideshow
 links:
   - label: Embla
-    to: https://www.embla-carousel.com/api/
+    to: https://www.embla-carousel.com/docs/v8/api
     icon: i-custom-embla-carousel
   - label: GitHub
     icon: i-simple-icons-github
@@ -150,13 +150,13 @@ class: 'p-8 px-16 pb-12'
 
 ## Plugins
 
-The Carousel component implements the official [Embla Carousel plugins](https://www.embla-carousel.com/plugins/).
+The Carousel component implements the official [Embla Carousel plugins](https://www.embla-carousel.com/docs/v8/plugins).
 
 ### Autoplay
 
 This plugin is used to extend Embla Carousel with **autoplay** functionality.
 
-Use the `autoplay` prop as a boolean or an object to configure the [Autoplay plugin](https://www.embla-carousel.com/plugins/autoplay/).
+Use the `autoplay` prop as a boolean or an object to configure the [Autoplay plugin](https://www.embla-carousel.com/docs/v8/plugins/autoplay).
 
 ::component-example
 ---
@@ -173,7 +173,7 @@ In this example, we're using the `loop` prop for an infinite carousel.
 
 This plugin is used to extend Embla Carousel with **auto scroll** functionality.
 
-Use the `auto-scroll` prop as a boolean or an object to configure the [Auto Scroll plugin](https://www.embla-carousel.com/plugins/auto-scroll/).
+Use the `auto-scroll` prop as a boolean or an object to configure the [Auto Scroll plugin](https://www.embla-carousel.com/docs/v8/plugins/auto-scroll).
 
 ::component-example
 ---
@@ -190,7 +190,7 @@ In this example, we're using the `loop` prop for an infinite carousel.
 
 This plugin is used to extend Embla Carousel with **auto height** functionality. It changes the height of the carousel container to fit the height of the highest slide in view.
 
-Use the `auto-height` prop as a boolean or an object to configure the [Auto Height plugin](https://www.embla-carousel.com/plugins/auto-height/).
+Use the `auto-height` prop as a boolean or an object to configure the [Auto Height plugin](https://www.embla-carousel.com/docs/v8/plugins/auto-height).
 
 ::component-example
 ---
@@ -207,7 +207,7 @@ In this example, we add the `transition-[height]` class on the container to anim
 
 Class Names is a **class name toggle** utility plugin for Embla Carousel that enables you to automate the toggling of class names on your carousel.
 
-Use the `class-names` prop as a boolean or an object to configure the [Class Names plugin](https://www.embla-carousel.com/plugins/class-names/).
+Use the `class-names` prop as a boolean or an object to configure the [Class Names plugin](https://www.embla-carousel.com/docs/v8/plugins/class-names).
 
 ::component-example
 ---
@@ -224,7 +224,7 @@ In this example, we add the `transition-opacity [&:not(.is-snapped)]:opacity-10`
 
 This plugin is used to replace the Embla Carousel scroll functionality with **fade transitions**.
 
-Use the `fade` prop as a boolean or an object to configure the [Fade plugin](https://www.embla-carousel.com/plugins/fade/).
+Use the `fade` prop as a boolean or an object to configure the [Fade plugin](https://www.embla-carousel.com/docs/v8/plugins/fade).
 
 ::component-example
 ---
@@ -237,7 +237,7 @@ class: 'p-8 pb-12'
 
 This plugin is used to extend Embla Carousel with the ability to **use the mouse/trackpad wheel** to navigate the carousel.
 
-Use the `wheel-gestures` prop as a boolean or an object to configure the [Wheel Gestures plugin](https://www.embla-carousel.com/plugins/wheel-gestures/).
+Use the `wheel-gestures` prop as a boolean or an object to configure the [Wheel Gestures plugin](https://www.embla-carousel.com/docs/v8/plugins/wheel-gestures).
 
 ::note
 Use your mouse wheel to scroll the carousel.
@@ -254,7 +254,7 @@ class: 'p-8 px-16'
 
 ### With thumbnails
 
-You can use the [`emblaApi`](#expose) function [scrollTo](https://www.embla-carousel.com/api/methods/#scrollto) to display thumbnails under the carousel that allows you to navigate to a specific slide.
+You can use the [`emblaApi`](#expose) function [scrollTo](https://www.embla-carousel.com/docs/v8/api/methods#scrollto) to display thumbnails under the carousel that navigate to a specific slide.
 
 ::component-example
 ---
@@ -296,7 +296,7 @@ This will give you access to the following:
 | Name | Type |
 | ---- | ---- |
 | `emblaRef`{lang="ts-type"} | `Ref<HTMLElement \| null>`{lang="ts-type"} |
-| `emblaApi`{lang="ts-type"} | [`Ref<EmblaCarouselType \| null>`{lang="ts-type"}](https://www.embla-carousel.com/api/methods/#typescript) |
+| `emblaApi`{lang="ts-type"} | [`Ref<EmblaCarouselType \| null>`{lang="ts-type"}](https://www.embla-carousel.com/docs/v8/api/methods#typescript) |
 
 ## Theme
 

--- a/docs/content/docs/2.components/changelog-version.md
+++ b/docs/content/docs/2.components/changelog-version.md
@@ -36,11 +36,11 @@ authors:
     to: https://x.com/atinux
     target: _blank
   - name: Hugo Richard
-    description: '@hugorcd__'
+    description: '@hugorcd'
     avatar:
       src: https://github.com/hugorcd.png
       loading: lazy
-    to: https://x.com/hugorcd__
+    to: https://x.com/hugorcd
     target: _blank
 to: 'https://nuxt.com/blog/nuxt-ui-v3'
 target: '_blank'
@@ -254,11 +254,11 @@ props:
       to: https://x.com/atinux
       target: _blank
     - name: Hugo Richard
-      description: '@hugorcd__'
+      description: '@hugorcd'
       avatar:
         src: https://github.com/hugorcd.png
         loading: lazy
-      to: https://x.com/hugorcd__
+      to: https://x.com/hugorcd
       target: _blank
   class: 'w-full'
   ui.container: 'max-w-lg'

--- a/docs/content/docs/2.components/changelog-versions.md
+++ b/docs/content/docs/2.components/changelog-versions.md
@@ -243,7 +243,7 @@ When using a custom `container`, make sure the container element is mounted befo
 :component-slots
 
 ::tip
-You can use all the slots of the [`ChangelogVersion`](/docs/components/changelog-version#slots) component inside ChangelogVersions, they are automatically forwarded allowing you to customize individual versions when using the `versions` prop.
+You can use all the slots of the [`ChangelogVersion`](/docs/components/changelog-version#slots) component inside ChangelogVersions, they are automatically forwarded so you can customize individual versions when using the `versions` prop.
 
 ```vue{3-5}
 <template>

--- a/docs/content/docs/2.components/chat-message.md
+++ b/docs/content/docs/2.components/chat-message.md
@@ -58,7 +58,7 @@ props:
 ::
 
 ::note
-The `parts` prop is the recommended format for the AI SDK. Each part has a `type` (e.g., 'text') and corresponding content. The ChatMessage component also supports the deprecated `content` prop for backward compatibility.
+The `parts` prop is the recommended format for the AI SDK. Each part has a `type` (e.g. 'text') and corresponding content. The ChatMessage component also supports the deprecated `content` prop for backward compatibility.
 ::
 
 ### Side

--- a/docs/content/docs/2.components/chat-messages.md
+++ b/docs/content/docs/2.components/chat-messages.md
@@ -372,7 +372,7 @@ Use the `should-auto-scroll` prop to enable/disable continuous auto scroll while
 </template>
 ```
 
-### Should Scroll To Bottom
+### Should Scroll to Bottom
 
 Use the `should-scroll-to-bottom` prop to enable/disable bottom auto scroll when the component is mounted. Defaults to `true`.
 
@@ -411,7 +411,7 @@ collapse: true
 :component-slots
 
 ::tip
-You can use all the slots of the [`ChatMessage`](/docs/components/chat-message#slots) component inside ChatMessages, they are automatically forwarded allowing you to customize individual messages when using the `messages` prop.
+You can use all the slots of the [`ChatMessage`](/docs/components/chat-message#slots) component inside ChatMessages, they are automatically forwarded so you can customize individual messages when using the `messages` prop.
 
 ```vue{7-15}
 <script setup lang="ts">

--- a/docs/content/docs/2.components/chat-messages.md
+++ b/docs/content/docs/2.components/chat-messages.md
@@ -372,7 +372,7 @@ Use the `should-auto-scroll` prop to enable/disable continuous auto scroll while
 </template>
 ```
 
-### Should Scroll to Bottom
+### Should Scroll To Bottom
 
 Use the `should-scroll-to-bottom` prop to enable/disable bottom auto scroll when the component is mounted. Defaults to `true`.
 

--- a/docs/content/docs/2.components/chat.md
+++ b/docs/content/docs/2.components/chat.md
@@ -147,7 +147,7 @@ export default defineEventHandler(async (event) => {
 
 ### Reasoning
 
-To enable [reasoning](https://ai-sdk.dev/docs/ai-sdk-ui/chatbot#reasoning), configure `providerOptions` for your provider ([Anthropic](https://ai-sdk.dev/docs/guides/providers/anthropic#reasoning), [Google](https://ai-sdk.dev/providers/ai-sdk-providers/google#thinking), [OpenAI](https://ai-sdk.dev/docs/guides/providers/openai#reasoning)):
+To enable [reasoning](https://ai-sdk.dev/docs/ai-sdk-ui/chatbot#reasoning), configure `providerOptions` for your provider ([Anthropic](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic#reasoning), [Google](https://ai-sdk.dev/providers/ai-sdk-providers/google#thinking), [OpenAI](https://ai-sdk.dev/providers/ai-sdk-providers/openai#reasoning)):
 
 ```ts [server/api/chat.post.ts]
 import { streamText, convertToModelMessages, toUIMessageStream, createUIMessageStreamResponse } from 'ai'
@@ -188,7 +188,7 @@ export default defineEventHandler(async (event) => {
 
 ### Web Search
 
-Some providers offer built-in web search tools: [Anthropic](https://ai-sdk.dev/docs/guides/providers/anthropic#web-search-tool), [Google](https://ai-sdk.dev/providers/ai-sdk-providers/google#google-search), [OpenAI](https://ai-sdk.dev/providers/ai-sdk-providers/openai#web-search-tool).
+Some providers offer built-in web search tools: [Anthropic](https://ai-sdk.dev/providers/ai-sdk-providers/anthropic#web-search-tool), [Google](https://ai-sdk.dev/providers/ai-sdk-providers/google#google-search), [OpenAI](https://ai-sdk.dev/providers/ai-sdk-providers/openai#web-search-tool).
 
 ::code-group
 

--- a/docs/content/docs/2.components/chat.md
+++ b/docs/content/docs/2.components/chat.md
@@ -1,5 +1,4 @@
 ---
-title: Chat
 description: Build AI chat interfaces with streaming, reasoning, and tool calling.
 category: chat
 index: true
@@ -148,7 +147,7 @@ export default defineEventHandler(async (event) => {
 
 ### Reasoning
 
-To enable [reasoning](https://ai-sdk.dev/docs/ai-sdk-ui/chatbot#reasoning), configure `providerOptions` for your provider ([Anthropic](https://ai-sdk.dev/docs/guides/providers/anthropic#reasoning), [Google](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai#thinking), [OpenAI](https://ai-sdk.dev/docs/guides/providers/openai#reasoning)):
+To enable [reasoning](https://ai-sdk.dev/docs/ai-sdk-ui/chatbot#reasoning), configure `providerOptions` for your provider ([Anthropic](https://ai-sdk.dev/docs/guides/providers/anthropic#reasoning), [Google](https://ai-sdk.dev/providers/ai-sdk-providers/google#thinking), [OpenAI](https://ai-sdk.dev/docs/guides/providers/openai#reasoning)):
 
 ```ts [server/api/chat.post.ts]
 import { streamText, convertToModelMessages, toUIMessageStream, createUIMessageStreamResponse } from 'ai'
@@ -189,7 +188,7 @@ export default defineEventHandler(async (event) => {
 
 ### Web Search
 
-Some providers offer built-in web search tools: [Anthropic](https://ai-sdk.dev/docs/guides/providers/anthropic#web-search-tool), [Google](https://ai-sdk.dev/providers/ai-sdk-providers/google-generative-ai#google-search), [OpenAI](https://ai-sdk.dev/providers/ai-sdk-providers/openai#web-search-tool).
+Some providers offer built-in web search tools: [Anthropic](https://ai-sdk.dev/docs/guides/providers/anthropic#web-search-tool), [Google](https://ai-sdk.dev/providers/ai-sdk-providers/google#google-search), [OpenAI](https://ai-sdk.dev/providers/ai-sdk-providers/openai#web-search-tool).
 
 ::code-group
 

--- a/docs/content/docs/2.components/checkbox-group.md
+++ b/docs/content/docs/2.components/checkbox-group.md
@@ -5,7 +5,6 @@ category: form
 keywords:
   - multi select
   - checklist
-  - options
 links:
   - label: CheckboxGroup
     icon: i-custom-reka-ui

--- a/docs/content/docs/2.components/checkbox-group.md
+++ b/docs/content/docs/2.components/checkbox-group.md
@@ -1,7 +1,11 @@
 ---
 title: CheckboxGroup
-description: A set of checklist buttons to select multiple option from a list.
+description: A set of checkboxes to select multiple options from a list.
 category: form
+keywords:
+  - multi select
+  - checklist
+  - options
 links:
   - label: CheckboxGroup
     icon: i-custom-reka-ui

--- a/docs/content/docs/2.components/checkbox.md
+++ b/docs/content/docs/2.components/checkbox.md
@@ -1,6 +1,10 @@
 ---
 description: An input element to toggle between checked and unchecked states.
 category: form
+keywords:
+  - tickbox
+  - check
+  - boolean
 links:
   - label: Checkbox
     icon: i-custom-reka-ui

--- a/docs/content/docs/2.components/collapsible.md
+++ b/docs/content/docs/2.components/collapsible.md
@@ -119,7 +119,7 @@ In this example, leveraging [`defineShortcuts`](/docs/composables/define-shortcu
 ::
 
 ::tip
-This allows you to move the trigger outside of the Collapsible or remove it entirely.
+This lets you move the trigger outside of the Collapsible or remove it entirely.
 ::
 
 ### With rotating icon

--- a/docs/content/docs/2.components/color-mode-select.md
+++ b/docs/content/docs/2.components/color-mode-select.md
@@ -1,6 +1,6 @@
 ---
 title: ColorModeSelect
-description: 'A Select to switch between system, dark & light mode.'
+description: 'A Select to switch between system, dark and light mode.'
 category: color-mode
 links:
   - label: SelectMenu

--- a/docs/content/docs/2.components/color-mode-switch.md
+++ b/docs/content/docs/2.components/color-mode-switch.md
@@ -1,6 +1,6 @@
 ---
 title: ColorModeSwitch
-description: 'A switch to toggle between light and dark mode.'
+description: 'A Switch to toggle between light and dark mode.'
 category: color-mode
 links:
   - label: Switch

--- a/docs/content/docs/2.components/color-picker.md
+++ b/docs/content/docs/2.components/color-picker.md
@@ -2,6 +2,10 @@
 title: ColorPicker
 description: A component to select a color.
 category: form
+keywords:
+  - colour picker
+  - swatch
+  - hex
 links:
   - label: GitHub
     icon: i-simple-icons-github

--- a/docs/content/docs/2.components/command-palette.md
+++ b/docs/content/docs/2.components/command-palette.md
@@ -983,7 +983,7 @@ You can use the `fuse` prop to override the options of [useFuse](https://vueuse.
 ```
 
 ::tip
-The `fuseOptions` are the options of [Fuse.js](https://www.fusejs.io/api/options.html), the `resultLimit` is the maximum number of results to return and the `matchAllWhenSearchEmpty` is a boolean to match all items when the search term is empty.
+The `fuseOptions` are the options of [Fuse.js](https://www.fusejs.io/fuzzy-search.html#other-options), the `resultLimit` is the maximum number of results to return and the `matchAllWhenSearchEmpty` is a boolean to match all items when the search term is empty.
 ::
 
 You can for example set `{ fuseOptions: { includeMatches: true } }`{lang="ts-type"} to highlight the search term in the items.

--- a/docs/content/docs/2.components/command-palette.md
+++ b/docs/content/docs/2.components/command-palette.md
@@ -983,7 +983,7 @@ You can use the `fuse` prop to override the options of [useFuse](https://vueuse.
 ```
 
 ::tip
-The `fuseOptions` are the options of [Fuse.js](https://www.fusejs.io/fuzzy-search.html#other-options), the `resultLimit` is the maximum number of results to return and the `matchAllWhenSearchEmpty` is a boolean to match all items when the search term is empty.
+The `fuseOptions` are the options of [Fuse.js](https://www.fusejs.io/), the `resultLimit` is the maximum number of results to return and the `matchAllWhenSearchEmpty` is a boolean to match all items when the search term is empty.
 ::
 
 You can for example set `{ fuseOptions: { includeMatches: true } }`{lang="ts-type"} to highlight the search term in the items.

--- a/docs/content/docs/2.components/container.md
+++ b/docs/content/docs/2.components/container.md
@@ -1,5 +1,5 @@
 ---
-description: A container lets you center and constrain the width of your content.
+description: A layout element to center and constrain the width of your content.
 category: layout
 links:
   - label: GitHub

--- a/docs/content/docs/2.components/content-navigation.md
+++ b/docs/content/docs/2.components/content-navigation.md
@@ -235,16 +235,8 @@ props:
 ---
 ::
 
-::framework-only
-#nuxt
-:::tip{to="/docs/getting-started/integrations/icons/nuxt#theme"}
+::tip{to="/docs/getting-started/integrations/icons/nuxt#theme"}
 You can customize this icon globally in your `app.config.ts` under `ui.icons.chevronDown` key.
-:::
-
-#vue
-:::tip{to="/docs/getting-started/integrations/icons/vue#theme"}
-You can customize this icon globally in your `vite.config.ts` under `ui.icons.chevronDown` key.
-:::
 ::
 
 ## Examples

--- a/docs/content/docs/2.components/content-navigation.md
+++ b/docs/content/docs/2.components/content-navigation.md
@@ -198,6 +198,8 @@ props:
 
 ### Trailing Icon
 
+Use the `trailing-icon` prop to customize the trailing [Icon](/docs/components/icon) of items that have children. Defaults to `i-lucide-chevron-down`.
+
 ::component-code{prefix="content"}
 ---
 prettier: true

--- a/docs/content/docs/2.components/content-navigation.md
+++ b/docs/content/docs/2.components/content-navigation.md
@@ -235,6 +235,18 @@ props:
 ---
 ::
 
+::framework-only
+#nuxt
+:::tip{to="/docs/getting-started/integrations/icons/nuxt#theme"}
+You can customize this icon globally in your `app.config.ts` under `ui.icons.chevronDown` key.
+:::
+
+#vue
+:::tip{to="/docs/getting-started/integrations/icons/vue#theme"}
+You can customize this icon globally in your `vite.config.ts` under `ui.icons.chevronDown` key.
+:::
+::
+
 ## Examples
 
 ### Within a layout

--- a/docs/content/docs/2.components/content-search.md
+++ b/docs/content/docs/2.components/content-search.md
@@ -1,6 +1,6 @@
 ---
 title: ContentSearch
-description: 'A ready to use CommandPalette to add to your documentation.'
+description: 'A ready-to-use CommandPalette to add to your documentation.'
 category: content
 framework: nuxt
 links:

--- a/docs/content/docs/2.components/content-surround.md
+++ b/docs/content/docs/2.components/content-surround.md
@@ -44,12 +44,12 @@ props:
   nextIcon: 'i-lucide-chevron-right'
   surround:
   - title: ContentSearchButton
-    path: /components/content-search-button
-    stem: 3.components/content-search-button
+    path: /docs/components/content-search-button
+    stem: docs/2.components/content-search-button
     description: A pre-styled Button to open the ContentSearch modal.
   - title: ContentToc
-    path: /components/content-toc
-    stem: 3.components/content-toc
+    path: /docs/components/content-toc
+    stem: docs/2.components/content-toc
     description: A sticky Table of Contents with customizable slots.
 ---
 ::

--- a/docs/content/docs/2.components/dashboard-panel.md
+++ b/docs/content/docs/2.components/dashboard-panel.md
@@ -33,7 +33,7 @@ It is recommended to set an `id` when using multiple panels in different pages t
 ::
 
 ::warning
-This component does not have a single root element when using the `resizable` prop, so wrap it in a container (e.g., `<div class="flex flex-1">`) if you use page transitions or require a single root for layout.
+This component does not have a single root element when using the `resizable` prop, so wrap it in a container (e.g. `<div class="flex flex-1">`) if you use page transitions or require a single root for layout.
 ::
 
 Use the `header`, `body` and `footer` slots to customize the panel or the default slot if you don't want a scrollable body with padding.

--- a/docs/content/docs/2.components/dashboard-search.md
+++ b/docs/content/docs/2.components/dashboard-search.md
@@ -1,6 +1,6 @@
 ---
 title: DashboardSearch
-description: 'A ready to use CommandPalette to add to your dashboard.'
+description: 'A ready-to-use CommandPalette to add to your dashboard.'
 category: dashboard
 links:
   - label: CommandPalette

--- a/docs/content/docs/2.components/dashboard-sidebar.md
+++ b/docs/content/docs/2.components/dashboard-sidebar.md
@@ -31,7 +31,7 @@ Use it inside the default slot of the [DashboardGroup](/docs/components/dashboar
 ```
 
 ::warning
-This component does not have a single root element when using the `resizable` prop, so wrap it in a container (e.g., `<div class="flex flex-1">`) if you use page transitions or require a single root for layout.
+This component does not have a single root element when using the `resizable` prop, so wrap it in a container (e.g. `<div class="flex flex-1">`) if you use page transitions or require a single root for layout.
 ::
 
 Use the `header`, `default` and `footer` slots to customize the sidebar and the `body` or `content` slots to customize the sidebar menu.

--- a/docs/content/docs/2.components/drawer.md
+++ b/docs/content/docs/2.components/drawer.md
@@ -1,5 +1,5 @@
 ---
-description: A drawer that smoothly slides in & out of the screen.
+description: A drawer that smoothly slides in and out of the screen.
 category: overlay
 keywords:
   - bottom sheet
@@ -404,7 +404,7 @@ In this example, leveraging [`defineShortcuts`](/docs/composables/define-shortcu
 ::
 
 ::tip
-This allows you to move the trigger outside of the Drawer or remove it entirely.
+This lets you move the trigger outside of the Drawer or remove it entirely.
 ::
 
 ### Responsive drawer

--- a/docs/content/docs/2.components/dropdown-menu.md
+++ b/docs/content/docs/2.components/dropdown-menu.md
@@ -2,6 +2,10 @@
 title: DropdownMenu
 description: A menu to display actions when clicking on an element.
 category: overlay
+keywords:
+  - menu
+  - context menu
+  - actions
 links:
   - label: DropdownMenu
     icon: i-custom-reka-ui

--- a/docs/content/docs/2.components/editor-toolbar.md
+++ b/docs/content/docs/2.components/editor-toolbar.md
@@ -29,7 +29,7 @@ class: 'p-8'
 ::
 
 ::callout{icon="i-custom-tiptap"}
-The bubble and floating layouts use TipTap's [BubbleMenu](https://tiptap.dev/docs/editor/extensions/functionality/bubble-menu) and [FloatingMenu](https://tiptap.dev/docs/editor/extensions/functionality/floating-menu) extensions.
+The bubble and floating layouts use TipTap's [BubbleMenu](https://tiptap.dev/docs/editor/extensions/functionality/bubble-menu) and [FloatingMenu](https://tiptap.dev/docs/editor/extensions/functionality/floatingmenu) extensions.
 ::
 
 ### Items

--- a/docs/content/docs/2.components/editor.md
+++ b/docs/content/docs/2.components/editor.md
@@ -1,5 +1,4 @@
 ---
-title: Editor
 description: A rich text editor component based on TipTap with support for markdown, HTML, and JSON content types.
 category: editor
 links:
@@ -309,7 +308,7 @@ const items: EditorToolbarItem[] = [
 
 #### Custom handlers
 
-Use the `handlers` prop to extend or override the default handlers. Custom handlers are merged with the default handlers, allowing you to add new actions or modify existing behavior.
+Use the `handlers` prop to extend or override the default handlers. Custom handlers are merged with the default handlers, so you can add new actions or modify existing behavior.
 
 Each handler implements the `EditorHandler`{lang="ts-type"} interface:
 

--- a/docs/content/docs/2.components/empty.md
+++ b/docs/content/docs/2.components/empty.md
@@ -1,5 +1,4 @@
 ---
-title: Empty
 description: 'A component to display an empty state.'
 category: data
 keywords:
@@ -13,6 +12,8 @@ links:
 ---
 
 ## Usage
+
+Use the Empty component to display a placeholder state when there is no content to show.
 
 ::code-preview
 

--- a/docs/content/docs/2.components/error.md
+++ b/docs/content/docs/2.components/error.md
@@ -1,5 +1,4 @@
 ---
-title: Error
 description: 'A pre-built error component with NuxtError support.'
 category: layout
 links:

--- a/docs/content/docs/2.components/file-upload.md
+++ b/docs/content/docs/2.components/file-upload.md
@@ -77,7 +77,7 @@ props:
 
 ### Accept
 
-Use the `accept` prop to specify the allowed file types for the input. Provide a comma-separated list of [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types) or file extensions (e.g., `image/png,application/pdf,.jpg`). Defaults to `*` (all file types).
+Use the `accept` prop to specify the allowed file types for the input. Provide a comma-separated list of [MIME types](https://developer.mozilla.org/en-US/docs/Web/HTTP/Guides/MIME_types) or file extensions (e.g. `image/png,application/pdf,.jpg`). Defaults to `*` (all file types).
 
 ::component-code
 ---

--- a/docs/content/docs/2.components/footer-columns.md
+++ b/docs/content/docs/2.components/footer-columns.md
@@ -2,6 +2,10 @@
 title: FooterColumns
 description: 'A list of links as columns to display in your Footer.'
 category: navigation
+keywords:
+  - footer links
+  - sitemap
+  - columns
 links:
   - label: GitHub
     icon: i-simple-icons-github

--- a/docs/content/docs/2.components/footer.md
+++ b/docs/content/docs/2.components/footer.md
@@ -1,6 +1,5 @@
 ---
-title: Footer
-description: 'A responsive footer component.'
+description: 'A responsive footer for your site links and legal notices.'
 category: layout
 links:
   - label: GitHub

--- a/docs/content/docs/2.components/form-field.md
+++ b/docs/content/docs/2.components/form-field.md
@@ -146,7 +146,7 @@ slots:
 This sets the `color` to `error` on the form control. You can change it globally in your `app.config.ts`.
 ::
 
-### Error pattern
+### Error Pattern
 
 Use the `error-pattern` prop to match form errors with a regular expression. This is especially relevant for components with array values such as [InputTags](/docs/components/input-tags), where errors include array indices in their name (e.g. `tags.0`).
 

--- a/docs/content/docs/2.components/form.md
+++ b/docs/content/docs/2.components/form.md
@@ -1,6 +1,10 @@
 ---
 description: A form component with built-in validation and submission handling.
 category: form
+keywords:
+  - validation
+  - schema
+  - submit
 links:
   - label: GitHub
     icon: i-simple-icons-github

--- a/docs/content/docs/2.components/header.md
+++ b/docs/content/docs/2.components/header.md
@@ -1,6 +1,5 @@
 ---
-title: Header
-description: 'A responsive header component.'
+description: 'A responsive header for your site navigation.'
 category: layout
 links:
   - label: GitHub

--- a/docs/content/docs/2.components/icon.md
+++ b/docs/content/docs/2.components/icon.md
@@ -1,16 +1,23 @@
 ---
 description: A component to display any icon from Iconify or another component.
 category: element
+keywords:
+  - svg
+  - iconify
+  - symbol
 links:
   - label: Iconify
     to: https://iconify.design/
     target: _blank
     icon: i-simple-icons-iconify
+  - label: GitHub
+    icon: i-simple-icons-github
+    to: https://github.com/nuxt/ui/blob/v4/src/runtime/components/Icon.vue
 ---
 
 ## Usage
 
-Use the `name` prop to display an icon:
+Use the `name` prop to display an icon.
 
 ::component-code
 ---

--- a/docs/content/docs/2.components/input-time.md
+++ b/docs/content/docs/2.components/input-time.md
@@ -2,6 +2,10 @@
 title: InputTime
 description: 'An input for selecting a time.'
 category: form
+keywords:
+  - time picker
+  - clock
+  - hour
 links:
   - label: TimeField
     icon: i-custom-reka-ui

--- a/docs/content/docs/2.components/input.md
+++ b/docs/content/docs/2.components/input.md
@@ -278,7 +278,7 @@ name: 'input-kbd-example'
 ---
 ::
 
-::note{to="/composables/define-shortcuts"}
+::note{to="/docs/composables/define-shortcuts"}
 This example uses the `defineShortcuts` composable to focus the Input when the :kbd{value="/"} key is pressed.
 ::
 

--- a/docs/content/docs/2.components/kbd.md
+++ b/docs/content/docs/2.components/kbd.md
@@ -1,5 +1,4 @@
 ---
-title: Kbd
 description: A kbd element to display a keyboard key.
 category: element
 keywords:

--- a/docs/content/docs/2.components/link.md
+++ b/docs/content/docs/2.components/link.md
@@ -1,6 +1,10 @@
 ---
-description: A wrapper around <NuxtLink> with extra props.
+description: A wrapper around NuxtLink with extra props.
 category: navigation
+keywords:
+  - anchor
+  - href
+  - navigation
 links:
   - label: GitHub
     icon: i-simple-icons-github

--- a/docs/content/docs/2.components/listbox.md
+++ b/docs/content/docs/2.components/listbox.md
@@ -1,6 +1,10 @@
 ---
 description: A selectable list of items with search, virtualization and rich item rendering.
 category: form
+keywords:
+  - option list
+  - picker
+  - selection
 links:
   - label: Listbox
     icon: i-custom-reka-ui
@@ -573,7 +577,7 @@ props:
 ---
 ::
 
-### Control selected items
+### Control selected item(s)
 
 You can control the selected item by using the `default-value` prop or the `v-model` directive.
 

--- a/docs/content/docs/2.components/main.md
+++ b/docs/content/docs/2.components/main.md
@@ -1,5 +1,4 @@
 ---
-title: Main
 description: 'A main element that fills the available viewport height.'
 category: layout
 links:

--- a/docs/content/docs/2.components/marquee.md
+++ b/docs/content/docs/2.components/marquee.md
@@ -1,7 +1,10 @@
 ---
-title: Marquee
 description: 'A component to create infinite scrolling content.'
 category: data
+keywords:
+  - ticker
+  - scroller
+  - carousel
 links:
   - label: GitHub
     icon: i-simple-icons-github

--- a/docs/content/docs/2.components/modal.md
+++ b/docs/content/docs/2.components/modal.md
@@ -440,7 +440,7 @@ preview: false
 ::
 
 ::note
-We are emitting a `close` event when the modal is closed or dismissed here. You can emit any data through the `close` event, but it must be emitted to capture the return value.
+We are emitting a `close` event when the modal is closed or dismissed here. You can emit any data through the `close` event, and that data becomes the resolved value of `open()`. The event must be emitted for the promise to resolve.
 ::
 
 Then, use it in your app:

--- a/docs/content/docs/2.components/modal.md
+++ b/docs/content/docs/2.components/modal.md
@@ -418,7 +418,7 @@ In this example, leveraging [`defineShortcuts`](/docs/composables/define-shortcu
 ::
 
 ::tip
-This allows you to move the trigger outside of the Modal or remove it entirely.
+This lets you move the trigger outside of the Modal or remove it entirely.
 ::
 
 ### Programmatic usage
@@ -440,7 +440,7 @@ preview: false
 ::
 
 ::note
-We are emitting a `close` event when the modal is closed or dismissed here. You can emit any data through the `close` event, however, the event must be emitted in order to capture the return value.
+We are emitting a `close` event when the modal is closed or dismissed here. You can emit any data through the `close` event, but it must be emitted to capture the return value.
 ::
 
 Then, use it in your app:

--- a/docs/content/docs/2.components/page-card.md
+++ b/docs/content/docs/2.components/page-card.md
@@ -101,7 +101,7 @@ props:
   title: 'Tailwind CSS'
   description: 'Nuxt UI integrates with latest Tailwind CSS, bringing significant improvements.'
   icon: 'i-simple-icons-tailwindcss'
-  to: 'https://tailwindcss.com/docs/v4-beta'
+  to: 'https://tailwindcss.com/blog/tailwindcss-v4'
   target: _blank
   class: 'w-96'
 ---
@@ -126,7 +126,7 @@ props:
   title: 'Tailwind CSS'
   description: 'Nuxt UI integrates with latest Tailwind CSS, bringing significant improvements.'
   icon: 'i-simple-icons-tailwindcss'
-  to: 'https://tailwindcss.com/docs/v4-beta'
+  to: 'https://tailwindcss.com/blog/tailwindcss-v4'
   target: _blank
   variant: soft
   class: 'w-96'

--- a/docs/content/docs/2.components/page-links.md
+++ b/docs/content/docs/2.components/page-links.md
@@ -26,7 +26,7 @@ props:
   links:
     - label: 'Edit this page'
       icon: i-lucide-file-pen
-      to: https://github.com/nuxt/ui/blob/v4/docs/content/3.components/page-links.md
+      to: https://github.com/nuxt/ui/blob/v4/docs/content/docs/2.components/page-links.md
     - label: 'Star on GitHub'
       icon: i-lucide-star
       to: https://github.com/nuxt/ui
@@ -60,7 +60,7 @@ props:
   links:
     - label: 'Edit this page'
       icon: i-lucide-file-pen
-      to: https://github.com/nuxt/ui/blob/v4/docs/content/3.components/page-links.md
+      to: https://github.com/nuxt/ui/blob/v4/docs/content/docs/2.components/page-links.md
     - label: 'Star on GitHub'
       icon: i-lucide-star
       to: https://github.com/nuxt/ui
@@ -88,7 +88,7 @@ props:
   links:
     - label: 'Edit this page'
       icon: i-lucide-file-pen
-      to: https://github.com/nuxt/ui/blob/v4/docs/content/3.components/page-links.md
+      to: https://github.com/nuxt/ui/blob/v4/docs/content/docs/2.components/page-links.md
     - label: 'Star on GitHub'
       icon: i-lucide-star
       to: https://github.com/nuxt/ui

--- a/docs/content/docs/2.components/page-logos.md
+++ b/docs/content/docs/2.components/page-logos.md
@@ -61,7 +61,7 @@ props:
 You can display logos in two ways:
 
 1. Using the `items` prop to provide a list of logos. Each item can be either:
-  - An icon name (e.g., `i-simple-icons-github`)
+  - An icon name (e.g. `i-simple-icons-github`)
   - An object containing `src` and `alt` properties for images, which will be utilized in a `UAvatar` component
 2. Using the default slot to have complete control over the content
 

--- a/docs/content/docs/2.components/pagination.md
+++ b/docs/content/docs/2.components/pagination.md
@@ -52,7 +52,7 @@ props:
 ---
 ::
 
-### Items Per Page
+### Items per Page
 
 Use the `items-per-page` prop to set the number of items per page. Defaults to `10`.
 

--- a/docs/content/docs/2.components/pagination.md
+++ b/docs/content/docs/2.components/pagination.md
@@ -52,7 +52,7 @@ props:
 ---
 ::
 
-### Items per Page
+### Items Per Page
 
 Use the `items-per-page` prop to set the number of items per page. Defaults to `10`.
 

--- a/docs/content/docs/2.components/pricing-table.md
+++ b/docs/content/docs/2.components/pricing-table.md
@@ -100,10 +100,10 @@ Use the `tiers` prop as an array of objects to define your pricing plans. Each t
 - `id: string`{lang="ts-type"} - Unique identifier for the tier (required)
 - `title?: string`{lang="ts-type"} - Name of the pricing plan
 - `description?: string`{lang="ts-type"} - Short description of the plan
-- `price?: string`{lang="ts-type"} - The current price of the plan (e.g., "$99", "€99", "Free")
-- `discount?: string`{lang="ts-type"} - The discounted price that will display the `price` with strikethrough (e.g., "$79", "€79")
-- `billingCycle?: string`{lang="ts-type"} - The unit price period that appears next to the price (e.g., "/month", "/seat/month")
-- `billingPeriod?: string`{lang="ts-type"} - Additional billing context that appears above the billing cycle (e.g., "billed monthly")
+- `price?: string`{lang="ts-type"} - The current price of the plan (e.g. "$99", "€99", "Free")
+- `discount?: string`{lang="ts-type"} - The discounted price that will display the `price` with strikethrough (e.g. "$79", "€79")
+- `billingCycle?: string`{lang="ts-type"} - The unit price period that appears next to the price (e.g. "/month", "/seat/month")
+- `billingPeriod?: string`{lang="ts-type"} - Additional billing context that appears above the billing cycle (e.g. "billed monthly")
 - `badge?: string | BadgeProps`{lang="ts-type"} - Display a badge next to the title `{ color: 'primary', variant: 'subtle' }`{lang="ts-type"}
 - `button?: ButtonProps`{lang="ts-type"} - Configure the CTA button `{ size: 'lg', block: true }`{lang="ts-type"}
 - `highlight?: boolean`{lang="ts-type"} - Whether to visually emphasize this tier as the recommended option
@@ -160,8 +160,8 @@ Use the `sections` prop to organize features into logical groups. Each section r
 - `features: PricingTableSectionFeature[]`{lang="ts-type"} - An array of features with their availability in each tier:
   - Each feature requires a `title` and a `tiers` object mapping tier IDs to values
   - Boolean values (`true`/`false`) will display as checkmarks (✓) or minus icons (-)
-  - String values will be shown as text (e.g., "Unlimited", "Up to 5 users")
-  - Numeric values will be displayed as is (e.g., 10, 100)
+  - String values will be shown as text (e.g. "Unlimited", "Up to 5 users")
+  - Numeric values will be displayed as is (e.g. 10, 100)
 
 ::component-code
 ---
@@ -249,7 +249,7 @@ The component supports various slot types for maximum customization flexibility:
 | **Generic slots** | `#tier-title`, `#section-title`, etc. | Apply to all items | `#feature-value` |
 
 ::note
-When no `id` is provided, the slot name is auto-generated from the title (e.g., "Premium Features!" becomes `#section-premium-features-title`).
+When no `id` is provided, the slot name is auto-generated from the title (e.g. "Premium Features!" becomes `#section-premium-features-title`).
 ::
 
 ## API

--- a/docs/content/docs/2.components/radio-group.md
+++ b/docs/content/docs/2.components/radio-group.md
@@ -2,6 +2,10 @@
 title: RadioGroup
 description: A set of radio buttons to select a single option from a list.
 category: form
+keywords:
+  - radio buttons
+  - single choice
+  - options
 links:
   - label: RadioGroup
     icon: i-custom-reka-ui

--- a/docs/content/docs/2.components/radio-group.md
+++ b/docs/content/docs/2.components/radio-group.md
@@ -5,7 +5,6 @@ category: form
 keywords:
   - radio buttons
   - single choice
-  - options
 links:
   - label: RadioGroup
     icon: i-custom-reka-ui

--- a/docs/content/docs/2.components/scroll-area.md
+++ b/docs/content/docs/2.components/scroll-area.md
@@ -2,6 +2,10 @@
 title: ScrollArea
 description: A flexible scroll container with virtualization support.
 category: data
+keywords:
+  - scrollbar
+  - overflow
+  - scrolling
 links:
   - label: TanStack Virtual
     avatar:

--- a/docs/content/docs/2.components/select.md
+++ b/docs/content/docs/2.components/select.md
@@ -1,6 +1,10 @@
 ---
 description: A select element to choose from a list of options.
 category: form
+keywords:
+  - dropdown
+  - picker
+  - options
 links:
   - label: Select
     icon: i-custom-reka-ui

--- a/docs/content/docs/2.components/select.md
+++ b/docs/content/docs/2.components/select.md
@@ -4,7 +4,6 @@ category: form
 keywords:
   - dropdown
   - picker
-  - options
 links:
   - label: Select
     icon: i-custom-reka-ui

--- a/docs/content/docs/2.components/sidebar.md
+++ b/docs/content/docs/2.components/sidebar.md
@@ -1,5 +1,4 @@
 ---
-title: Sidebar
 description: 'A collapsible sidebar with multiple visual variants.'
 category: layout
 links:

--- a/docs/content/docs/2.components/slideover.md
+++ b/docs/content/docs/2.components/slideover.md
@@ -408,7 +408,7 @@ In this example, leveraging [`defineShortcuts`](/docs/composables/define-shortcu
 ::
 
 ::tip
-This allows you to move the trigger outside of the Slideover or remove it entirely.
+This lets you move the trigger outside of the Slideover or remove it entirely.
 ::
 
 ### Programmatic usage
@@ -430,7 +430,7 @@ preview: false
 ::
 
 ::note
-We are emitting a `close` event when the slideover is closed or dismissed here. You can emit any data through the `close` event, however, the event must be emitted in order to capture the return value.
+We are emitting a `close` event when the slideover is closed or dismissed here. You can emit any data through the `close` event, but it must be emitted to capture the return value.
 ::
 
 Then, use it in your app:

--- a/docs/content/docs/2.components/slideover.md
+++ b/docs/content/docs/2.components/slideover.md
@@ -430,7 +430,7 @@ preview: false
 ::
 
 ::note
-We are emitting a `close` event when the slideover is closed or dismissed here. You can emit any data through the `close` event, but it must be emitted to capture the return value.
+We are emitting a `close` event when the slideover is closed or dismissed here. You can emit any data through the `close` event, and that data becomes the resolved value of `open()`. The event must be emitted for the promise to resolve.
 ::
 
 Then, use it in your app:

--- a/docs/content/docs/2.components/table.md
+++ b/docs/content/docs/2.components/table.md
@@ -99,7 +99,7 @@ Use the `columns` prop as an array of [ColumnDef](https://tanstack.com/table/v8/
   - [`rowspan`](#with-column-span):
     - `td`: [The rowspan attribute to apply to the `td` element.]{class="text-muted"}
 
-In order to render components or other HTML elements, you will need to use the Vue [`h` function](https://vuejs.org/api/render-function.html#h) inside the `header` and `cell` props. This is different from other components that use slots but allows for more flexibility.
+To render components or other HTML elements, you need to use the Vue [`h` function](https://vuejs.org/api/render-function.html#h) inside the `header` and `cell` props. This is different from other components that use slots but allows for more flexibility.
 
 ::tip{to="#with-slots" aria-label="Table columns with slots"}
 You can also use slots to customize the header and data cells of the table.
@@ -304,7 +304,7 @@ You could also add this action to the [`DropdownMenu`](/docs/components/dropdown
 
 You can group rows based on a given column value and show/hide sub rows via some button added to the cell using the TanStack Table [Grouping APIs](https://tanstack.com/table/v8/docs/api/features/grouping).
 
-#### Important parts:
+#### Important parts
 
 * Add `grouping` prop with an array of column ids you want to group by.
 * Add `grouping-options` prop. It must include `getGroupedRowModel`, you can import it from `@tanstack/vue-table` or implement your own.
@@ -693,7 +693,7 @@ class: '!p-0'
 ::
 
 ::note
-A height constraint is required on the table for virtualization to work properly (e.g., `class="h-[400px]"`).
+A height constraint is required on the table for virtualization to work properly (e.g. `class="h-[400px]"`).
 ::
 
 ### With external scroll element :badge{label="4.10+" class="align-text-top"}

--- a/docs/content/docs/2.components/tabs.md
+++ b/docs/content/docs/2.components/tabs.md
@@ -1,6 +1,10 @@
 ---
 description: A set of tab panels that are displayed one at a time.
 category: navigation
+keywords:
+  - tabbed
+  - panels
+  - sections
 links:
   - label: Tabs
     icon: i-custom-reka-ui
@@ -12,7 +16,7 @@ links:
 
 ## Usage
 
-Use the Tabs component to display a list of items in a tabs.
+Use the Tabs component to display a list of items in tabs.
 
 ::component-example
 ---

--- a/docs/content/docs/2.components/theme.md
+++ b/docs/content/docs/2.components/theme.md
@@ -9,7 +9,7 @@ links:
 
 ## Usage
 
-The Theme component allows you to override default **slot classes** and **props** of all child components without modifying each one individually. It uses Vue's `provide` / `inject` mechanism under the hood, so the overrides apply at any depth.
+The Theme component overrides default **slot classes** and **props** of all child components without modifying each one individually. It uses Vue's `provide` / `inject` mechanism under the hood, so the overrides apply at any depth.
 
 ::note
 The Theme component doesn't render any HTML element, it only provides theme overrides to its children.

--- a/docs/content/docs/2.components/timeline.md
+++ b/docs/content/docs/2.components/timeline.md
@@ -1,5 +1,4 @@
 ---
-title: Timeline
 description: 'A component that displays a sequence of events with dates, titles, icons or avatars.'
 category: data
 keywords:

--- a/docs/content/docs/2.components/toast.md
+++ b/docs/content/docs/2.components/toast.md
@@ -129,7 +129,7 @@ name: 'toast-close-example'
 
 ### Close Icon
 
-Pass a `closeIcon` field to customize the close button [Icon](/docs/components/icon). Default to `i-lucide-x`.
+Pass a `closeIcon` field to customize the close button [Icon](/docs/components/icon). Defaults to `i-lucide-x`.
 
 ::component-example
 ---
@@ -223,7 +223,7 @@ name: 'toast-orientation-example'
 
 ## Examples
 
-::note{to="/components/app"}
+::note{to="/docs/components/app"}
 Nuxt UI provides an **App** component that wraps your app to provide global configurations.
 ::
 

--- a/docs/content/docs/2.components/user.md
+++ b/docs/content/docs/2.components/user.md
@@ -1,7 +1,10 @@
 ---
-title: User
 description: 'Display user information with name, description and avatar.'
 category: data
+keywords:
+  - profile
+  - person
+  - account
 links:
   - label: GitHub
     icon: i-simple-icons-github
@@ -9,6 +12,8 @@ links:
 ---
 
 ## Usage
+
+Use the User component to display a person with their name, description and avatar.
 
 ### Name
 

--- a/docs/content/docs/2.components/user.md
+++ b/docs/content/docs/2.components/user.md
@@ -13,8 +13,6 @@ links:
 
 ## Usage
 
-Use the User component to display a person with their name, description and avatar.
-
 ### Name
 
 Use the `name` prop to display a name for the user.

--- a/docs/content/docs/3.composables/define-locale.md
+++ b/docs/content/docs/3.composables/define-locale.md
@@ -5,7 +5,7 @@ description: 'A utility to create a custom locale for your app.'
 
 ## Usage
 
-Use the `defineLocale` utility to create a custom locale with your own translations.
+Use the auto-imported `defineLocale` utility to create a custom locale with your own translations.
 
 ```vue
 <script setup lang="ts">
@@ -28,8 +28,16 @@ const locale = defineLocale<Messages>({
 </template>
 ```
 
-::tip{to="/docs/getting-started/integrations/i18n"}
+::framework-only
+#nuxt
+:::tip{to="/docs/getting-started/integrations/i18n/nuxt"}
 Learn more about internationalization in the **i18n integration** documentation.
+:::
+
+#vue
+:::tip{to="/docs/getting-started/integrations/i18n/vue"}
+Learn more about internationalization in the **i18n integration** documentation.
+:::
 ::
 
 ## API
@@ -50,11 +58,11 @@ Creates a new locale object with the provided options.
       ::field-group
 
         ::field{name="name" type="string" required}
-        The display name of the locale (e.g., `'English'`, `'Français'`).
+        The display name of the locale (e.g. `'English'`, `'Français'`).
         ::
 
         ::field{name="code" type="string" required}
-        The ISO code of the locale (e.g., `'en'`, `'fr'`, `'de-AT'`).
+        The ISO code of the locale (e.g. `'en'`, `'fr'`, `'de-AT'`).
         ::
 
         ::field{name="dir" type="'ltr' | 'rtl'"}

--- a/docs/content/docs/3.composables/define-shortcuts.md
+++ b/docs/content/docs/3.composables/define-shortcuts.md
@@ -88,7 +88,7 @@ Use these names to match keys that don't produce a character.
 - `tab`: Triggers on Tab key
 - `backspace`: Triggers on Backspace key
 - `delete`: Triggers on Delete key
-- `space`: Triggers on the space bar
+- `space`: Triggers on the space bar, only when `layoutIndependent` is enabled
 
 ### Shortcut configuration
 

--- a/docs/content/docs/3.composables/define-shortcuts.md
+++ b/docs/content/docs/3.composables/define-shortcuts.md
@@ -71,8 +71,6 @@ Shortcuts are defined using the following format:
 
 ### Modifiers
 
-Combine these with another key using `_`, for example `meta_k`.
-
 - `meta` / `command`: Represents `⌘ Command` on macOS and `Ctrl` on other platforms
 - `ctrl`: Represents `Ctrl` on all platforms
 - `shift`: Used for alphabetic keys when Shift is required
@@ -88,7 +86,7 @@ Use these names to match keys that don't produce a character.
 - `tab`: Triggers on Tab key
 - `backspace`: Triggers on Backspace key
 - `delete`: Triggers on Delete key
-- `space`: Triggers on the space bar, only when `layoutIndependent` is enabled
+- `space`: Triggers on the space bar. Requires `layoutIndependent` unless combined with `alt`
 
 ### Shortcut configuration
 

--- a/docs/content/docs/3.composables/define-shortcuts.md
+++ b/docs/content/docs/3.composables/define-shortcuts.md
@@ -21,7 +21,7 @@ defineShortcuts({
 
 - Shortcuts are automatically adjusted for non-macOS platforms, converting `meta` to `ctrl`.
 - The composable uses VueUse's [`useEventListener`](https://vueuse.org/core/useEventListener/) to handle keydown events.
-- For a complete list of available shortcut keys, refer to the [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values) API documentation. Note that the key should be written in lowercase.
+- For a complete list of available shortcut keys, refer to the [`KeyboardEvent.key`](https://developer.mozilla.org/en-US/docs/Web/API/UI_Events/Keyboard_event_key_values) API documentation. Keys in the config are case-insensitive, so `meta_k` and `meta_K` are equivalent.
 
 ::tip{to="/docs/components/kbd"}
 Learn how to display shortcuts in components in the **Kbd** component documentation.
@@ -29,16 +29,16 @@ Learn how to display shortcuts in components in the **Kbd** component documentat
 
 ## API
 
-`defineShortcuts(config: ShortcutsConfig, options?: ShortcutsOptions): void`{lang="ts-type"}
+`defineShortcuts(config: MaybeRef<ShortcutsConfig>, options?: ShortcutsOptions): () => void`{lang="ts-type"}
 
-Define keyboard shortcuts for your application.
+Define keyboard shortcuts for your application. Returns a function that removes the listener, in case you need to stop the shortcuts before the component unmounts.
 
-#### Parameters
+### Parameters
 
 ::field-group
 
-  ::field{name="config" type="ShortcutsConfig" required}
-  An object where keys are shortcut definitions and values are either handler functions or shortcut configuration objects.
+  ::field{name="config" type="MaybeRef<ShortcutsConfig>" required}
+  An object where keys are shortcut definitions and values are either handler functions or shortcut configuration objects. Pass a `ref` to update the shortcuts reactively. A value of `false`, `null` or `undefined` skips that shortcut, which is how you enable one conditionally.
   ::
 
   ::field{name="options" type="ShortcutsOptions"}
@@ -46,50 +46,61 @@ Define keyboard shortcuts for your application.
 
     ::collapsible
 
-      ::field{name="chainDelay" type="number"}
-      The delay between key presses to consider the shortcut as chained. Default is `800`.
-      ::
+      ::field-group
+        ::field{name="chainDelay" type="number"}
+        The delay between key presses to consider the shortcut as chained. Defaults to `800`.
+        ::
 
-      ::field{name="layoutIndependent" type="boolean"}
-      When enabled, shortcuts work consistently across different keyboard layouts (Arabic, Hebrew) by matching physical key positions rather than character values.
-      - `false` (default): Uses `e.key` for character-based matching (Layout specific)
-      - `true`: Uses `e.code` for physical key matching (Layout agnostic)
+        ::field{name="layoutIndependent" type="boolean"}
+        When enabled, shortcuts work consistently across different keyboard layouts (Arabic, Hebrew) by matching physical key positions rather than character values.
+        - `false` (default): Uses `e.key` for character-based matching (Layout specific)
+        - `true`: Uses `e.code` for physical key matching (Layout agnostic)
+        ::
       ::
     ::
   ::
 ::
 
-#### Shortcut definition
+### Shortcut definition
 
 Shortcuts are defined using the following format:
 
 - Single key: `'a'`, `'b'`, `'1'`, `'?'`, etc.
-- Key combinations: Use `_` to separate keys, e.g., `'meta_k'`, `'ctrl_shift_f'`
-- Key sequences: Use `-` to define a sequence, e.g., `'g-d'`
+- Key combinations: Use `_` to separate keys, e.g. `'meta_k'`, `'ctrl_shift_f'`
+- Key sequences: Use `-` to define a sequence, e.g. `'g-d'`
 
-#### Modifiers
+### Modifiers
 
-- `meta`: Represents `⌘ Command` on macOS and `Ctrl` on other platforms
+Combine these with another key using `_`, for example `meta_k`.
+
+- `meta` / `command`: Represents `⌘ Command` on macOS and `Ctrl` on other platforms
 - `ctrl`: Represents `Ctrl` on all platforms
 - `shift`: Used for alphabetic keys when Shift is required
+- `alt` / `option`: Represents `⌥ Option` on macOS and `Alt` on other platforms. Matched by physical key position, since Option rewrites the character on macOS
 
-#### Special keys
+### Special keys
+
+Use these names to match keys that don't produce a character.
 
 - `escape`: Triggers on Esc key
 - `enter`: Triggers on Enter key
 - `arrowleft`, `arrowright`, `arrowup`, `arrowdown`: Trigger on respective arrow keys
+- `tab`: Triggers on Tab key
+- `backspace`: Triggers on Backspace key
+- `delete`: Triggers on Delete key
+- `space`: Triggers on the space bar
 
-#### Shortcut configuration
+### Shortcut configuration
 
 Each shortcut can be defined as a function or an object with the following properties:
 
-`interface ShortcutConfig { handler: () => void; usingInput?: boolean | string }`{lang="ts-type"}
+`interface ShortcutConfig { handler: (e?: KeyboardEvent) => void; usingInput?: boolean | string }`{lang="ts-type"}
 
 #### Parameters
 
 ::field-group
-  ::field{name="handler" type="() => void" required}
-  Function to be executed when the shortcut is triggered.
+  ::field{name="handler" type="(e?: KeyboardEvent) => void" required}
+  Function to be executed when the shortcut is triggered. It receives the originating `KeyboardEvent`.
   ::
 
   ::field{name="usingInput" type="boolean | string"}
@@ -116,7 +127,7 @@ defineShortcuts({
 
 ### With input focus handling
 
-The `usingInput` option allows you to specify that a shortcut should only trigger when a specific input is focused.
+Use `usingInput` to trigger a shortcut only when a specific input is focused.
 
 ```vue
 <template>

--- a/docs/content/docs/3.composables/define-shortcuts.md
+++ b/docs/content/docs/3.composables/define-shortcuts.md
@@ -78,7 +78,7 @@ Shortcuts are defined using the following format:
 
 ### Special keys
 
-Use these names to match keys that don't produce a character.
+Use these names to match special keys.
 
 - `escape`: Triggers on Esc key
 - `enter`: Triggers on Enter key

--- a/docs/content/docs/3.composables/extend-locale.md
+++ b/docs/content/docs/3.composables/extend-locale.md
@@ -5,7 +5,7 @@ description: 'A utility to extend an existing locale with custom translations.'
 
 ## Usage
 
-Use the `extendLocale` utility to customize an existing locale by overriding specific properties or messages.
+Use the auto-imported `extendLocale` utility to customize an existing locale by overriding specific properties or messages.
 
 ```vue
 <script setup lang="ts">
@@ -29,12 +29,20 @@ const locale = extendLocale(en, {
 ```
 
 This is useful when you want to:
-- Create a regional variant of a language (e.g., `en-AU` from `en`)
+- Create a regional variant of a language (e.g. `en-AU` from `en`)
 - Override specific translations without redefining the entire locale
 - Customize component labels for your application
 
-::tip{to="/docs/getting-started/integrations/i18n"}
+::framework-only
+#nuxt
+:::tip{to="/docs/getting-started/integrations/i18n/nuxt"}
 Learn more about internationalization in the **i18n integration** documentation.
+:::
+
+#vue
+:::tip{to="/docs/getting-started/integrations/i18n/vue"}
+Learn more about internationalization in the **i18n integration** documentation.
+:::
 ::
 
 ## API
@@ -63,7 +71,7 @@ Extends an existing locale with the provided options, deeply merging the message
         ::
 
         ::field{name="code" type="string"}
-        Override the ISO code of the locale (e.g., `'en-GB'`, `'fr-CA'`).
+        Override the ISO code of the locale (e.g. `'en-GB'`, `'fr-CA'`).
         ::
 
         ::field{name="dir" type="'ltr' | 'rtl'"}

--- a/docs/content/docs/3.composables/extract-shortcuts.md
+++ b/docs/content/docs/3.composables/extract-shortcuts.md
@@ -51,7 +51,7 @@ Extracts keyboard shortcuts from an array of menu items and returns a configurat
       ::field-group
 
         ::field{name="kbds" type="string[]"}
-        An array of keyboard keys that form the shortcut (e.g., `['meta', 'S']`).
+        An array of keyboard keys that form the shortcut (e.g. `['meta', 'S']`).
         ::
 
         ::field{name="onSelect" type="() => void"}
@@ -74,7 +74,7 @@ Extracts keyboard shortcuts from an array of menu items and returns a configurat
   ::
 
   ::field{name="separator" type="'_' | '-'"}
-  The separator used to join keyboard keys. Use `'_'` for key combinations (e.g., `meta_k`) or `'-'` for key sequences (e.g., `g-d`). Defaults to `'_'`.
+  The separator used to join keyboard keys. Use `'_'` for key combinations (e.g. `meta_k`) or `'-'` for key sequences (e.g. `g-d`). Defaults to `'_'`.
   ::
 ::
 

--- a/docs/content/docs/3.composables/use-overlay.md
+++ b/docs/content/docs/3.composables/use-overlay.md
@@ -16,7 +16,7 @@ name: 'use-overlay-example'
 - The `useOverlay` composable is created using `createSharedComposable`, ensuring that the same overlay state is shared across your entire application.
 
 ::note
-In order to return a value from the overlay, the `overlay.open()` can be awaited. In order for this to work, however, the **overlay component must emit a `close` event**. See example below for details.
+Await `overlay.open()` to get a value back from the overlay. This only works if the **overlay component emits a `close` event**. See the example below for details.
 ::
 
 ## API
@@ -27,7 +27,7 @@ The `useOverlay` composable provides methods to manage overlays globally. Each c
 
 ### create()
 
-`create(component: T, options: OverlayOptions): OverlayInstance`{lang="ts-type"}
+`create(component: T, options?: OverlayOptions<ComponentProps<T>>): OverlayInstance<T>`{lang="ts-type"}
 
 Create an overlay, and return a factory instance.
 
@@ -157,11 +157,13 @@ In-memory list of all overlays that were created.
 
 ## Instance API
 
+These are the methods available on the instance returned by `create()`.
+
 ### open()
 
 `open(props?: ComponentProps<T>): OpenedOverlay<T>`{lang="ts-type"}
 
-Open the overlay. Returns an `OpenedOverlay` which is a Promise that resolves with the value emitted by the `close` event.
+Open the overlay. Returns an `OpenedOverlay`, a Promise that resolves with the value emitted by the `close` event. The same promise is also exposed as `result`, so `const { result } = modal.open()` works too.
 
 #### Parameters
 
@@ -357,7 +359,7 @@ const handleDelete = async () => {
 
 ### Provide / Inject
 
-When opening overlays programmatically (e.g. modals, slideovers, etc), the overlay component can only access injected values from the component containing `UApp` (typically `app.vue` or layout components). This is because overlays are mounted outside of the page context by the `UApp` component.
+When opening overlays programmatically (modals, slideovers and so on), the overlay component can only access injected values from the component containing `UApp` (typically `app.vue` or layout components). This is because overlays are mounted outside of the page context by the `UApp` component.
 
 As such, using `provide()` in pages or parent components isn't supported directly. To pass provided values to overlays, the recommended approach is to use props instead:
 

--- a/docs/content/docs/3.composables/use-toast.md
+++ b/docs/content/docs/3.composables/use-toast.md
@@ -149,7 +149,7 @@ Updates an existing toast notification.
   ::
 
   ::field{name="toast" type="Omit<Partial<Toast>, 'id'>" required}
-  A partial `Toast` object with the properties to update. The `id` cannot be changed.
+  A partial `Toast` object with the properties to update. The `id` cannot be changed, the toast is reopened, and `duration` is reset unless you pass it again.
   ::
 ::
 

--- a/docs/content/docs/3.composables/use-toast.md
+++ b/docs/content/docs/3.composables/use-toast.md
@@ -14,7 +14,7 @@ name: 'use-toast-example'
 ::
 
 - The `useToast` composable uses Nuxt's `useState` to manage the toast state, ensuring reactivity across your application.
-- A maximum of 5 toasts are displayed at a time. When adding a new toast that would exceed this limit, the oldest toast is automatically removed.
+- A maximum of 5 toasts are displayed at a time by default. When adding a new toast that would exceed this limit, the oldest toast is automatically removed. Change it with the `toaster.max` prop on the [`App`](/docs/components/app#props) component.
 - When removing a toast, there's a 200ms delay before it's actually removed from the state, allowing for exit animations.
 
 ::warning
@@ -48,18 +48,18 @@ Adds a new toast notification.
 
       ::field-group
         ::field{name="id" type="string | number"}
-        A unique identifier for the toast. If not provided, a timestamp will be used.
+        A unique identifier for the toast. If not provided, a unique id is generated. Reusing an existing id merges into that toast instead of adding a new one.
         ::
 
         ::field{name="open" type="boolean"}
         Whether the toast is open. Defaults to `true`.
         ::
 
-        ::field{name="title" type="string"}
+        ::field{name="title" type="string | VNode | (() => VNode)"}
         The title displayed in the toast.
         ::
 
-        ::field{name="description" type="string"}
+        ::field{name="description" type="string | VNode | (() => VNode)"}
         The description displayed in the toast.
         ::
 
@@ -72,14 +72,14 @@ Adds a new toast notification.
         ::
 
         ::field{name="color" type="string"}
-        The color of the toast.
+        The color of the toast. Defaults to `primary`.
         ::
 
         ::field{name="orientation" type="'horizontal' | 'vertical'"}
         The orientation between the content and the actions. Defaults to `vertical`.
         ::
 
-        ::field{name="close" type="boolean | ButtonProps"}
+        ::field{name="close" type="boolean | Omit<ButtonProps, LinkPropsKeys>"}
         Customize or hide the close button (with `false` value). Defaults to `true`.
         ::
 
@@ -91,12 +91,12 @@ Adds a new toast notification.
         The actions displayed in the toast. See [Button](/docs/components/button#props).
         ::
 
-        ::field{name="progress" type="boolean | ProgressProps"}
+        ::field{name="progress" type="boolean | Pick<ProgressProps, 'color' | 'ui'>"}
         Customize or hide the progress bar (with `false` value). Defaults to `true`.
         ::
 
         ::field{name="duration" type="number"}
-        The duration in milliseconds before the toast auto-closes. Can also be set globally on the [`App`](/docs/components/app) component.
+        The duration in milliseconds before the toast auto-closes. Defaults to `5000`. Set to `0` to keep the toast open until it's manually closed. Can also be set globally on the [`App`](/docs/components/app) component.
         ::
 
         ::field{name="onClick" type="(toast: Toast) => void"}
@@ -105,6 +105,14 @@ Adds a new toast notification.
 
         ::field{name="onUpdateOpen" type="(open: boolean) => void"}
         A callback function invoked when the toast open state changes. Useful to perform an action when the toast closes (expired or dismissed).
+        ::
+
+        ::field{name="type" type="'foreground' | 'background'"}
+        How assistive technologies announce the toast. Use `background` for toasts that aren't the result of a direct user action.
+        ::
+
+        ::field{name="as" type="any"}
+        The element or component the toast renders as. Defaults to `li`.
         ::
       ::
     ::
@@ -129,7 +137,7 @@ function showToast() {
 
 ### update()
 
-`update(id: string | number, toast: Partial<Toast>): void`{lang="ts-type"}
+`update(id: string | number, toast: Omit<Partial<Toast>, 'id'>): void`{lang="ts-type"}
 
 Updates an existing toast notification.
 
@@ -140,8 +148,8 @@ Updates an existing toast notification.
   The unique identifier of the toast to update.
   ::
 
-  ::field{name="toast" type="Partial<Toast>" required}
-  A partial `Toast` object with the properties to update.
+  ::field{name="toast" type="Omit<Partial<Toast>, 'id'>" required}
+  A partial `Toast` object with the properties to update. The `id` cannot be changed.
   ::
 ::
 

--- a/docs/content/docs/4.typography/1.index.md
+++ b/docs/content/docs/4.typography/1.index.md
@@ -56,16 +56,16 @@ export default defineConfig({
 :::div
 There are multiple ways to render styled content:
 
-1. **Markdown Rendering** - Use ContentRenderer, MDC, Markdown, or MarkdownDocument to render markdown with automatic prose styling
-2. **Direct Vue Usage** - Import and use prose components directly in your Vue templates
+1. **Markdown rendering**: use ContentRenderer, MDC, Markdown, or MarkdownDocument to render markdown with automatic prose styling
+2. **Direct Vue usage**: import and use prose components directly in your Vue templates
 :::
 
 #vue
 :::div
 There are multiple ways to render styled content:
 
-1. **Markdown Rendering** - Use Markdown or MarkdownDocument to render markdown with automatic prose styling
-2. **Direct Vue Usage** - Import and use prose components directly in your Vue templates
+1. **Markdown rendering**: use Markdown or MarkdownDocument to render markdown with automatic prose styling
+2. **Direct Vue usage**: import and use prose components directly in your Vue templates
 :::
 
 ::
@@ -266,7 +266,7 @@ npm install @nuxt/ui
 
 ```bash [bun]
 bun add @nuxt/ui
-````
+```
 
 ::::
 

--- a/docs/content/docs/4.typography/2.headers-and-text.md
+++ b/docs/content/docs/4.typography/2.headers-and-text.md
@@ -7,7 +7,7 @@ description: 'Beautifully styled headings, paragraphs, text formatting, and link
 
 Use headings to organize your content and make it easier to read.
 
-Headings can be wrapped in an anchor link when they have an `id`, with a hash icon shown on hover for `H2`, `H3` and `H4` so readers can link directly to a section.
+Headings can be wrapped in an anchor link when they have an `id`, with a hash icon shown on hover for `H2` and `H3` (on large screens) so readers can link directly to a section.
 
 Anchor links are off by default. Use the [`Theme`](/docs/components/theme) component with the `anchor` prop to toggle them for a section of your app:
 

--- a/docs/content/docs/4.typography/2.headers-and-text.md
+++ b/docs/content/docs/4.typography/2.headers-and-text.md
@@ -9,7 +9,7 @@ Use headings to organize your content and make it easier to read.
 
 Headings can be wrapped in an anchor link when they have an `id`, with a hash icon shown on hover for `H2` and `H3` (on large screens) so readers can link directly to a section.
 
-Anchor links are off by default. Use the [`Theme`](/docs/components/theme) component with the `anchor` prop to toggle them for a section of your app:
+Anchor links are enabled by default for `H2` to `H4` when using `@nuxt/content` or `@nuxtjs/mdc`, and disabled otherwise. Use the [`Theme`](/docs/components/theme) component with the `anchor` prop to toggle them for a section of your app:
 
 ```vue
 <template>

--- a/docs/content/docs/4.typography/5.code.md
+++ b/docs/content/docs/4.typography/5.code.md
@@ -67,7 +67,7 @@ function updateMessage() {
 
 #code
 
-````html
+````mdc
 ```vue
 <script setup lang="ts">
 const message = ref('Hello World!')
@@ -275,7 +275,7 @@ export default defineNuxtConfig({
 
 #code
 
-````md
+````mdc
 ```diff [nuxt.config.ts]
 export default defineNuxtConfig({
   modules: [

--- a/docs/content/docs/4.typography/5.code.md
+++ b/docs/content/docs/4.typography/5.code.md
@@ -67,7 +67,7 @@ function updateMessage() {
 
 #code
 
-````mdc
+````html
 ```vue
 <script setup lang="ts">
 const message = ref('Hello World!')

--- a/docs/content/docs/4.typography/badge.md
+++ b/docs/content/docs/4.typography/badge.md
@@ -31,6 +31,10 @@ Use markdown in the default slot of the `badge` component to display a [Badge](/
 
 ## API
 
+### Props
+
+:component-props{prose}
+
 ### Slots
 
 :component-slots{prose}

--- a/docs/content/docs/4.typography/card-group.md
+++ b/docs/content/docs/4.typography/card-group.md
@@ -111,6 +111,10 @@ A landing page you can use as starting point.
 
 ## API
 
+### Props
+
+:component-props{prose}
+
 ### Slots
 
 :component-slots{prose}

--- a/docs/content/docs/4.typography/field-group.md
+++ b/docs/content/docs/4.typography/field-group.md
@@ -18,19 +18,19 @@ Group fields together in a list.
 ::field-group{class="my-0"}
 
   ::field{name="analytics" type="boolean"}
-  Default to `false` - Enables analytics for your project (coming soon).
+  Defaults to `false`. Enables analytics for your project (coming soon).
   ::
 
   ::field{name="blob" type="boolean"}
-  Default to `false` - Enables blob storage to store static assets, such as images, videos and more.
+  Defaults to `false`. Enables blob storage to store static assets, such as images, videos and more.
   ::
 
   ::field{name="cache" type="boolean"}
-  Default to `false` - Enables cache storage to cache your server route responses or functions using Nitro's `cachedEventHandler` and `cachedFunction`
+  Defaults to `false`. Enables cache storage to cache your server route responses or functions using Nitro's `cachedEventHandler` and `cachedFunction`.
   ::
 
   ::field{name="database" type="boolean"}
-  Default to `false` - Enables SQL database to store your application's data.
+  Defaults to `false`. Enables SQL database to store your application's data.
   ::
 
 ::
@@ -40,19 +40,19 @@ Group fields together in a list.
 ```mdc
 ::field-group
   ::field{name="analytics" type="boolean"}
-    Default to `false` - Enables analytics for your project (coming soon).
+    Defaults to `false`. Enables analytics for your project (coming soon).
   ::
 
   ::field{name="blob" type="boolean"}
-    Default to `false` - Enables blob storage to store static assets, such as images, videos and more.
+    Defaults to `false`. Enables blob storage to store static assets, such as images, videos and more.
   ::
 
   ::field{name="cache" type="boolean"}
-    Default to `false` - Enables cache storage to cache your server route responses or functions using Nitro's `cachedEventHandler` and `cachedFunction`
+    Defaults to `false`. Enables cache storage to cache your server route responses or functions using Nitro's `cachedEventHandler` and `cachedFunction`.
   ::
 
   ::field{name="database" type="boolean"}
-    Default to `false` - Enables SQL database to store your application's data.
+    Defaults to `false`. Enables SQL database to store your application's data.
   ::
 ::
 ```

--- a/docs/content/docs/4.typography/kbd.md
+++ b/docs/content/docs/4.typography/kbd.md
@@ -30,6 +30,10 @@ Use the `kbd` component to display a [Kbd](/docs/components/kbd) in your content
 
 :component-props{prose}
 
+### Slots
+
+:component-slots{prose}
+
 ## Theme
 
 :component-theme{prose}

--- a/docs/content/docs/4.typography/prompt.md
+++ b/docs/content/docs/4.typography/prompt.md
@@ -62,7 +62,7 @@ slots:
 
 ### Actions
 
-Use the `actions` prop to display additional buttons. The `copy` button is always displayed, available actions are `cursor`, `windsurf` and `claude`.
+Use the `actions` prop to display additional buttons. The `copy` button is always displayed. The available actions are `cursor`, `windsurf` and `claude`.
 
 ::component-code{slug="prompt" prose}
 ---

--- a/docs/content/figma.yml
+++ b/docs/content/figma.yml
@@ -3,7 +3,6 @@ description: Bridge the gap between designers and developers using professional-
 hero:
   title: From [Figma]{#figma} to [Nuxt]{#nuxt}, faster.
   description: From wireframe to production in no time with the official Nuxt UI design kit for Figma. Get access to all components, layouts, and enhanced design-to-code efficiency in one comprehensive kit.
-  image: /figma/hero.png
   links:
     - label: Open Figma Kit
       to: 'https://go.nuxt.com/figma-ui'

--- a/docs/content/index.yml
+++ b/docs/content/index.yml
@@ -30,7 +30,7 @@ features:
     description: A complete design system powered by Tailwind CSS and Reka UI for top performance and accessibility.
     icon: i-lucide-rocket
     to: /docs/getting-started
-  - title: Large icons sets
+  - title: Large icon sets
     description: Access to over 200,000 customizable icons from Iconify powered by @nuxt/icon.
     icon: i-lucide-smile
     to: /docs/getting-started/integrations/icons
@@ -84,12 +84,12 @@ design_system:
       --color-brand-200: #bae6fd;
       --color-brand-300: #7dd3fc;
       --color-brand-400: #38bdf8;
-      --color-brand-500: #3b82f6;
-      --color-brand-600: #2563eb;
-      --color-brand-700: #1d4ed8;
-      --color-brand-800: #1e40af;
-      --color-brand-900: #1e3a8a;
-      --color-brand-950: #172554;
+      --color-brand-500: #0ea5e9;
+      --color-brand-600: #0284c7;
+      --color-brand-700: #0369a1;
+      --color-brand-800: #075985;
+      --color-brand-900: #0c4a6e;
+      --color-brand-950: #082f49;
     }
     ```
 

--- a/src/runtime/components/Carousel.vue
+++ b/src/runtime/components/Carousel.vue
@@ -71,32 +71,32 @@ export interface CarouselProps<T extends CarouselItem = CarouselItem> extends Om
   items?: T[]
   /**
    * Enable Autoplay plugin
-   * @see https://www.embla-carousel.com/plugins/autoplay/
+   * @see https://www.embla-carousel.com/docs/v8/plugins/autoplay
    */
   autoplay?: boolean | AutoplayOptionsType
   /**
    * Enable Auto Scroll plugin
-   * @see https://www.embla-carousel.com/plugins/auto-scroll/
+   * @see https://www.embla-carousel.com/docs/v8/plugins/auto-scroll
    */
   autoScroll?: boolean | AutoScrollOptionsType
   /**
    * Enable Auto Height plugin
-   * @see https://www.embla-carousel.com/plugins/auto-height/
+   * @see https://www.embla-carousel.com/docs/v8/plugins/auto-height
    */
   autoHeight?: boolean | AutoHeightOptionsType
   /**
    * Enable Class Names plugin
-   * @see https://www.embla-carousel.com/plugins/class-names/
+   * @see https://www.embla-carousel.com/docs/v8/plugins/class-names
    */
   classNames?: boolean | ClassNamesOptionsType
   /**
    * Enable Fade plugin
-   * @see https://www.embla-carousel.com/plugins/fade/
+   * @see https://www.embla-carousel.com/docs/v8/plugins/fade
    */
   fade?: boolean | FadeOptionsType
   /**
    * Enable Wheel Gestures plugin
-   * @see https://www.embla-carousel.com/plugins/wheel-gestures/
+   * @see https://www.embla-carousel.com/docs/v8/plugins/wheel-gestures
    */
   wheelGestures?: boolean | WheelGesturesPluginOptions
   class?: any


### PR DESCRIPTION
### 🔗 Linked issue

n/a

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Audit of `docs/content` against the source and the external sites we link to.

- Dead external links: Embla moved to `/docs/v8/...`, AI SDK, TipTap, unhead, Fuse.js, color-mode, Cursor and Tailwind pages that moved. The Embla `@see` tags in `Carousel.vue` are updated too since they show up in the props table.
- Examples that couldn't run: the Vue color-mode button, the content breadcrumb, the v3 migration `modal.open()` call.
- Claims that didn't match the code: slotless components do have a `ui` prop, `theme.defaultVariants` only touches `primary`/`md`, several `useToast` / `defineShortcuts` / `useOverlay` types and defaults, H4 has no anchor icon, the contribution tree.
- Wording: no more em dashes, `e.g.,` and "allows you to", a few missing intro sentences, redundant titles, search keywords on 20 component pages.

Worth a look: the homepage brand palette sample now uses a single sky scale, and the new `keywords` on 20 component pages.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
