### PR TITLE
fix(PageCard): stack overlay link behind card content

### DIFF
--- a/src/runtime/components/PageCard.vue
+++ b/src/runtime/components/PageCard.vue
@@ -116,6 +116,7 @@ const ui = computed(() => tv({ extend: theme, ...(appConfig.ui?.pageCard || {}) 
   reverse: props.reverse,
   variant: props.variant,
   to: !!props.to || !!props.onClick,
+  overlay: !!props.to,
   title: !!props.title || !!slots.title,
   highlight: props.highlight,
   highlightColor: props.highlightColor,

--- a/src/runtime/components/PageCard.vue
+++ b/src/runtime/components/PageCard.vue
@@ -142,6 +142,16 @@ const ariaLabel = computed(() => {
   >
     <div v-if="props.spotlight" data-slot="spotlight" :class="ui.spotlight({ class: props.ui?.spotlight })" />
 
+    <ULink
+      v-if="props.to"
+      :aria-label="ariaLabel"
+      v-bind="{ 'to': props.to, 'target': props.target, ...$attrs, 'data-slot': undefined }"
+      :class="prefix('focus:outline-none peer')"
+      raw
+    >
+      <span :class="prefix('absolute inset-0')" aria-hidden="true" />
+    </ULink>
+
     <div data-slot="container" :class="ui.container({ class: props.ui?.container })">
       <div v-if="!!slots.header || (props.icon || !!slots.leading) || !!slots.body || (props.title || !!slots.title) || (props.description || !!slots.description) || !!slots.footer" data-slot="wrapper" :class="ui.wrapper({ class: props.ui?.wrapper })">
         <div v-if="!!slots.header" data-slot="header" :class="ui.header({ class: props.ui?.header })">
@@ -177,15 +187,5 @@ const ariaLabel = computed(() => {
 
       <slot />
     </div>
-
-    <ULink
-      v-if="props.to"
-      :aria-label="ariaLabel"
-      v-bind="{ 'to': props.to, 'target': props.target, ...$attrs, 'data-slot': undefined }"
-      :class="prefix('focus:outline-none peer')"
-      raw
-    >
-      <span :class="prefix('absolute inset-0')" aria-hidden="true" />
-    </ULink>
   </Primitive>
 </template>

--- a/src/theme/page-card.ts
+++ b/src/theme/page-card.ts
@@ -56,7 +56,9 @@ export default (options: Required<ModuleOptions>) => ({
     },
     to: {
       true: {
-        root: ['outline-primary/25 has-[>a:focus-visible]:outline-3', options.theme.transitions && 'transition']
+        root: ['outline-primary/25 has-[>a:focus-visible]:outline-3', options.theme.transitions && 'transition'],
+        container: 'pointer-events-none',
+        wrapper: 'pointer-events-auto'
       }
     },
     title: {

--- a/src/theme/page-card.ts
+++ b/src/theme/page-card.ts
@@ -56,7 +56,11 @@ export default (options: Required<ModuleOptions>) => ({
     },
     to: {
       true: {
-        root: ['outline-primary/25 has-[>a:focus-visible]:outline-3', options.theme.transitions && 'transition'],
+        root: ['outline-primary/25 has-[>a:focus-visible]:outline-3', options.theme.transitions && 'transition']
+      }
+    },
+    overlay: {
+      true: {
         container: 'pointer-events-none',
         wrapper: 'pointer-events-auto'
       }

--- a/test/components/PageCard.spec.ts
+++ b/test/components/PageCard.spec.ts
@@ -79,12 +79,14 @@ describe('PageCard', () => {
     expect(wrapper.find('a').attributes('aria-label')).toBe('test-label')
   })
 
-  it('renders the link before the container so nested interactive elements stay on top', async () => {
+  it('keeps nested interactive elements above the link overlay', async () => {
     const wrapper = await mountSuspended(PageCard, {
       props: { title: 'Title', to: 'https://github.com/benjamincanac' },
       slots: { footer: () => h('button', 'Click me') }
     })
     const html = wrapper.html()
     expect(html.indexOf('<a')).toBeLessThan(html.indexOf('<button'))
+    expect(wrapper.find('[data-slot="container"]').classes()).toContain('pointer-events-none')
+    expect(wrapper.find('[data-slot="wrapper"]').classes()).toContain('pointer-events-auto')
   })
 })

--- a/test/components/PageCard.spec.ts
+++ b/test/components/PageCard.spec.ts
@@ -84,9 +84,19 @@ describe('PageCard', () => {
       props: { title: 'Title', to: 'https://github.com/benjamincanac' },
       slots: { footer: () => h('button', 'Click me') }
     })
+    expect(wrapper.find('a').exists()).toBe(true)
     const html = wrapper.html()
     expect(html.indexOf('<a')).toBeLessThan(html.indexOf('<button'))
     expect(wrapper.find('[data-slot="container"]').classes()).toContain('pointer-events-none')
     expect(wrapper.find('[data-slot="wrapper"]').classes()).toContain('pointer-events-auto')
+  })
+
+  it('does not restrict pointer events when only `onClick` is set', async () => {
+    const wrapper = await mountSuspended(PageCard, {
+      props: { title: 'Title', onClick: () => {} },
+      slots: { footer: () => h('button', 'Click me') }
+    })
+    expect(wrapper.find('[data-slot="container"]').classes()).not.toContain('pointer-events-none')
+    expect(wrapper.find('[data-slot="wrapper"]').classes()).not.toContain('pointer-events-auto')
   })
 })

--- a/test/components/PageCard.spec.ts
+++ b/test/components/PageCard.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from 'vitest'
 import { axe } from 'vitest-axe'
+import { h } from 'vue'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { renderEach } from '../component-render'
 import PageCard from '../../src/runtime/components/PageCard.vue'
@@ -76,5 +77,14 @@ describe('PageCard', () => {
     })
     expect(wrapper.attributes('aria-label')).toBeUndefined()
     expect(wrapper.find('a').attributes('aria-label')).toBe('test-label')
+  })
+
+  it('renders the link before the container so nested interactive elements stay on top', async () => {
+    const wrapper = await mountSuspended(PageCard, {
+      props: { title: 'Title', to: 'https://github.com/benjamincanac' },
+      slots: { footer: () => h('button', 'Click me') }
+    })
+    const html = wrapper.html()
+    expect(html.indexOf('<a')).toBeLessThan(html.indexOf('<button'))
   })
 })

--- a/test/components/__snapshots__/PageCard-vue.spec.ts.snap
+++ b/test/components/__snapshots__/PageCard-vue.spec.ts.snap
@@ -3,15 +3,16 @@
 exports[`PageCard > renders with as correctly 1`] = `
 "<section data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <!--v-if-->
   </div>
-  <!--v-if-->
 </section>"
 `;
 
 exports[`PageCard > renders with body slot correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -21,12 +22,12 @@ exports[`PageCard > renders with body slot correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with class correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex bg-default ring ring-default rounded-xl">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -39,12 +40,12 @@ exports[`PageCard > renders with class correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with default slot correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -57,12 +58,12 @@ exports[`PageCard > renders with default slot correctly 1`] = `
       <!--v-if-->
     </div>Default slot
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with description correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -75,12 +76,12 @@ exports[`PageCard > renders with description correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with description slot correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -93,12 +94,12 @@ exports[`PageCard > renders with description slot correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with footer slot correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -111,12 +112,12 @@ exports[`PageCard > renders with footer slot correctly 1`] = `
       <div data-slot="footer" class="pt-4 mt-auto">Footer slot</div>
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with header slot correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -129,13 +130,13 @@ exports[`PageCard > renders with header slot correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color error correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-error">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -147,13 +148,13 @@ exports[`PageCard > renders with highlight color error correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color info correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-info">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -165,13 +166,13 @@ exports[`PageCard > renders with highlight color info correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color neutral correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-inverted">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -183,13 +184,13 @@ exports[`PageCard > renders with highlight color neutral correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color neutral correctly 2`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-inverted">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -201,13 +202,13 @@ exports[`PageCard > renders with highlight color neutral correctly 2`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color primary correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -219,13 +220,13 @@ exports[`PageCard > renders with highlight color primary correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color secondary correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-secondary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -237,13 +238,13 @@ exports[`PageCard > renders with highlight color secondary correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color success correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-success">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -255,13 +256,13 @@ exports[`PageCard > renders with highlight color success correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color warning correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-warning">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -273,13 +274,13 @@ exports[`PageCard > renders with highlight color warning correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -291,12 +292,12 @@ exports[`PageCard > renders with highlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with icon correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -306,12 +307,12 @@ exports[`PageCard > renders with icon correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with leading slot correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -324,13 +325,13 @@ exports[`PageCard > renders with leading slot correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with orientation horizontal correctly 1`] = `
 "<div data-orientation="horizontal" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 lg:grid-cols-2 lg:items-center">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -342,13 +343,13 @@ exports[`PageCard > renders with orientation horizontal correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with orientation horizontal reverse correctly 1`] = `
 "<div data-orientation="horizontal" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 lg:grid-cols-2 lg:items-center">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start order-last">
       <!--v-if-->
@@ -360,12 +361,12 @@ exports[`PageCard > renders with orientation horizontal reverse correctly 1`] = 
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with orientation vertical correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -378,12 +379,12 @@ exports[`PageCard > renders with orientation vertical correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with orientation vertical reverse correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start order-last">
@@ -396,13 +397,13 @@ exports[`PageCard > renders with orientation vertical reverse correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color error correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -414,13 +415,13 @@ exports[`PageCard > renders with spotlight color error correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color info correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -432,13 +433,13 @@ exports[`PageCard > renders with spotlight color info correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color neutral correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -450,13 +451,13 @@ exports[`PageCard > renders with spotlight color neutral correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color neutral correctly 2`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -468,13 +469,13 @@ exports[`PageCard > renders with spotlight color neutral correctly 2`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color primary correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -486,13 +487,13 @@ exports[`PageCard > renders with spotlight color primary correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color secondary correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -504,13 +505,13 @@ exports[`PageCard > renders with spotlight color secondary correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color success correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -522,13 +523,13 @@ exports[`PageCard > renders with spotlight color success correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color warning correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -540,13 +541,13 @@ exports[`PageCard > renders with spotlight color warning correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -558,12 +559,12 @@ exports[`PageCard > renders with spotlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with title correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -576,12 +577,12 @@ exports[`PageCard > renders with title correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with title slot correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -594,21 +595,21 @@ exports[`PageCard > renders with title slot correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated/50 has-[>a:focus-visible]:ring-primary">
-  <!--v-if-->
+  <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Card link" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <!--v-if-->
-  </div><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Card link" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
+  </div>
 </div>"
 `;
 
 exports[`PageCard > renders with ui correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -621,13 +622,13 @@ exports[`PageCard > renders with ui correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant ghost correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -639,13 +640,13 @@ exports[`PageCard > renders with variant ghost correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant ghost highlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -657,13 +658,12 @@ exports[`PageCard > renders with variant ghost highlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant ghost to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated/50">
-  <!--v-if-->
+  <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -674,13 +674,14 @@ exports[`PageCard > renders with variant ghost to correctly 1`] = `
       </div>
       <!--v-if-->
     </div>
-  </div><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
+  </div>
 </div>"
 `;
 
 exports[`PageCard > renders with variant naked correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-0 sm:p-0">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -692,13 +693,13 @@ exports[`PageCard > renders with variant naked correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant naked highlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-0 sm:p-0">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -710,13 +711,12 @@ exports[`PageCard > renders with variant naked highlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant naked to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg outline-primary/25 has-[>a:focus-visible]:outline-3 transition">
-  <!--v-if-->
+  <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-0 sm:p-0">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -727,13 +727,14 @@ exports[`PageCard > renders with variant naked to correctly 1`] = `
       </div>
       <!--v-if-->
     </div>
-  </div><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
+  </div>
 </div>"
 `;
 
 exports[`PageCard > renders with variant outline correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -745,13 +746,13 @@ exports[`PageCard > renders with variant outline correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant outline highlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -763,13 +764,12 @@ exports[`PageCard > renders with variant outline highlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant outline to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated/50 has-[>a:focus-visible]:ring-primary">
-  <!--v-if-->
+  <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -780,13 +780,14 @@ exports[`PageCard > renders with variant outline to correctly 1`] = `
       </div>
       <!--v-if-->
     </div>
-  </div><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
+  </div>
 </div>"
 `;
 
 exports[`PageCard > renders with variant soft correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -798,13 +799,13 @@ exports[`PageCard > renders with variant soft correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant soft highlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50 ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -816,13 +817,12 @@ exports[`PageCard > renders with variant soft highlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant soft to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50 outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated">
-  <!--v-if-->
+  <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -833,13 +833,14 @@ exports[`PageCard > renders with variant soft to correctly 1`] = `
       </div>
       <!--v-if-->
     </div>
-  </div><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
+  </div>
 </div>"
 `;
 
 exports[`PageCard > renders with variant solid correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-inverted text-inverted">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -851,13 +852,13 @@ exports[`PageCard > renders with variant solid correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant solid highlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-inverted text-inverted ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -869,13 +870,12 @@ exports[`PageCard > renders with variant solid highlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant solid to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-inverted text-inverted outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-inverted/90">
-  <!--v-if-->
+  <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -886,13 +886,14 @@ exports[`PageCard > renders with variant solid to correctly 1`] = `
       </div>
       <!--v-if-->
     </div>
-  </div><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
+  </div>
 </div>"
 `;
 
 exports[`PageCard > renders with variant subtle correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50 ring ring-default">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -904,13 +905,13 @@ exports[`PageCard > renders with variant subtle correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant subtle highlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50 ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -922,13 +923,12 @@ exports[`PageCard > renders with variant subtle highlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant subtle to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50 ring ring-default outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated hover:ring-accented has-[>a:focus-visible]:ring-primary">
-  <!--v-if-->
+  <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -939,6 +939,6 @@ exports[`PageCard > renders with variant subtle to correctly 1`] = `
       </div>
       <!--v-if-->
     </div>
-  </div><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
+  </div>
 </div>"
 `;

--- a/test/components/__snapshots__/PageCard-vue.spec.ts.snap
+++ b/test/components/__snapshots__/PageCard-vue.spec.ts.snap
@@ -601,7 +601,7 @@ exports[`PageCard > renders with title slot correctly 1`] = `
 exports[`PageCard > renders with to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated/50 has-[>a:focus-visible]:ring-primary">
   <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Card link" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
-  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
+  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 pointer-events-none">
     <!--v-if-->
   </div>
 </div>"
@@ -664,8 +664,8 @@ exports[`PageCard > renders with variant ghost highlight correctly 1`] = `
 exports[`PageCard > renders with variant ghost to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated/50">
   <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
-  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
-    <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
+  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 pointer-events-none">
+    <div data-slot="wrapper" class="flex flex-col flex-1 items-start pointer-events-auto">
       <!--v-if-->
       <div data-slot="leading" class="inline-flex items-center mb-2.5"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="leadingIcon" class="size-5 shrink-0 text-primary"></svg></div>
       <div data-slot="body" class="flex-1">
@@ -717,8 +717,8 @@ exports[`PageCard > renders with variant naked highlight correctly 1`] = `
 exports[`PageCard > renders with variant naked to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg outline-primary/25 has-[>a:focus-visible]:outline-3 transition">
   <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
-  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-0 sm:p-0">
-    <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
+  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-0 sm:p-0 pointer-events-none">
+    <div data-slot="wrapper" class="flex flex-col flex-1 items-start pointer-events-auto">
       <!--v-if-->
       <div data-slot="leading" class="inline-flex items-center mb-2.5"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="leadingIcon" class="size-5 shrink-0 text-primary"></svg></div>
       <div data-slot="body" class="flex-1">
@@ -770,8 +770,8 @@ exports[`PageCard > renders with variant outline highlight correctly 1`] = `
 exports[`PageCard > renders with variant outline to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated/50 has-[>a:focus-visible]:ring-primary">
   <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
-  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
-    <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
+  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 pointer-events-none">
+    <div data-slot="wrapper" class="flex flex-col flex-1 items-start pointer-events-auto">
       <!--v-if-->
       <div data-slot="leading" class="inline-flex items-center mb-2.5"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="leadingIcon" class="size-5 shrink-0 text-primary"></svg></div>
       <div data-slot="body" class="flex-1">
@@ -823,8 +823,8 @@ exports[`PageCard > renders with variant soft highlight correctly 1`] = `
 exports[`PageCard > renders with variant soft to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50 outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated">
   <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
-  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
-    <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
+  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 pointer-events-none">
+    <div data-slot="wrapper" class="flex flex-col flex-1 items-start pointer-events-auto">
       <!--v-if-->
       <div data-slot="leading" class="inline-flex items-center mb-2.5"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="leadingIcon" class="size-5 shrink-0 text-primary"></svg></div>
       <div data-slot="body" class="flex-1">
@@ -876,8 +876,8 @@ exports[`PageCard > renders with variant solid highlight correctly 1`] = `
 exports[`PageCard > renders with variant solid to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-inverted text-inverted outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-inverted/90">
   <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
-  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
-    <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
+  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 pointer-events-none">
+    <div data-slot="wrapper" class="flex flex-col flex-1 items-start pointer-events-auto">
       <!--v-if-->
       <div data-slot="leading" class="inline-flex items-center mb-2.5"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="leadingIcon" class="size-5 shrink-0 text-primary"></svg></div>
       <div data-slot="body" class="flex-1">
@@ -929,8 +929,8 @@ exports[`PageCard > renders with variant subtle highlight correctly 1`] = `
 exports[`PageCard > renders with variant subtle to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50 ring ring-default outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated hover:ring-accented has-[>a:focus-visible]:ring-primary">
   <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
-  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
-    <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
+  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 pointer-events-none">
+    <div data-slot="wrapper" class="flex flex-col flex-1 items-start pointer-events-auto">
       <!--v-if-->
       <div data-slot="leading" class="inline-flex items-center mb-2.5"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="leadingIcon" class="size-5 shrink-0 text-primary"></svg></div>
       <div data-slot="body" class="flex-1">

--- a/test/components/__snapshots__/PageCard.spec.ts.snap
+++ b/test/components/__snapshots__/PageCard.spec.ts.snap
@@ -601,7 +601,7 @@ exports[`PageCard > renders with title slot correctly 1`] = `
 exports[`PageCard > renders with to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated/50 has-[>a:focus-visible]:ring-primary">
   <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Card link" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
-  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
+  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 pointer-events-none">
     <!--v-if-->
   </div>
 </div>"
@@ -664,8 +664,8 @@ exports[`PageCard > renders with variant ghost highlight correctly 1`] = `
 exports[`PageCard > renders with variant ghost to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated/50">
   <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
-  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
-    <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
+  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 pointer-events-none">
+    <div data-slot="wrapper" class="flex flex-col flex-1 items-start pointer-events-auto">
       <!--v-if-->
       <div data-slot="leading" class="inline-flex items-center mb-2.5"><span class="iconify i-lucide:house size-5 shrink-0 text-primary" aria-hidden="true" data-slot="leadingIcon"></span></div>
       <div data-slot="body" class="flex-1">
@@ -717,8 +717,8 @@ exports[`PageCard > renders with variant naked highlight correctly 1`] = `
 exports[`PageCard > renders with variant naked to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg outline-primary/25 has-[>a:focus-visible]:outline-3 transition">
   <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
-  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-0 sm:p-0">
-    <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
+  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-0 sm:p-0 pointer-events-none">
+    <div data-slot="wrapper" class="flex flex-col flex-1 items-start pointer-events-auto">
       <!--v-if-->
       <div data-slot="leading" class="inline-flex items-center mb-2.5"><span class="iconify i-lucide:house size-5 shrink-0 text-primary" aria-hidden="true" data-slot="leadingIcon"></span></div>
       <div data-slot="body" class="flex-1">
@@ -770,8 +770,8 @@ exports[`PageCard > renders with variant outline highlight correctly 1`] = `
 exports[`PageCard > renders with variant outline to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated/50 has-[>a:focus-visible]:ring-primary">
   <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
-  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
-    <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
+  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 pointer-events-none">
+    <div data-slot="wrapper" class="flex flex-col flex-1 items-start pointer-events-auto">
       <!--v-if-->
       <div data-slot="leading" class="inline-flex items-center mb-2.5"><span class="iconify i-lucide:house size-5 shrink-0 text-primary" aria-hidden="true" data-slot="leadingIcon"></span></div>
       <div data-slot="body" class="flex-1">
@@ -823,8 +823,8 @@ exports[`PageCard > renders with variant soft highlight correctly 1`] = `
 exports[`PageCard > renders with variant soft to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50 outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated">
   <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
-  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
-    <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
+  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 pointer-events-none">
+    <div data-slot="wrapper" class="flex flex-col flex-1 items-start pointer-events-auto">
       <!--v-if-->
       <div data-slot="leading" class="inline-flex items-center mb-2.5"><span class="iconify i-lucide:house size-5 shrink-0 text-primary" aria-hidden="true" data-slot="leadingIcon"></span></div>
       <div data-slot="body" class="flex-1">
@@ -876,8 +876,8 @@ exports[`PageCard > renders with variant solid highlight correctly 1`] = `
 exports[`PageCard > renders with variant solid to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-inverted text-inverted outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-inverted/90">
   <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
-  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
-    <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
+  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 pointer-events-none">
+    <div data-slot="wrapper" class="flex flex-col flex-1 items-start pointer-events-auto">
       <!--v-if-->
       <div data-slot="leading" class="inline-flex items-center mb-2.5"><span class="iconify i-lucide:house size-5 shrink-0 text-primary" aria-hidden="true" data-slot="leadingIcon"></span></div>
       <div data-slot="body" class="flex-1">
@@ -929,8 +929,8 @@ exports[`PageCard > renders with variant subtle highlight correctly 1`] = `
 exports[`PageCard > renders with variant subtle to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50 ring ring-default outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated hover:ring-accented has-[>a:focus-visible]:ring-primary">
   <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
-  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
-    <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
+  <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 pointer-events-none">
+    <div data-slot="wrapper" class="flex flex-col flex-1 items-start pointer-events-auto">
       <!--v-if-->
       <div data-slot="leading" class="inline-flex items-center mb-2.5"><span class="iconify i-lucide:house size-5 shrink-0 text-primary" aria-hidden="true" data-slot="leadingIcon"></span></div>
       <div data-slot="body" class="flex-1">

--- a/test/components/__snapshots__/PageCard.spec.ts.snap
+++ b/test/components/__snapshots__/PageCard.spec.ts.snap
@@ -3,15 +3,16 @@
 exports[`PageCard > renders with as correctly 1`] = `
 "<section data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <!--v-if-->
   </div>
-  <!--v-if-->
 </section>"
 `;
 
 exports[`PageCard > renders with body slot correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -21,12 +22,12 @@ exports[`PageCard > renders with body slot correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with class correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex bg-default ring ring-default rounded-xl">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -39,12 +40,12 @@ exports[`PageCard > renders with class correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with default slot correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -57,12 +58,12 @@ exports[`PageCard > renders with default slot correctly 1`] = `
       <!--v-if-->
     </div>Default slot
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with description correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -75,12 +76,12 @@ exports[`PageCard > renders with description correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with description slot correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -93,12 +94,12 @@ exports[`PageCard > renders with description slot correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with footer slot correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -111,12 +112,12 @@ exports[`PageCard > renders with footer slot correctly 1`] = `
       <div data-slot="footer" class="pt-4 mt-auto">Footer slot</div>
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with header slot correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -129,13 +130,13 @@ exports[`PageCard > renders with header slot correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color error correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-error">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -147,13 +148,13 @@ exports[`PageCard > renders with highlight color error correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color info correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-info">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -165,13 +166,13 @@ exports[`PageCard > renders with highlight color info correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color neutral correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-inverted">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -183,13 +184,13 @@ exports[`PageCard > renders with highlight color neutral correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color neutral correctly 2`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-inverted">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -201,13 +202,13 @@ exports[`PageCard > renders with highlight color neutral correctly 2`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color primary correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -219,13 +220,13 @@ exports[`PageCard > renders with highlight color primary correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color secondary correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-secondary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -237,13 +238,13 @@ exports[`PageCard > renders with highlight color secondary correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color success correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-success">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -255,13 +256,13 @@ exports[`PageCard > renders with highlight color success correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight color warning correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-warning">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -273,13 +274,13 @@ exports[`PageCard > renders with highlight color warning correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with highlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -291,12 +292,12 @@ exports[`PageCard > renders with highlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with icon correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -306,12 +307,12 @@ exports[`PageCard > renders with icon correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with leading slot correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -324,13 +325,13 @@ exports[`PageCard > renders with leading slot correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with orientation horizontal correctly 1`] = `
 "<div data-orientation="horizontal" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 lg:grid-cols-2 lg:items-center">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -342,13 +343,13 @@ exports[`PageCard > renders with orientation horizontal correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with orientation horizontal reverse correctly 1`] = `
 "<div data-orientation="horizontal" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6 lg:grid-cols-2 lg:items-center">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start order-last">
       <!--v-if-->
@@ -360,12 +361,12 @@ exports[`PageCard > renders with orientation horizontal reverse correctly 1`] = 
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with orientation vertical correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -378,12 +379,12 @@ exports[`PageCard > renders with orientation vertical correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with orientation vertical reverse correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start order-last">
@@ -396,13 +397,13 @@ exports[`PageCard > renders with orientation vertical reverse correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color error correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -414,13 +415,13 @@ exports[`PageCard > renders with spotlight color error correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color info correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -432,13 +433,13 @@ exports[`PageCard > renders with spotlight color info correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color neutral correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -450,13 +451,13 @@ exports[`PageCard > renders with spotlight color neutral correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color neutral correctly 2`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -468,13 +469,13 @@ exports[`PageCard > renders with spotlight color neutral correctly 2`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color primary correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -486,13 +487,13 @@ exports[`PageCard > renders with spotlight color primary correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color secondary correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -504,13 +505,13 @@ exports[`PageCard > renders with spotlight color secondary correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color success correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -522,13 +523,13 @@ exports[`PageCard > renders with spotlight color success correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight color warning correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -540,13 +541,13 @@ exports[`PageCard > renders with spotlight color warning correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with spotlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <div data-slot="spotlight" class="absolute inset-0 rounded-[inherit] pointer-events-none bg-default/90"></div>
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -558,12 +559,12 @@ exports[`PageCard > renders with spotlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with title correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -576,12 +577,12 @@ exports[`PageCard > renders with title correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with title slot correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -594,21 +595,21 @@ exports[`PageCard > renders with title slot correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated/50 has-[>a:focus-visible]:ring-primary">
-  <!--v-if-->
+  <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Card link" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <!--v-if-->
-  </div><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Card link" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
+  </div>
 </div>"
 `;
 
 exports[`PageCard > renders with ui correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
+  <!--v-if-->
   <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
@@ -621,13 +622,13 @@ exports[`PageCard > renders with ui correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant ghost correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -639,13 +640,13 @@ exports[`PageCard > renders with variant ghost correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant ghost highlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -657,13 +658,12 @@ exports[`PageCard > renders with variant ghost highlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant ghost to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated/50">
-  <!--v-if-->
+  <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -674,13 +674,14 @@ exports[`PageCard > renders with variant ghost to correctly 1`] = `
       </div>
       <!--v-if-->
     </div>
-  </div><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
+  </div>
 </div>"
 `;
 
 exports[`PageCard > renders with variant naked correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-0 sm:p-0">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -692,13 +693,13 @@ exports[`PageCard > renders with variant naked correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant naked highlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-0 sm:p-0">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -710,13 +711,12 @@ exports[`PageCard > renders with variant naked highlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant naked to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg outline-primary/25 has-[>a:focus-visible]:outline-3 transition">
-  <!--v-if-->
+  <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-0 sm:p-0">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -727,13 +727,14 @@ exports[`PageCard > renders with variant naked to correctly 1`] = `
       </div>
       <!--v-if-->
     </div>
-  </div><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
+  </div>
 </div>"
 `;
 
 exports[`PageCard > renders with variant outline correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -745,13 +746,13 @@ exports[`PageCard > renders with variant outline correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant outline highlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -763,13 +764,12 @@ exports[`PageCard > renders with variant outline highlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant outline to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-default ring ring-default outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated/50 has-[>a:focus-visible]:ring-primary">
-  <!--v-if-->
+  <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -780,13 +780,14 @@ exports[`PageCard > renders with variant outline to correctly 1`] = `
       </div>
       <!--v-if-->
     </div>
-  </div><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
+  </div>
 </div>"
 `;
 
 exports[`PageCard > renders with variant soft correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -798,13 +799,13 @@ exports[`PageCard > renders with variant soft correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant soft highlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50 ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -816,13 +817,12 @@ exports[`PageCard > renders with variant soft highlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant soft to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50 outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated">
-  <!--v-if-->
+  <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -833,13 +833,14 @@ exports[`PageCard > renders with variant soft to correctly 1`] = `
       </div>
       <!--v-if-->
     </div>
-  </div><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
+  </div>
 </div>"
 `;
 
 exports[`PageCard > renders with variant solid correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-inverted text-inverted">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -851,13 +852,13 @@ exports[`PageCard > renders with variant solid correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant solid highlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-inverted text-inverted ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -869,13 +870,12 @@ exports[`PageCard > renders with variant solid highlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant solid to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-inverted text-inverted outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-inverted/90">
-  <!--v-if-->
+  <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -886,13 +886,14 @@ exports[`PageCard > renders with variant solid to correctly 1`] = `
       </div>
       <!--v-if-->
     </div>
-  </div><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
+  </div>
 </div>"
 `;
 
 exports[`PageCard > renders with variant subtle correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50 ring ring-default">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -904,13 +905,13 @@ exports[`PageCard > renders with variant subtle correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant subtle highlight correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50 ring-2 ring-primary">
   <!--v-if-->
+  <!--v-if-->
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -922,13 +923,12 @@ exports[`PageCard > renders with variant subtle highlight correctly 1`] = `
       <!--v-if-->
     </div>
   </div>
-  <!--v-if-->
 </div>"
 `;
 
 exports[`PageCard > renders with variant subtle to correctly 1`] = `
 "<div data-orientation="vertical" data-slot="root" class="relative flex rounded-lg bg-elevated/50 ring ring-default outline-primary/25 has-[>a:focus-visible]:outline-3 transition hover:bg-elevated hover:ring-accented has-[>a:focus-visible]:ring-primary">
-  <!--v-if-->
+  <!--v-if--><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
   <div data-slot="container" class="relative flex flex-col flex-1 lg:grid gap-x-8 gap-y-4 p-4 sm:p-6">
     <div data-slot="wrapper" class="flex flex-col flex-1 items-start">
       <!--v-if-->
@@ -939,6 +939,6 @@ exports[`PageCard > renders with variant subtle to correctly 1`] = `
       </div>
       <!--v-if-->
     </div>
-  </div><a href="https://github.com/benjamincanac" rel="noopener noreferrer" aria-label="Title" class="focus:outline-none peer"><span class="absolute inset-0" aria-hidden="true"></span></a>
+  </div>
 </div>"
 `;


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6873
Resolves #5526

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

When `to` is set, `PageCard` renders an invisible `<a>` with an absolutely positioned `<span class="absolute inset-0">` so the whole card is clickable. Because `container` also has `position: relative`, both it and that overlay span compete for the same paint layer, and whichever sits later in the template wins everywhere it overlaps. The overlay came after `container`, so it always won, swallowing hover/click on anything nested inside the card, like a `Tooltip` trigger in the footer slot.

Reordering the two isn't enough on its own: it just flips which one wins everywhere, so the card stops navigating from empty space instead. The fix needs both pieces: the `<a>` moves before `container` so real content can sit above the overlay, and `container` gets `pointer-events-none` with `wrapper` (where the header/leading/body/footer content lives) back to `pointer-events-auto`, so clicks on nested interactive elements land on that content while clicks on the empty parts of the card fall through to the link underneath. `page-aside.ts` already uses this exact pairing for a similar overlay.

This does mean clicking directly on the title or description text no longer also triggers navigation, only actual interactive content and empty space do. That's the standard trade-off of this "stretched link" pattern (the same one Bootstrap's `.stretched-link` makes), and it's a smaller behavior change than leaving nested Tooltips and buttons permanently unusable.

The `pointer-events` split is scoped to only apply when `to` is actually set, not the broader `to || onClick` condition `PageCard` otherwise uses for its hover styling, so a plain `onClick`-only card (no overlay link at all) keeps its default-slot content fully interactive as before.

### 🧪 Testing

Added tests in `test/components/PageCard.spec.ts` covering: the link renders before the container and `container`/`wrapper` carry the right `pointer-events` classes when `to` is set, and that an `onClick`-only card (no `to`) is untouched. Verified interactively against the real repro from #6873 (a `Tooltip` in the `footer` slot) that the trigger is hoverable/clickable and the rest of the card still navigates. Updated the affected `PageCard` snapshots.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.