### PR TITLE
fix(SelectMenu): key items by identity so aria-activedescendant moves while filtering

### DIFF
--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -392,6 +392,42 @@ const filteredGroups = computed(() => {
 })
 const filteredItems = computed(() => filteredGroups.value.flatMap(group => group))
 
+// Keys each rendered item by where it sits in the *unfiltered* items, so the key follows the
+// item as filtering re-sorts the list. A positional key over `filteredGroups` makes Vue reuse
+// the same `ComboboxItem` instance and rewrite its text, and reka's item id lives on that
+// instance — so `aria-activedescendant` keeps pointing at an id that never changes and a
+// screen reader is never told the active option moved.
+//
+// `filterGroups` drops groups that filter away entirely, so `filteredGroups` indices do not
+// align with `groups` and the group key has to come from an item too. Identical primitives
+// cannot be told apart by value, so each occurrence takes one of that value's original
+// positions in turn, which keeps the keys unique.
+const keyedGroups = computed(() => {
+  const positions = new Map<SelectMenuItem, string[]>()
+
+  groups.value.forEach((group, groupIndex) => {
+    group.forEach((item, index) => {
+      const key = `item-${groupIndex}-${index}`
+      const queue = positions.get(item)
+
+      if (queue) {
+        queue.push(key)
+      } else {
+        positions.set(item, [key])
+      }
+    })
+  })
+
+  return filteredGroups.value.map((group, groupIndex) => {
+    const entries = group.map((item, index) => ({
+      item,
+      key: positions.get(item)?.shift() ?? `filtered-${groupIndex}-${index}`
+    }))
+
+    return { key: entries[0]?.key ?? `filtered-${groupIndex}`, entries }
+  })
+})
+
 // eslint-disable-next-line vue/no-dupe-keys
 const createItem = computed(() => {
   if (!props.createItem || !searchTerm.value) {
@@ -739,8 +775,8 @@ defineExpose({
                   <ReuseCreateItemTemplate />
                 </ComboboxGroup>
 
-                <ComboboxGroup v-for="(group, groupIndex) in filteredGroups" :key="`group-${groupIndex}`" data-slot="group" :class="ui.group({ class: props.ui?.group })">
-                  <ReuseItemTemplate v-for="(item, index) in group" :key="`group-${groupIndex}-${index}`" :item="item" :index="index" />
+                <ComboboxGroup v-for="group in keyedGroups" :key="group.key" data-slot="group" :class="ui.group({ class: props.ui?.group })">
+                  <ReuseItemTemplate v-for="(entry, index) in group.entries" :key="entry.key" :item="entry.item" :index="index" />
                 </ComboboxGroup>
 
                 <ComboboxGroup v-if="createItem && createItemPosition === 'bottom'" data-slot="group" :class="ui.group({ class: props.ui?.group })">

--- a/test/components/SelectMenu.spec.ts
+++ b/test/components/SelectMenu.spec.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, test } from 'vitest'
+import { describe, it, expect, test, vi } from 'vitest'
 import { axe } from 'vitest-axe'
 import { mountSuspended } from '@nuxt/test-utils/runtime'
 import { renderEach } from '../component-render'
@@ -196,6 +196,61 @@ describe('SelectMenu', () => {
       const input = wrapper.find('[data-slot="input"] input')
       expect(document.activeElement).not.toBe(input.element)
 
+      wrapper.unmount()
+    })
+  })
+
+  describe('filtering', () => {
+    // Keying the items by position makes Vue reuse the same ComboboxItem instance and rewrite
+    // its text when the filter re-sorts the list. reka's item id lives on that instance and
+    // `aria-activedescendant` is read from the highlighted element's id, so the attribute keeps
+    // pointing at an id that never changes: the highlight moves for sighted users and is never
+    // announced to a screen reader.
+    test('moves aria-activedescendant when filtering changes the highlighted item', async () => {
+      const wrapper = mount(SelectMenu, {
+        attachTo: document.body,
+        props: { open: true, portal: false, items: ['Alpha', 'Beta', 'Gamma'] }
+      })
+      await flushPromises()
+
+      const search = wrapper.find('[data-slot="input"] input')
+      const highlighted = () => wrapper.find('[role="option"][data-highlighted]')
+      const activeDescendant = () => search.attributes('aria-activedescendant')
+
+      expect(highlighted().text()).toContain('Alpha')
+      const before = highlighted().attributes('id')
+      expect(activeDescendant()).toBe(before)
+
+      // Typed, not set as a prop: it is reka's own search-term watcher that moves the
+      // highlight, and that is the path a member takes.
+      await search.setValue('Gam')
+      await flushPromises()
+
+      expect(highlighted().text()).toContain('Gamma')
+      expect(highlighted().attributes('id')).not.toBe(before)
+      expect(activeDescendant()).toBe(highlighted().attributes('id'))
+
+      wrapper.unmount()
+    })
+
+    // Identical primitives cannot be told apart by value, so each occurrence has to take one of
+    // that value's original positions in turn or the keys collide and Vue warns.
+    test('keeps keys unique when items repeat', async () => {
+      const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+      const wrapper = mount(SelectMenu, {
+        attachTo: document.body,
+        props: { open: true, portal: false, items: ['Alpha', 'Alpha', 'Beta'] }
+      })
+      await flushPromises()
+
+      await wrapper.find('[data-slot="input"] input').setValue('Alp')
+      await flushPromises()
+
+      expect(wrapper.findAll('[role="option"]')).toHaveLength(2)
+      expect(warn.mock.calls.flat().join(' ')).not.toContain('Duplicate keys')
+
+      warn.mockRestore()
       wrapper.unmount()
     })
   })


### PR DESCRIPTION
Resolves #6910.

### The problem

`SelectMenu` keys its options by position, so typing in the search input — which re-sorts the list through `filterGroups` — makes Vue reuse the same `ComboboxItem` instance and rewrite its text rather than move or replace it.

The item's `id` belongs to that instance (`ComboboxItem`: `useId(undefined, 'reka-combobox-item')`), and `aria-activedescendant` is derived from the highlighted **element's** id (`ListboxFilter`: `watchSyncEffect(() => activedescendant.value = rootContext.highlightedElement.value?.id)`). So the attribute keeps pointing at an id that never changes, the `watchSyncEffect` never fires, and assistive technology is never told the active option moved — it keeps announcing the option that was active before the filter ran.

Sighted users see nothing wrong, because `data-highlighted` lands on that same reused node.

This is not a reka bug: a stable id per item instance is exactly what `aria-activedescendant` needs, and reka is handed the same element with new text. Item identity is information only `SelectMenu` has, since it owns the `v-for`.

### The fix

Key each rendered item by where it sits in the *unfiltered* items, so the key follows the item through any re-sort. Two details the obvious fix gets wrong, and both are covered:

- `filterGroups` ends with `.filter(group => group.some(...))`, so groups that filter away entirely are dropped and `filteredGroups` indices no longer align with `groups`. A group key built from `groupIndex` is wrong as soon as one group empties, so the group key comes from its first item instead.
- Identical primitives (`['A', 'A']`) cannot be told apart by value, so each occurrence consumes one of that value's original positions in turn. A naive value-derived key collides and Vue warns.

### Tests

Two regression tests in `test/components/SelectMenu.spec.ts`:

- **`moves aria-activedescendant when filtering changes the highlighted item`** — the property that matters: when the highlighted option's text changes, its `id` must change too, and the search input's `aria-activedescendant` must follow. On `v4` it fails with `expected 'reka-combobox-item-v-3' not to be 'reka-combobox-item-v-3'` — the text went from `Alpha` to `Gamma` and the id did not move.
- **`keeps keys unique when items repeat`** — pins the duplicate-primitive case, asserting no Vue duplicate-key warning.

It types into the search input rather than setting `search-term` as a prop, because it is reka's own search-term watcher that moves the highlight, and typing is the path a user takes.

Locally, on this branch: `test/components/SelectMenu.spec.ts` 194 passed (both the `nuxt` and `vue` projects, no snapshot churn — keys are not rendered), `eslint` clean on both changed files, `vue-tsc --noEmit` clean.

Beyond the suite, measured by hand in Chromium across the item shapes, asserting the same property:

| item shape | before | after |
| --- | --- | --- |
| plain strings | ✗ | ✓ |
| duplicate strings | ✗ | ✓ |
| numbers | ✗ | ✓ |
| objects, `label` only, no `value-key` | ✗ | ✓ |
| objects with `value-key` | ✗ | ✓ |
| duplicate labels, distinct values | ✗ | ✓ |
| groups + `type: label`/`separator` | ✓ | ✓ |
| `virtualize` | ✗ | ✗ |

Selecting the highlighted option after filtering still yields the right value for every shape.

### Scope, and what this deliberately leaves alone

- **`virtualize` is not fixed**, and looks like a separate problem: that branch renders through `ComboboxVirtualizer`, which recycles its own nodes and is passed no key at all, so the same id is reused by construction. reka excludes the virtual path from its highlight handling too (`!rootContext.isVirtual.value`).
- **The same positional-key pattern is in `InputMenu.vue#L803-L804`, `Listbox.vue#L410-L411` and `DropdownMenuContent.vue#L186-L187`**, which all filter through `filterGroups` and whose reka counterparts bind `aria-activedescendant` the same way. I have left them alone on purpose: `SelectMenu` is the one I could measure against a real screen-reader user, and doing all four properly wants the keying extracted into `useFilter` (which already owns `filterGroups`) rather than copied four times. That is a shape question for you — happy to extend this PR either way.

### Why it was reported

A blind member of our church could not use a venue picker in our app: it read out the first option and then went silent while he typed. He has been running exactly this change as a local patch and confirms it fixes it for him.
