### PR TITLE
fix(SelectMenu): prevent search input focus on open with `autofocus: false`

### DIFF
--- a/docs/content/docs/2.components/select-menu.md
+++ b/docs/content/docs/2.components/select-menu.md
@@ -279,6 +279,10 @@ props:
 You can set the `search-input` prop to `false` to hide the search input.
 ::
 
+::note
+Use `:search-input="{ autofocus: false }"` to prevent the search input from being focused when the menu opens, e.g. to avoid opening the virtual keyboard on touch devices.
+::
+
 ### Content
 
 Use the `content` prop to control how the SelectMenu content is rendered, like its `align` or `side` for example.

--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -53,6 +53,7 @@ export interface SelectMenuProps<T extends ArrayOrNested<SelectMenuItem> = Array
    * Whether to display the search input or not.
    * Can be an object to pass additional props to the input.
    * `{ placeholder: 'Search...', variant: 'none' }`{lang="ts-type"}
+   * Set `autofocus: false` to prevent the search input from being focused when the menu opens (e.g. to avoid opening the virtual keyboard on touch devices).
    * @defaultValue true
    */
   searchInput?: boolean | Omit<InputProps, 'modelValue' | 'defaultValue'>
@@ -525,6 +526,13 @@ function onClear() {
   emits('clear')
 }
 
+function onMountAutoFocus(event: Event) {
+  // Prevent the `FocusScope` from focusing the search input on open when its autofocus is disabled.
+  if (searchInputProps.value.autofocus === false) {
+    event.preventDefault()
+  }
+}
+
 const viewportRef = useTemplateRef('viewportRef')
 
 const comboboxRootRef = useTemplateRef('comboboxRootRef')
@@ -686,7 +694,7 @@ defineExpose({
     <ComboboxPortal v-bind="portalProps">
       <FieldGroupReset>
         <ComboboxContent data-slot="content" :class="ui.content({ class: props.ui?.content })" v-bind="contentProps">
-          <FocusScope trapped data-slot="focusScope" :class="ui.focusScope({ class: props.ui?.focusScope })">
+          <FocusScope trapped data-slot="focusScope" :class="ui.focusScope({ class: props.ui?.focusScope })" @mount-auto-focus="onMountAutoFocus">
             <slot name="content-top" />
 
             <ComboboxInput v-if="!!props.searchInput" v-model="searchTerm" :display-value="() => searchTerm" as-child>

--- a/test/components/SelectMenu.spec.ts
+++ b/test/components/SelectMenu.spec.ts
@@ -173,6 +173,33 @@ describe('SelectMenu', () => {
     })
   })
 
+  describe('search input', () => {
+    test('focuses the search input when the menu opens by default', async () => {
+      const wrapper = mount(SelectMenu, { attachTo: document.body, props: { open: true, portal: false, items } })
+
+      await flushPromises()
+      // Input.vue's autofocus runs on a macrotask
+      await new Promise(resolve => setTimeout(resolve))
+
+      const input = wrapper.find('[data-slot="input"] input')
+      expect(document.activeElement).toBe(input.element)
+
+      wrapper.unmount()
+    })
+
+    test('does not focus the search input with searchInput autofocus disabled', async () => {
+      const wrapper = mount(SelectMenu, { attachTo: document.body, props: { open: true, portal: false, items, searchInput: { autofocus: false } } })
+
+      await flushPromises()
+      await new Promise(resolve => setTimeout(resolve))
+
+      const input = wrapper.find('[data-slot="input"] input')
+      expect(document.activeElement).not.toBe(input.element)
+
+      wrapper.unmount()
+    })
+  })
+
   describe('create-item', () => {
     // With `create-item`, the create item is always registered so reka-ui's collection
     // never goes from empty to non-empty, leaving the highlight stale when async items load.


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6891

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Opening a `USelectMenu` always focuses the search input, which raises the on-screen keyboard on touch devices even when `:search-input="{ autofocus: false }"` is set.

Turns out the programmatic focus in reka-ui's `ComboboxContentImpl` pointed at in the issue is a no-op in browsers: with `<ComboboxInput as-child>`, reka registers `UInput`'s root `div` as the input element and calling `.focus()` on a div without tabindex does nothing. The focus actually comes from our own `<FocusScope trapped>` in the content, which focuses the first tabbable candidate on mount.

This prevents the `FocusScope` mount auto-focus when `searchInput.autofocus` is explicitly `false`, making the existing prop a real opt-out. Default behavior is unchanged.

Note: with the opt-out, arrow key navigation is inert until the input is focused since reka-ui binds list navigation on the filter input. That's the expected trade-off for a touch-targeted opt-out.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
