### PR TITLE
docs(icons): document what `clientBundle.scan` covers

### DIFF
--- a/docs/content/docs/1.getting-started/6.integrations/1.icons/1.nuxt.md
+++ b/docs/content/docs/1.getting-started/6.integrations/1.icons/1.nuxt.md
@@ -107,6 +107,24 @@ export default defineNuxtConfig({
 })
 ```
 
+Scanning only reads `.vue`, `.jsx`, `.tsx`, `.md`, `.mdc`, `.mdx`, `.yml` and `.yaml` files, and it only matches icon names written as literal strings. Icons defined in a `.ts` or `.js` file, like a list of navigation links, are missed, as are names built dynamically like `i-lucide-${name}`. Set `globInclude` to scan those files as well. It replaces the default list, so keep the extensions you still need:
+
+```ts [nuxt.config.ts]
+export default defineNuxtConfig({
+  modules: ['@nuxt/ui'],
+  css: ['~/assets/css/main.css'],
+  icon: {
+    clientBundle: {
+      scan: {
+        globInclude: ['**/*.{vue,jsx,tsx,md,mdc,mdx,yml,yaml,ts,js}']
+      }
+    }
+  }
+})
+```
+
+Names that are only known at runtime, like icons coming from an API, can't be scanned. Add them to `clientBundle.icons` instead. Any icon that is not bundled is loaded on demand at runtime, from the `/api/_nuxt_icon` route when your app is server-rendered and from the Iconify API when you use `nuxt generate` or `ssr: false`.
+
 ::note{to="https://github.com/nuxt/icon?tab=readme-ov-file#iconify-dataset" target="_blank"}
 Read more about this in the `@nuxt/icon` documentation.
 ::

--- a/docs/content/docs/1.getting-started/6.integrations/1.icons/1.nuxt.md
+++ b/docs/content/docs/1.getting-started/6.integrations/1.icons/1.nuxt.md
@@ -123,7 +123,7 @@ export default defineNuxtConfig({
 })
 ```
 
-Names that are only known at runtime, like icons coming from an API, can't be scanned. Add them to `clientBundle.icons` instead. Any icon that is not bundled is loaded on demand at runtime, from the `/api/_nuxt_icon` route when your app is server-rendered and from the Iconify API when you use `nuxt generate` or `ssr: false`.
+Dynamic names can still be bundled when you know the whole set at build time, by listing them in `clientBundle.icons`. Names that only exist at runtime, like icons coming from an API, can't be bundled at all. They are loaded on demand from the `/api/_nuxt_icon` route when your app is server-rendered, with the Iconify API as a fallback, and from the Iconify API directly when you use `nuxt generate` or `ssr: false`.
 
 ::note{to="https://github.com/nuxt/icon?tab=readme-ov-file#iconify-dataset" target="_blank"}
 Read more about this in the `@nuxt/icon` documentation.

--- a/docs/content/docs/1.getting-started/6.integrations/1.icons/2.vue.md
+++ b/docs/content/docs/1.getting-started/6.integrations/1.icons/2.vue.md
@@ -123,6 +123,28 @@ export default defineConfig({
 })
 ```
 
+Scanning only reads `.vue`, `.jsx`, `.tsx`, `.md`, `.mdc`, `.mdx`, `.yml` and `.yaml` files, and it only matches icon names written as literal strings. Icons defined in a `.ts` or `.js` file, like a list of navigation links, are missed, as are names built dynamically like `i-lucide-${name}`. Set `globInclude` to scan those files as well. It replaces the default list, so keep the extensions you still need:
+
+```ts [vite.config.ts]
+import ui from '@nuxt/ui/vite'
+
+export default defineConfig({
+  plugins: [
+    ui({
+      icon: {
+        clientBundle: {
+          scan: {
+            globInclude: ['**/*.{vue,jsx,tsx,md,mdc,mdx,yml,yaml,ts,js}']
+          }
+        }
+      }
+    })
+  ]
+})
+```
+
+Names that are only known at runtime, like icons coming from an API, can't be scanned. Add them to `clientBundle.icons` instead.
+
 Icons whose collection is not installed still load from the Iconify API at runtime, so install each collection you use with `@iconify-json/{collection_name}`. To opt out of bundling entirely, set `icon.clientBundle` to `false`.
 
 ## Theme

--- a/docs/content/docs/1.getting-started/6.integrations/1.icons/2.vue.md
+++ b/docs/content/docs/1.getting-started/6.integrations/1.icons/2.vue.md
@@ -143,7 +143,7 @@ export default defineConfig({
 })
 ```
 
-Names that are only known at runtime, like icons coming from an API, can't be scanned. Add them to `clientBundle.icons` instead.
+Dynamic names can still be bundled when you know the whole set at build time, by listing them in `clientBundle.icons`. Names that only exist at runtime, like icons coming from an API, can't be bundled at all and are loaded from the Iconify API on demand.
 
 Icons whose collection is not installed still load from the Iconify API at runtime, so install each collection you use with `@iconify-json/{collection_name}`. To opt out of bundling entirely, set `icon.clientBundle` to `false`.
 


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

The icons pages document how to turn `clientBundle.scan` on but not what it actually covers, so icons that live in a `.ts` or `.js` file (a nav config, a list of constants) silently never get bundled and keep loading at runtime.

`@nuxt/icon`'s scanner defaults to `globInclude: ['**/*.{vue,jsx,tsx,md,mdc,mdx,yml,yaml}']` and only matches literal icon names, so this adds a short passage on both pages covering the file types it reads, the `globInclude` escape hatch for `.ts`/`.js` sources, and the fact that dynamic names have to go in `clientBundle.icons`. The Nuxt page also spells out where an unbundled icon is loaded from, since it differs between SSR and `nuxt generate`.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
