### PR TITLE
fix(Form): omit method attribute on nested forms

### DIFF
--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -463,7 +463,7 @@ defineExpose(api)
     :id="formId"
     ref="formRef"
     :name="parentBus ? undefined : props.name"
-    method="post"
+    :method="parentBus ? undefined : 'post'"
     :class="ui({ class: [props.ui?.base, props.class] })"
     @submit.prevent="onSubmitWrapper"
   >


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Nested `UForm` components render as `div` elements to avoid invalid nested forms. However, they still received the form-specific `method="post"` attribute.

This change omits the `method` attribute when a form is attached to a parent while preserving `method="post"` for root forms.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
