### PR TITLE
fix(Input/Textarea): keep `0` with `nullable` and `optional` modifiers

### DIFF
--- a/src/runtime/components/Input.vue
+++ b/src/runtime/components/Input.vue
@@ -136,12 +136,15 @@ function updateInput(value: string | null | undefined) {
     value = looseToNumber(value)
   }
 
-  if (props.modelModifiers?.nullable) {
-    value ||= null
+  // Only empty values are mapped, `0` is a value on its own with the `number` modifier
+  const isEmpty = value === '' || value === null || value === undefined
+
+  if (props.modelModifiers?.nullable && isEmpty) {
+    value = null
   }
 
-  if (props.modelModifiers?.optional && !props.modelModifiers?.nullable && value !== null) {
-    value ||= undefined
+  if (props.modelModifiers?.optional && !props.modelModifiers?.nullable && value !== null && isEmpty) {
+    value = undefined
   }
 
   modelValue.value = value as ApplyModifiers<T, Mod>

--- a/src/runtime/components/Input.vue
+++ b/src/runtime/components/Input.vue
@@ -74,7 +74,7 @@ import { useComponentProps } from '../composables/useComponentProps'
 import { useFieldGroup } from '../composables/useFieldGroup'
 import { useComponentIcons } from '../composables/useComponentIcons'
 import { useFormField } from '../composables/useFormField'
-import { looseToNumber } from '../utils'
+import { isEmpty, looseToNumber } from '../utils'
 import { tv } from '../utils/tv'
 import UIcon from './Icon.vue'
 import UAvatar from './Avatar.vue'
@@ -137,13 +137,11 @@ function updateInput(value: string | null | undefined) {
   }
 
   // Only empty values are mapped, `0` is a value on its own with the `number` modifier
-  const isEmpty = value === '' || value === null || value === undefined
-
-  if (props.modelModifiers?.nullable && isEmpty) {
+  if (props.modelModifiers?.nullable && isEmpty(value)) {
     value = null
   }
 
-  if (props.modelModifiers?.optional && !props.modelModifiers?.nullable && value !== null && isEmpty) {
+  if (props.modelModifiers?.optional && !props.modelModifiers?.nullable && value !== null && isEmpty(value)) {
     value = undefined
   }
 

--- a/src/runtime/components/Textarea.vue
+++ b/src/runtime/components/Textarea.vue
@@ -134,12 +134,15 @@ function updateInput(value: string | null | undefined) {
     value = looseToNumber(value)
   }
 
-  if (props.modelModifiers?.nullable) {
-    value ||= null
+  // Only empty values are mapped, `0` is a value on its own with the `number` modifier
+  const isEmpty = value === '' || value === null || value === undefined
+
+  if (props.modelModifiers?.nullable && isEmpty) {
+    value = null
   }
 
-  if (props.modelModifiers?.optional && !props.modelModifiers?.nullable && value !== null) {
-    value ||= undefined
+  if (props.modelModifiers?.optional && !props.modelModifiers?.nullable && value !== null && isEmpty) {
+    value = undefined
   }
 
   modelValue.value = value as ApplyModifiers<T, Mod>

--- a/src/runtime/components/Textarea.vue
+++ b/src/runtime/components/Textarea.vue
@@ -74,7 +74,7 @@ import { useAppConfig } from '#imports'
 import { useComponentProps } from '../composables/useComponentProps'
 import { useComponentIcons } from '../composables/useComponentIcons'
 import { useFormField } from '../composables/useFormField'
-import { looseToNumber } from '../utils'
+import { isEmpty, looseToNumber } from '../utils'
 import { tv } from '../utils/tv'
 import UIcon from './Icon.vue'
 import UAvatar from './Avatar.vue'
@@ -135,13 +135,11 @@ function updateInput(value: string | null | undefined) {
   }
 
   // Only empty values are mapped, `0` is a value on its own with the `number` modifier
-  const isEmpty = value === '' || value === null || value === undefined
-
-  if (props.modelModifiers?.nullable && isEmpty) {
+  if (props.modelModifiers?.nullable && isEmpty(value)) {
     value = null
   }
 
-  if (props.modelModifiers?.optional && !props.modelModifiers?.nullable && value !== null && isEmpty) {
+  if (props.modelModifiers?.optional && !props.modelModifiers?.nullable && value !== null && isEmpty(value)) {
     value = undefined
   }
 

--- a/test/components/Input.spec.ts
+++ b/test/components/Input.spec.ts
@@ -56,7 +56,12 @@ describe('Input', () => {
       ['with .number modifier', { props: { modelModifiers: { number: true } } }, { input: '42', expected: 42 }],
       ['with .lazy modifier', { props: { modelModifiers: { lazy: true } } }, { input: 'input', expected: 'input' }],
       ['with .nullable modifier', { props: { modelModifiers: { nullable: true } } }, { input: '', expected: null }],
-      ['with .optional modifier', { props: { modelModifiers: { optional: true } } }, { input: '', expected: undefined }]
+      ['with .optional modifier', { props: { modelModifiers: { optional: true } } }, { input: '', expected: undefined }],
+      ['with .number and .nullable modifiers', { props: { modelModifiers: { number: true, nullable: true } } }, { input: '0', expected: 0 }],
+      ['with .number and .optional modifiers', { props: { modelModifiers: { number: true, optional: true } } }, { input: '0', expected: 0 }],
+      ['with .number and .nullable modifiers on an empty value', { props: { modelModifiers: { number: true, nullable: true } } }, { input: '', expected: null }],
+      ['with .number and .optional modifiers on an empty value', { props: { modelModifiers: { number: true, optional: true } } }, { input: '', expected: undefined }],
+      ['with number type and .nullable modifier', { props: { type: 'number', modelModifiers: { nullable: true } } }, { input: '0', expected: 0 }]
     ],
     '%s works',
     async (_nameOrHtml, options, spec) => {

--- a/test/components/Textarea.spec.ts
+++ b/test/components/Textarea.spec.ts
@@ -69,7 +69,11 @@ describe('Textarea', () => {
       ['with .number modifier', { props: { modelModifiers: { number: true } } }, { input: '42', expected: 42 }],
       ['with .lazy modifier', { props: { modelModifiers: { lazy: true } } }, { input: 'input', expected: 'input' }],
       ['with .nullable modifier', { props: { modelModifiers: { nullable: true } } }, { input: '', expected: null }],
-      ['with .optional modifier', { props: { modelModifiers: { optional: true } } }, { input: '', expected: undefined }]
+      ['with .optional modifier', { props: { modelModifiers: { optional: true } } }, { input: '', expected: undefined }],
+      ['with .number and .nullable modifiers', { props: { modelModifiers: { number: true, nullable: true } } }, { input: '0', expected: 0 }],
+      ['with .number and .optional modifiers', { props: { modelModifiers: { number: true, optional: true } } }, { input: '0', expected: 0 }],
+      ['with .number and .nullable modifiers on an empty value', { props: { modelModifiers: { number: true, nullable: true } } }, { input: '', expected: null }],
+      ['with .number and .optional modifiers on an empty value', { props: { modelModifiers: { number: true, optional: true } } }, { input: '', expected: undefined }]
     ],
     '%s works',
     async (_, options, spec) => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #5950

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`Input` and `Textarea` mapped empty values with `||=`:

```ts
if (props.modelModifiers?.nullable) {
  value ||= null
}
```

`||=` fires on every falsy value, so combined with the `number` modifier (or `type="number"` on `Input`) a typed `0` went through `looseToNumber('0')` → `0` and then `0 ||= null` → `null`. `.optional` had the same problem and produced `undefined`. Both are the case @sandros94 described in the issue.

`??=` is not the fix: `Input` and `Textarea` must still map `''`, which `??=` would leave untouched. The mapping is now driven by an explicit emptiness test, so `''`, `null` and `undefined` behave exactly as before and only falsy numbers change:

```ts
const isEmpty = value === '' || value === null || value === undefined
```

`Select`, `SelectMenu`, `InputMenu` and `Listbox` already use `??=`, which is right for them — their value is an option, not a typed string — so they are untouched.

Nine table-driven rows added across `Input.spec.ts` and `Textarea.spec.ts`, covering both the `0` cases and the `''` cases that must not regress. Reverting only the component change turns the five `0` rows red in both the `nuxt` and `vue` projects, while the `''` rows stay green.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
