### PR TITLE
fix(Select): don't reopen the menu on a real pointer click

### DIFF
--- a/src/runtime/components/Select.vue
+++ b/src/runtime/components/Select.vue
@@ -323,14 +323,32 @@ function isSelectItem(item: SelectItem): item is Exclude<SelectItem, SelectValue
   return typeof item === 'object' && item !== null
 }
 
+// Set by a real pointer press on the trigger. A `<label for>` click forwards only a
+// `click`, never a `pointerdown`, and that absence is what tells the two apart.
+let triggerSawPointerDown = false
+
+function onTriggerPointerDown() {
+  triggerSawPointerDown = true
+}
+
 function onTriggerClick(open: boolean) {
   // A real pointer click opens the menu via `pointerdown` (so `open` is already `true`
   // here), and keyboard activation opens via `keydown`. A `<label for>` click only
   // forwards a `click` with no `pointerdown`, so the menu is still closed. In that case
   // re-dispatch a `pointerdown` to open it, matching SelectMenu (Combobox opens on click).
-  if (!open) {
+  //
+  // `open` alone is not enough to detect that. While the menu is open, Reka's
+  // dismissable layer normally makes the trigger unclickable, but a `pointer-events`
+  // utility on the trigger or an ancestor lets the click through: the outside
+  // `pointerdown` has already closed the menu, so `open` is `false` by the time `click`
+  // fires and the menu would immediately reopen. Requiring the absence of a real
+  // `pointerdown` keeps the label case working without reopening on a genuine click.
+  const forwardedFromLabel = !triggerSawPointerDown
+  if (!open && forwardedFromLabel) {
     triggerRef.value?.$el?.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0 }))
   }
+  // Reset last: the synthesized `pointerdown` above re-enters `onTriggerPointerDown`.
+  triggerSawPointerDown = false
 }
 
 const viewportRef = useTemplateRef('viewportRef')
@@ -363,6 +381,7 @@ defineExpose({
       data-slot="base"
       :class="ui.base({ class: [props.ui?.base, props.class] })"
       v-bind="{ ...$attrs, ...ariaAttrs }"
+      @pointerdown="onTriggerPointerDown"
       @click="onTriggerClick(open)"
     >
       <span v-if="isLeading || !!props.avatar || !!slots.leading" data-slot="leading" :class="ui.leading({ class: props.ui?.leading })">

--- a/src/runtime/components/Select.vue
+++ b/src/runtime/components/Select.vue
@@ -331,6 +331,13 @@ function onTriggerPointerDown() {
   triggerSawPointerDown = true
 }
 
+// A cancelled sequence (touch scrolling, the browser taking over the gesture)
+// fires no `click`, so without this the flag would outlive the interaction and
+// make the next label click look like a real pointer press.
+function onTriggerPointerCancel() {
+  triggerSawPointerDown = false
+}
+
 function onTriggerClick(open: boolean) {
   // A real pointer click opens the menu via `pointerdown` (so `open` is already `true`
   // here), and keyboard activation opens via `keydown`. A `<label for>` click only
@@ -382,6 +389,7 @@ defineExpose({
       :class="ui.base({ class: [props.ui?.base, props.class] })"
       v-bind="{ ...$attrs, ...ariaAttrs }"
       @pointerdown="onTriggerPointerDown"
+      @pointercancel="onTriggerPointerCancel"
       @click="onTriggerClick(open)"
     >
       <span v-if="isLeading || !!props.avatar || !!slots.leading" data-slot="leading" :class="ui.leading({ class: props.ui?.leading })">

--- a/test/components/Select.spec.ts
+++ b/test/components/Select.spec.ts
@@ -276,6 +276,38 @@ describe('Select', () => {
 
       expect(pointerDowns).toBe(1)
     })
+
+    test('a cancelled pointer sequence does not block a later label click', async () => {
+      const wrapper = await renderForm({
+        slotVars: {
+          items: ['Option 1', 'Option 2']
+        },
+        slotTemplate: `
+        <UFormField name="value" label="Label">
+          <USelect :items="items" :open="false" :portal="false" />
+        </UFormField>
+        `
+      })
+
+      const trigger = wrapper.find('[data-slot="base"]')
+      const el = trigger.element
+
+      let pointerDowns = 0
+      el.addEventListener('pointerdown', () => {
+        pointerDowns++
+      })
+
+      // Touch scrolling cancels the sequence, so no `click` follows and the
+      // "saw a real pointerdown" flag must not survive into the next
+      // interaction, or the label click after it would stop opening the menu.
+      await trigger.trigger('pointerdown')
+      await trigger.trigger('pointercancel')
+      await trigger.trigger('click')
+      await flushPromises()
+
+      // The real press plus the one synthesized for the label-style click.
+      expect(pointerDowns).toBe(2)
+    })
   })
 
   describe('form integration', async () => {

--- a/test/components/Select.spec.ts
+++ b/test/components/Select.spec.ts
@@ -244,6 +244,38 @@ describe('Select', () => {
 
       expect(trigger.attributes('aria-expanded')).toBe('true')
     })
+
+    test('a real pointer click does not synthesize a second pointerdown', async () => {
+      const wrapper = await renderForm({
+        slotVars: {
+          items: ['Option 1', 'Option 2']
+        },
+        slotTemplate: `
+        <UFormField name="value" label="Label">
+          <USelect :items="items" :open="false" :portal="false" />
+        </UFormField>
+        `
+      })
+
+      const trigger = wrapper.find('[data-slot="base"]')
+      const el = trigger.element
+
+      let pointerDowns = 0
+      el.addEventListener('pointerdown', () => {
+        pointerDowns++
+      })
+
+      // A genuine pointer interaction is `pointerdown` then `click`. With a
+      // `pointer-events` utility in play, Reka's outside-pointerdown closes the
+      // menu first, so the click lands while the menu reads as closed. The
+      // trigger must not answer that click by synthesizing another
+      // `pointerdown`, which is what reopened the menu.
+      await trigger.trigger('pointerdown')
+      await trigger.trigger('click')
+      await flushPromises()
+
+      expect(pointerDowns).toBe(1)
+    })
   })
 
   describe('form integration', async () => {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6752

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`USelect` closes and then immediately reopens when the trigger, or any ancestor, carries a `pointer-events` utility. The reporter hit it with the documented map-overlay pattern (`pointer-events-none` container, `pointer-events-auto` control), and their video shows it across Chrome, Firefox and Edge.

This is a regression from #6575, which added a synthesized `pointerdown` so `<label for>` clicks open the menu:

```ts
if (!open) {
  triggerRef.value?.$el?.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, button: 0 }))
}
```

`open` turns out not to be a reliable stand-in for "this click came from a label". Normally the dismissable layer makes the trigger unclickable while the menu is open, so a click on it never lands and the branch is unreachable. A `pointer-events` utility removes that protection: the outside `pointerdown` closes the menu first, so `open` is already `false` by the time `click` fires, the branch runs, and the synthesized `pointerdown` reopens what the user just closed.

The distinction the code actually wants is the one its own comment describes: a `<label for>` click forwards a `click` with no preceding `pointerdown`. So the trigger now records whether a real `pointerdown` reached it and only synthesizes one when none did. The flag is reset at the end of the handler rather than the start, because the synthesized event re-enters the `pointerdown` handler.

Label clicks are unaffected: they still arrive without a `pointerdown`, so they still open the menu.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

Behaviour only, no public API change, so nothing to document.

**Tests.** Added `a real pointer click does not synthesize a second pointerdown` next to the existing label test from #6575, which stays as the regression guard for that path. It counts `pointerdown` events reaching the trigger across a `pointerdown` then `click` sequence and asserts exactly one.

I first wrote the test to assert `aria-expanded` after a click, and it failed: the dismissable-layer close that makes this bug visible does not happen in the test environment, so that assertion was measuring the wrong thing. Counting the synthesized event tests the actual mechanism and is deterministic.

Mutation tested: reverting only `Select.vue` and keeping the test gives `expected 2 to be 1` in both the nuxt and vue environments, confirming the second `pointerdown` is real and that the test catches it.

`pnpm run test` 172/172, `pnpm run lint` and `pnpm run typecheck` clean.
