### PR TITLE
fix(Slider): emit a number for a single thumb

### DIFF
--- a/src/runtime/components/Slider.vue
+++ b/src/runtime/components/Slider.vue
@@ -71,7 +71,7 @@ const modelValue = defineModel<T>()
 
 const appConfig = useAppConfig() as Slider['AppConfig']
 
-const rootProps = useForwardProps(reactivePick(props, 'as', 'orientation', 'min', 'max', 'step', 'minStepsBetweenThumbs', 'inverted'), emits)
+const rootProps = useForwardProps(reactivePick(props, 'as', 'orientation', 'min', 'max', 'step', 'minStepsBetweenThumbs', 'inverted'))
 
 const { id, emitFormChange, emitFormInput, size: formFieldSize, color: formFieldColor, name, disabled: formFieldDisabled, ariaAttrs } = useFormField<SliderProps>(_props)
 

--- a/test/components/Slider.spec.ts
+++ b/test/components/Slider.spec.ts
@@ -192,7 +192,25 @@ describe('Slider', () => {
       const input = wrapper.findComponent({ name: 'SliderRoot' })
       input.vm.$emit('update:modelValue', 1)
 
-      expect(wrapper.emitted()).toMatchObject({ 'update:modelValue': [[1], [1]] })
+      expect(wrapper.emitted()).toMatchObject({ 'update:modelValue': [[1]] })
+    })
+
+    test('update:modelValue event with a single thumb', async () => {
+      const wrapper = mount(Slider, { props: { modelValue: 25 } })
+
+      const input = wrapper.findComponent({ name: 'SliderRoot' })
+      input.vm.$emit('update:modelValue', [71])
+
+      expect(wrapper.emitted()).toMatchObject({ 'update:modelValue': [[71]] })
+    })
+
+    test('update:modelValue event with multiple thumbs', async () => {
+      const wrapper = mount(Slider, { props: { modelValue: [10, 90] } })
+
+      const input = wrapper.findComponent({ name: 'SliderRoot' })
+      input.vm.$emit('update:modelValue', [10, 71])
+
+      expect(wrapper.emitted()).toMatchObject({ 'update:modelValue': [[[10, 71]]] })
     })
 
     test('change event', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6889

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Since v4.11.0 a single-thumb `USlider` writes `[71]` back into `v-model` instead of `71`.

`Slider` keeps the model in `sliderValue`, a computed that wraps a number into an array for Reka UI on the way in and unwraps a one-element array on the way out. That setter is what decides the shape the component emits. But `rootProps` is built with `useForwardProps(..., emits)`, and `useEmitAsProps` walks the component's declared emits, which include the `update:modelValue` that `defineModel` adds. `SliderRoot` therefore also got an `onUpdate:modelValue` that re-emits Reka UI's raw array to the parent.

Both handlers have always been bound, so the value the parent kept was whichever one ran last. #6848 moved `v-bind` after `v-model` on `SliderRoot`, which flipped that order and let the raw array win. The duplicate emit is visible in the existing test, which asserted `{ 'update:modelValue': [[1], [1]] }`.

Dropping `emits` from that `useForwardProps` call removes the extra handler. `update:modelValue` is already wired through `v-model="sliderValue"` and `@update:model-value="emitFormInput()"`, and `change` comes from `onChange` on `@value-commit`, so nothing else was relying on it.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
