### PR TITLE
fix(Checkbox/RadioGroup): add `flex-wrap` on `list` and `card` variants

### DIFF
--- a/src/theme/checkbox-group.ts
+++ b/src/theme/checkbox-group.ts
@@ -23,8 +23,12 @@ export default (options: Required<ModuleOptions>) => ({
       neutral: {}
     },
     variant: {
-      list: {},
-      card: {},
+      list: {
+        fieldset: 'flex-wrap'
+      },
+      card: {
+        fieldset: 'flex-wrap'
+      },
       table: {
         item: [`border border-default ${hover}bg-elevated/50`, options.theme.transitions && 'transition-colors']
       }

--- a/src/theme/radio-group.ts
+++ b/src/theme/radio-group.ts
@@ -26,9 +26,11 @@ export default (options: Required<ModuleOptions>) => ({
     },
     variant: {
       list: {
+        fieldset: 'flex-wrap',
         item: ''
       },
       card: {
+        fieldset: 'flex-wrap',
         item: [`border border-default rounded-lg ${hover}bg-elevated/50`, options.theme.transitions && 'transition-colors']
       },
       table: {

--- a/test/components/__snapshots__/CheckboxGroup-vue.spec.ts.snap
+++ b/test/components/__snapshots__/CheckboxGroup-vue.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`CheckboxGroup > renders with ariaLabel correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" aria-label="Aria label" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -44,7 +44,7 @@ exports[`CheckboxGroup > renders with ariaLabel correctly 1`] = `
 
 exports[`CheckboxGroup > renders with as correctly 1`] = `
 "<section id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -86,7 +86,7 @@ exports[`CheckboxGroup > renders with as correctly 1`] = `
 
 exports[`CheckboxGroup > renders with class correctly 1`] = `
 "<div id="v-0" data-slot="root" class="absolute" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -128,7 +128,7 @@ exports[`CheckboxGroup > renders with class correctly 1`] = `
 
 exports[`CheckboxGroup > renders with defaultValue correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>
@@ -168,7 +168,7 @@ exports[`CheckboxGroup > renders with defaultValue correctly 1`] = `
 
 exports[`CheckboxGroup > renders with description correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -210,7 +210,7 @@ exports[`CheckboxGroup > renders with description correctly 1`] = `
 
 exports[`CheckboxGroup > renders with description slot correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -252,7 +252,7 @@ exports[`CheckboxGroup > renders with description slot correctly 1`] = `
 
 exports[`CheckboxGroup > renders with descriptionKey correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -294,7 +294,7 @@ exports[`CheckboxGroup > renders with descriptionKey correctly 1`] = `
 
 exports[`CheckboxGroup > renders with disabled correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="-1" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row opacity-75">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 cursor-not-allowed outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-disabled="" disabled="" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -336,7 +336,7 @@ exports[`CheckboxGroup > renders with disabled correctly 1`] = `
 
 exports[`CheckboxGroup > renders with highlight indicator hidden correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if--><label data-slot="item" class="relative flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10 not-has-disabled:border-primary not-has-disabled:has-data-[state=checked]:border-primary">
       <div data-slot="container" class="flex items-center h-auto"><button data-slot="base" class="rounded-sm ring ring-inset overflow-hidden focus-visible:outline-none sr-only size-4 ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"></button>
         <!--v-if-->
@@ -372,7 +372,7 @@ exports[`CheckboxGroup > renders with highlight indicator hidden correctly 1`] =
 
 exports[`CheckboxGroup > renders with horizontal variant card correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="horizontal" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-row gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-row flex-wrap gap-y-1">
     <!--v-if--><label data-slot="item" class="relative flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden focus-visible:outline-none size-4" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="horizontal"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>
         <!--v-if-->
@@ -412,7 +412,7 @@ exports[`CheckboxGroup > renders with horizontal variant card correctly 1`] = `
 
 exports[`CheckboxGroup > renders with horizontal variant list correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="horizontal" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-row gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-row flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="horizontal"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>
@@ -492,7 +492,7 @@ exports[`CheckboxGroup > renders with horizontal variant table correctly 1`] = `
 
 exports[`CheckboxGroup > renders with icon card correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if--><label data-slot="item" class="relative flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-auto"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden focus-visible:outline-none sr-only size-4" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"></button>
         <!--v-if-->
@@ -525,7 +525,7 @@ exports[`CheckboxGroup > renders with icon card correctly 1`] = `
 
 exports[`CheckboxGroup > renders with icon correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1]">
       <div data-slot="container" class="flex items-center h-auto"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden focus-visible:outline-none sr-only size-4" id="v-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"></button>
@@ -591,7 +591,7 @@ exports[`CheckboxGroup > renders with icon table correctly 1`] = `
 
 exports[`CheckboxGroup > renders with indicator end correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row-reverse">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>
@@ -631,7 +631,7 @@ exports[`CheckboxGroup > renders with indicator end correctly 1`] = `
 
 exports[`CheckboxGroup > renders with indicator hidden correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1]">
       <div data-slot="container" class="flex items-center h-auto"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden focus-visible:outline-none sr-only size-4" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"></button>
@@ -667,7 +667,7 @@ exports[`CheckboxGroup > renders with indicator hidden correctly 1`] = `
 
 exports[`CheckboxGroup > renders with indicator start correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>
@@ -707,7 +707,7 @@ exports[`CheckboxGroup > renders with indicator start correctly 1`] = `
 
 exports[`CheckboxGroup > renders with items correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -749,7 +749,7 @@ exports[`CheckboxGroup > renders with items correctly 1`] = `
 
 exports[`CheckboxGroup > renders with label slot correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -791,7 +791,7 @@ exports[`CheckboxGroup > renders with label slot correctly 1`] = `
 
 exports[`CheckboxGroup > renders with labelKey correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -833,7 +833,7 @@ exports[`CheckboxGroup > renders with labelKey correctly 1`] = `
 
 exports[`CheckboxGroup > renders with legend slot correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <legend data-slot="legend" class="mb-1 block font-medium text-default text-sm">Legend slot</legend>
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -875,7 +875,7 @@ exports[`CheckboxGroup > renders with legend slot correctly 1`] = `
 
 exports[`CheckboxGroup > renders with modelValue correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>
@@ -915,7 +915,7 @@ exports[`CheckboxGroup > renders with modelValue correctly 1`] = `
 
 exports[`CheckboxGroup > renders with neutral variant card correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if--><label data-slot="item" class="relative flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-inverted/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-inverted has-focus-visible:z-[1] has-data-[state=checked]:border-inverted/50 has-data-[state=checked]:bg-elevated">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden focus-visible:outline-none size-4" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-inverted"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>
         <!--v-if-->
@@ -955,7 +955,7 @@ exports[`CheckboxGroup > renders with neutral variant card correctly 1`] = `
 
 exports[`CheckboxGroup > renders with neutral variant card highlight correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if--><label data-slot="item" class="relative flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row p-3.5 outline-inverted/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-inverted has-focus-visible:z-[1] has-data-[state=checked]:border-inverted/50 has-data-[state=checked]:bg-elevated">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset overflow-hidden focus-visible:outline-none size-4 ring-inverted" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-inverted"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>
         <!--v-if-->
@@ -995,7 +995,7 @@ exports[`CheckboxGroup > renders with neutral variant card highlight correctly 1
 
 exports[`CheckboxGroup > renders with neutral variant list correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-inverted/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-inverted" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-inverted"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>
@@ -1035,7 +1035,7 @@ exports[`CheckboxGroup > renders with neutral variant list correctly 1`] = `
 
 exports[`CheckboxGroup > renders with neutral variant list highlight correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset overflow-hidden size-4 outline-inverted/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-inverted ring-inverted" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-inverted"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>
@@ -1155,7 +1155,7 @@ exports[`CheckboxGroup > renders with neutral variant table highlight correctly 
 
 exports[`CheckboxGroup > renders with primary variant card correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if--><label data-slot="item" class="relative flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden focus-visible:outline-none size-4" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>
         <!--v-if-->
@@ -1195,7 +1195,7 @@ exports[`CheckboxGroup > renders with primary variant card correctly 1`] = `
 
 exports[`CheckboxGroup > renders with primary variant card highlight correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if--><label data-slot="item" class="relative flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset overflow-hidden focus-visible:outline-none size-4 ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>
         <!--v-if-->
@@ -1235,7 +1235,7 @@ exports[`CheckboxGroup > renders with primary variant card highlight correctly 1
 
 exports[`CheckboxGroup > renders with primary variant list correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>
@@ -1275,7 +1275,7 @@ exports[`CheckboxGroup > renders with primary variant list correctly 1`] = `
 
 exports[`CheckboxGroup > renders with primary variant list highlight correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>
@@ -1395,7 +1395,7 @@ exports[`CheckboxGroup > renders with primary variant table highlight correctly 
 
 exports[`CheckboxGroup > renders with required correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <legend data-slot="legend" class="mb-1 block font-medium text-default text-sm after:content-['*'] after:ms-0.5 after:text-error">Legend</legend>
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -1437,7 +1437,7 @@ exports[`CheckboxGroup > renders with required correctly 1`] = `
 
 exports[`CheckboxGroup > renders with size lg correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4.5 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-4"></svg></span></button>
@@ -1477,7 +1477,7 @@ exports[`CheckboxGroup > renders with size lg correctly 1`] = `
 
 exports[`CheckboxGroup > renders with size md correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>
@@ -1517,7 +1517,7 @@ exports[`CheckboxGroup > renders with size md correctly 1`] = `
 
 exports[`CheckboxGroup > renders with size sm correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-0.5">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-0.5">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-4"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-3.5 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3"></svg></span></button>
@@ -1557,7 +1557,7 @@ exports[`CheckboxGroup > renders with size sm correctly 1`] = `
 
 exports[`CheckboxGroup > renders with size xl correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1.5">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1.5">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-6"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-5 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-4.5"></svg></span></button>
@@ -1597,7 +1597,7 @@ exports[`CheckboxGroup > renders with size xl correctly 1`] = `
 
 exports[`CheckboxGroup > renders with size xs correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-0.5">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-0.5">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-4"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-3 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-2.5"></svg></span></button>
@@ -1637,7 +1637,7 @@ exports[`CheckboxGroup > renders with size xs correctly 1`] = `
 
 exports[`CheckboxGroup > renders with ui correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex flex-col gap-y-1 gap-x-4">
+  <fieldset data-slot="fieldset" class="flex flex-col flex-wrap gap-y-1 gap-x-4">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -1679,7 +1679,7 @@ exports[`CheckboxGroup > renders with ui correctly 1`] = `
 
 exports[`CheckboxGroup > renders with valueKey correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0:Option 1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" aria-hidden="true" role="img" width="1em" height="1em" viewBox="0 0 16 16" data-slot="icon" class="shrink-0 size-3.5"></svg></span></button>

--- a/test/components/__snapshots__/CheckboxGroup.spec.ts.snap
+++ b/test/components/__snapshots__/CheckboxGroup.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`CheckboxGroup > renders with ariaLabel correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" aria-label="Aria label" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -44,7 +44,7 @@ exports[`CheckboxGroup > renders with ariaLabel correctly 1`] = `
 
 exports[`CheckboxGroup > renders with as correctly 1`] = `
 "<section id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -86,7 +86,7 @@ exports[`CheckboxGroup > renders with as correctly 1`] = `
 
 exports[`CheckboxGroup > renders with class correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="absolute" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -128,7 +128,7 @@ exports[`CheckboxGroup > renders with class correctly 1`] = `
 
 exports[`CheckboxGroup > renders with defaultValue correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>
@@ -168,7 +168,7 @@ exports[`CheckboxGroup > renders with defaultValue correctly 1`] = `
 
 exports[`CheckboxGroup > renders with description correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -210,7 +210,7 @@ exports[`CheckboxGroup > renders with description correctly 1`] = `
 
 exports[`CheckboxGroup > renders with description slot correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -252,7 +252,7 @@ exports[`CheckboxGroup > renders with description slot correctly 1`] = `
 
 exports[`CheckboxGroup > renders with descriptionKey correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -294,7 +294,7 @@ exports[`CheckboxGroup > renders with descriptionKey correctly 1`] = `
 
 exports[`CheckboxGroup > renders with disabled correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="-1" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row opacity-75">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 cursor-not-allowed outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-disabled="" disabled="" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -336,7 +336,7 @@ exports[`CheckboxGroup > renders with disabled correctly 1`] = `
 
 exports[`CheckboxGroup > renders with highlight indicator hidden correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if--><label data-slot="item" class="relative flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10 not-has-disabled:border-primary not-has-disabled:has-data-[state=checked]:border-primary">
       <div data-slot="container" class="flex items-center h-auto"><button data-slot="base" class="rounded-sm ring ring-inset overflow-hidden focus-visible:outline-none sr-only size-4 ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"></button>
         <!--v-if-->
@@ -372,7 +372,7 @@ exports[`CheckboxGroup > renders with highlight indicator hidden correctly 1`] =
 
 exports[`CheckboxGroup > renders with horizontal variant card correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="horizontal" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-row gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-row flex-wrap gap-y-1">
     <!--v-if--><label data-slot="item" class="relative flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden focus-visible:outline-none size-4" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="horizontal"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>
         <!--v-if-->
@@ -412,7 +412,7 @@ exports[`CheckboxGroup > renders with horizontal variant card correctly 1`] = `
 
 exports[`CheckboxGroup > renders with horizontal variant list correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="horizontal" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-row gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-row flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="horizontal"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>
@@ -492,7 +492,7 @@ exports[`CheckboxGroup > renders with horizontal variant table correctly 1`] = `
 
 exports[`CheckboxGroup > renders with icon card correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if--><label data-slot="item" class="relative flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-auto"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden focus-visible:outline-none sr-only size-4" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"></button>
         <!--v-if-->
@@ -525,7 +525,7 @@ exports[`CheckboxGroup > renders with icon card correctly 1`] = `
 
 exports[`CheckboxGroup > renders with icon correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1]">
       <div data-slot="container" class="flex items-center h-auto"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden focus-visible:outline-none sr-only size-4" id="v-0-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"></button>
@@ -591,7 +591,7 @@ exports[`CheckboxGroup > renders with icon table correctly 1`] = `
 
 exports[`CheckboxGroup > renders with indicator end correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row-reverse">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>
@@ -631,7 +631,7 @@ exports[`CheckboxGroup > renders with indicator end correctly 1`] = `
 
 exports[`CheckboxGroup > renders with indicator hidden correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1]">
       <div data-slot="container" class="flex items-center h-auto"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden focus-visible:outline-none sr-only size-4" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"></button>
@@ -667,7 +667,7 @@ exports[`CheckboxGroup > renders with indicator hidden correctly 1`] = `
 
 exports[`CheckboxGroup > renders with indicator start correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>
@@ -707,7 +707,7 @@ exports[`CheckboxGroup > renders with indicator start correctly 1`] = `
 
 exports[`CheckboxGroup > renders with items correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -749,7 +749,7 @@ exports[`CheckboxGroup > renders with items correctly 1`] = `
 
 exports[`CheckboxGroup > renders with label slot correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -791,7 +791,7 @@ exports[`CheckboxGroup > renders with label slot correctly 1`] = `
 
 exports[`CheckboxGroup > renders with labelKey correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -833,7 +833,7 @@ exports[`CheckboxGroup > renders with labelKey correctly 1`] = `
 
 exports[`CheckboxGroup > renders with legend slot correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <legend data-slot="legend" class="mb-1 block font-medium text-default text-sm">Legend slot</legend>
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -875,7 +875,7 @@ exports[`CheckboxGroup > renders with legend slot correctly 1`] = `
 
 exports[`CheckboxGroup > renders with modelValue correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>
@@ -915,7 +915,7 @@ exports[`CheckboxGroup > renders with modelValue correctly 1`] = `
 
 exports[`CheckboxGroup > renders with neutral variant card correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if--><label data-slot="item" class="relative flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-inverted/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-inverted has-focus-visible:z-[1] has-data-[state=checked]:border-inverted/50 has-data-[state=checked]:bg-elevated">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden focus-visible:outline-none size-4" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-inverted"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>
         <!--v-if-->
@@ -955,7 +955,7 @@ exports[`CheckboxGroup > renders with neutral variant card correctly 1`] = `
 
 exports[`CheckboxGroup > renders with neutral variant card highlight correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if--><label data-slot="item" class="relative flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row p-3.5 outline-inverted/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-inverted has-focus-visible:z-[1] has-data-[state=checked]:border-inverted/50 has-data-[state=checked]:bg-elevated">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset overflow-hidden focus-visible:outline-none size-4 ring-inverted" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-inverted"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>
         <!--v-if-->
@@ -995,7 +995,7 @@ exports[`CheckboxGroup > renders with neutral variant card highlight correctly 1
 
 exports[`CheckboxGroup > renders with neutral variant list correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-inverted/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-inverted" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-inverted"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>
@@ -1035,7 +1035,7 @@ exports[`CheckboxGroup > renders with neutral variant list correctly 1`] = `
 
 exports[`CheckboxGroup > renders with neutral variant list highlight correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset overflow-hidden size-4 outline-inverted/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-inverted ring-inverted" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-inverted"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>
@@ -1155,7 +1155,7 @@ exports[`CheckboxGroup > renders with neutral variant table highlight correctly 
 
 exports[`CheckboxGroup > renders with primary variant card correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if--><label data-slot="item" class="relative flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden focus-visible:outline-none size-4" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>
         <!--v-if-->
@@ -1195,7 +1195,7 @@ exports[`CheckboxGroup > renders with primary variant card correctly 1`] = `
 
 exports[`CheckboxGroup > renders with primary variant card highlight correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if--><label data-slot="item" class="relative flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset overflow-hidden focus-visible:outline-none size-4 ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>
         <!--v-if-->
@@ -1235,7 +1235,7 @@ exports[`CheckboxGroup > renders with primary variant card highlight correctly 1
 
 exports[`CheckboxGroup > renders with primary variant list correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>
@@ -1275,7 +1275,7 @@ exports[`CheckboxGroup > renders with primary variant list correctly 1`] = `
 
 exports[`CheckboxGroup > renders with primary variant list highlight correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>
@@ -1395,7 +1395,7 @@ exports[`CheckboxGroup > renders with primary variant table highlight correctly 
 
 exports[`CheckboxGroup > renders with required correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <legend data-slot="legend" class="mb-1 block font-medium text-default text-sm after:content-['*'] after:ms-0.5 after:text-error">Legend</legend>
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -1437,7 +1437,7 @@ exports[`CheckboxGroup > renders with required correctly 1`] = `
 
 exports[`CheckboxGroup > renders with size lg correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4.5 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-4" aria-hidden="true" data-slot="icon"></span></span></button>
@@ -1477,7 +1477,7 @@ exports[`CheckboxGroup > renders with size lg correctly 1`] = `
 
 exports[`CheckboxGroup > renders with size md correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>
@@ -1517,7 +1517,7 @@ exports[`CheckboxGroup > renders with size md correctly 1`] = `
 
 exports[`CheckboxGroup > renders with size sm correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-0.5">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-0.5">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-4"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-3.5 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-3" aria-hidden="true" data-slot="icon"></span></span></button>
@@ -1557,7 +1557,7 @@ exports[`CheckboxGroup > renders with size sm correctly 1`] = `
 
 exports[`CheckboxGroup > renders with size xl correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1.5">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1.5">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-6"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-5 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-4.5" aria-hidden="true" data-slot="icon"></span></span></button>
@@ -1597,7 +1597,7 @@ exports[`CheckboxGroup > renders with size xl correctly 1`] = `
 
 exports[`CheckboxGroup > renders with size xs correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-0.5">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-0.5">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-4"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-3 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-2.5" aria-hidden="true" data-slot="icon"></span></span></button>
@@ -1637,7 +1637,7 @@ exports[`CheckboxGroup > renders with size xs correctly 1`] = `
 
 exports[`CheckboxGroup > renders with ui correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex flex-col gap-y-1 gap-x-4">
+  <fieldset data-slot="fieldset" class="flex flex-col flex-wrap gap-y-1 gap-x-4">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:1" role="checkbox" type="button" aria-checked="false" aria-required="false" data-state="unchecked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical">
@@ -1679,7 +1679,7 @@ exports[`CheckboxGroup > renders with ui correctly 1`] = `
 
 exports[`CheckboxGroup > renders with valueKey correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col flex-wrap gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="relative flex items-start flex-row">
       <div data-slot="container" class="flex items-center h-5"><button data-slot="base" class="rounded-sm ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" id="v-0-0:Option 1" role="checkbox" type="button" aria-checked="true" aria-required="false" data-state="checked" data-reka-collection-item="" tabindex="-1" data-orientation="vertical"><span data-state="checked" style="pointer-events: none;" data-slot="indicator" class="flex items-center justify-center size-full text-inverted bg-primary"><span class="iconify i-lucide:check shrink-0 size-3.5" aria-hidden="true" data-slot="icon"></span></span></button>

--- a/test/components/__snapshots__/RadioGroup-vue.spec.ts.snap
+++ b/test/components/__snapshots__/RadioGroup-vue.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`RadioGroup > renders with ariaLabel correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" aria-label="Aria label" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -44,7 +44,7 @@ exports[`RadioGroup > renders with ariaLabel correctly 1`] = `
 
 exports[`RadioGroup > renders with as correctly 1`] = `
 "<section id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -86,7 +86,7 @@ exports[`RadioGroup > renders with as correctly 1`] = `
 
 exports[`RadioGroup > renders with class correctly 1`] = `
 "<div id="v-0" data-slot="root" class="absolute" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -128,7 +128,7 @@ exports[`RadioGroup > renders with class correctly 1`] = `
 
 exports[`RadioGroup > renders with defaultValue correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -168,7 +168,7 @@ exports[`RadioGroup > renders with defaultValue correctly 1`] = `
 
 exports[`RadioGroup > renders with description correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -210,7 +210,7 @@ exports[`RadioGroup > renders with description correctly 1`] = `
 
 exports[`RadioGroup > renders with description slot correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -252,7 +252,7 @@ exports[`RadioGroup > renders with description slot correctly 1`] = `
 
 exports[`RadioGroup > renders with descriptionKey correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -294,7 +294,7 @@ exports[`RadioGroup > renders with descriptionKey correctly 1`] = `
 
 exports[`RadioGroup > renders with disabled correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="-1" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" data-disabled="" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm opacity-75">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="false" disabled="" data-state="unchecked" data-disabled="" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 cursor-not-allowed outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -336,7 +336,7 @@ exports[`RadioGroup > renders with disabled correctly 1`] = `
 
 exports[`RadioGroup > renders with highlight indicator hidden correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if--><label data-slot="item" class="flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors text-sm p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10 not-has-disabled:border-primary not-has-disabled:has-data-[state=checked]:border-primary">
       <div data-slot="container" class="flex items-center h-auto"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset overflow-hidden focus-visible:outline-none sr-only size-4 ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
         <!--v-if-->
@@ -376,7 +376,7 @@ exports[`RadioGroup > renders with highlight indicator hidden correctly 1`] = `
 
 exports[`RadioGroup > renders with horizontal variant card correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="horizontal" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="horizontal" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-row gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-row gap-y-1">
     <!--v-if--><label data-slot="item" class="flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row text-sm hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="horizontal" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden focus-visible:outline-none size-4" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
         <!--v-if-->
@@ -416,7 +416,7 @@ exports[`RadioGroup > renders with horizontal variant card correctly 1`] = `
 
 exports[`RadioGroup > renders with horizontal variant list correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="horizontal" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="horizontal" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-row gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-row gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="horizontal" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -496,7 +496,7 @@ exports[`RadioGroup > renders with horizontal variant table correctly 1`] = `
 
 exports[`RadioGroup > renders with icon card correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if--><label data-slot="item" class="flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors text-sm hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-auto"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden focus-visible:outline-none sr-only size-4" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
         <!--v-if-->
@@ -533,7 +533,7 @@ exports[`RadioGroup > renders with icon card correctly 1`] = `
 
 exports[`RadioGroup > renders with icon correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start text-sm outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1]">
       <div data-slot="container" class="flex items-center h-auto"><button id="v-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden focus-visible:outline-none sr-only size-4" value="1">
@@ -609,7 +609,7 @@ exports[`RadioGroup > renders with icon table correctly 1`] = `
 
 exports[`RadioGroup > renders with indicator end correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row-reverse text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -649,7 +649,7 @@ exports[`RadioGroup > renders with indicator end correctly 1`] = `
 
 exports[`RadioGroup > renders with indicator hidden correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start text-sm outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1]">
       <div data-slot="container" class="flex items-center h-auto"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden focus-visible:outline-none sr-only size-4" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -689,7 +689,7 @@ exports[`RadioGroup > renders with indicator hidden correctly 1`] = `
 
 exports[`RadioGroup > renders with indicator start correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -729,7 +729,7 @@ exports[`RadioGroup > renders with indicator start correctly 1`] = `
 
 exports[`RadioGroup > renders with items correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -771,7 +771,7 @@ exports[`RadioGroup > renders with items correctly 1`] = `
 
 exports[`RadioGroup > renders with label slot correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -813,7 +813,7 @@ exports[`RadioGroup > renders with label slot correctly 1`] = `
 
 exports[`RadioGroup > renders with labelKey correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -855,7 +855,7 @@ exports[`RadioGroup > renders with labelKey correctly 1`] = `
 
 exports[`RadioGroup > renders with legend slot correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -897,7 +897,7 @@ exports[`RadioGroup > renders with legend slot correctly 1`] = `
 
 exports[`RadioGroup > renders with modelValue correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -937,7 +937,7 @@ exports[`RadioGroup > renders with modelValue correctly 1`] = `
 
 exports[`RadioGroup > renders with neutral variant card correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if--><label data-slot="item" class="flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row text-sm hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-inverted/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-inverted has-focus-visible:z-[1] has-data-[state=checked]:border-inverted/50 has-data-[state=checked]:bg-elevated">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden focus-visible:outline-none size-4" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-inverted after:size-1.5"></span></button>
         <!--v-if-->
@@ -977,7 +977,7 @@ exports[`RadioGroup > renders with neutral variant card correctly 1`] = `
 
 exports[`RadioGroup > renders with neutral variant card highlight correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if--><label data-slot="item" class="flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row text-sm p-3.5 outline-inverted/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-inverted has-focus-visible:z-[1] has-data-[state=checked]:border-inverted/50 has-data-[state=checked]:bg-elevated">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset overflow-hidden focus-visible:outline-none size-4 ring-inverted" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-inverted after:size-1.5"></span></button>
         <!--v-if-->
@@ -1017,7 +1017,7 @@ exports[`RadioGroup > renders with neutral variant card highlight correctly 1`] 
 
 exports[`RadioGroup > renders with neutral variant list correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-inverted/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-inverted" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-inverted after:size-1.5"></span></button>
@@ -1057,7 +1057,7 @@ exports[`RadioGroup > renders with neutral variant list correctly 1`] = `
 
 exports[`RadioGroup > renders with neutral variant list highlight correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset overflow-hidden size-4 outline-inverted/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-inverted ring-inverted" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-inverted after:size-1.5"></span></button>
@@ -1177,7 +1177,7 @@ exports[`RadioGroup > renders with neutral variant table highlight correctly 1`]
 
 exports[`RadioGroup > renders with primary variant card correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if--><label data-slot="item" class="flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row text-sm hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden focus-visible:outline-none size-4" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
         <!--v-if-->
@@ -1217,7 +1217,7 @@ exports[`RadioGroup > renders with primary variant card correctly 1`] = `
 
 exports[`RadioGroup > renders with primary variant card highlight correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if--><label data-slot="item" class="flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row text-sm p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset overflow-hidden focus-visible:outline-none size-4 ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
         <!--v-if-->
@@ -1257,7 +1257,7 @@ exports[`RadioGroup > renders with primary variant card highlight correctly 1`] 
 
 exports[`RadioGroup > renders with primary variant list correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -1297,7 +1297,7 @@ exports[`RadioGroup > renders with primary variant list correctly 1`] = `
 
 exports[`RadioGroup > renders with primary variant list highlight correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -1417,7 +1417,7 @@ exports[`RadioGroup > renders with primary variant table highlight correctly 1`]
 
 exports[`RadioGroup > renders with required correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="true">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <legend data-slot="legend" class="mb-1 block font-medium text-default text-sm after:content-['*'] after:ms-0.5 after:text-error">Legend</legend>
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="true" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -1459,7 +1459,7 @@ exports[`RadioGroup > renders with required correctly 1`] = `
 
 exports[`RadioGroup > renders with size lg correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4.5 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -1499,7 +1499,7 @@ exports[`RadioGroup > renders with size lg correctly 1`] = `
 
 exports[`RadioGroup > renders with size md correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -1539,7 +1539,7 @@ exports[`RadioGroup > renders with size md correctly 1`] = `
 
 exports[`RadioGroup > renders with size sm correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-0.5">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-0.5">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-xs">
       <div data-slot="container" class="flex items-center h-4"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-3.5 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1"></span></button>
@@ -1579,7 +1579,7 @@ exports[`RadioGroup > renders with size sm correctly 1`] = `
 
 exports[`RadioGroup > renders with size xl correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1.5">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1.5">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-base">
       <div data-slot="container" class="flex items-center h-6"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-5 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-2"></span></button>
@@ -1619,7 +1619,7 @@ exports[`RadioGroup > renders with size xl correctly 1`] = `
 
 exports[`RadioGroup > renders with size xs correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-0.5">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-0.5">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-xs">
       <div data-slot="container" class="flex items-center h-4"><button id="v-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-3 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1"></span></button>
@@ -1659,7 +1659,7 @@ exports[`RadioGroup > renders with size xs correctly 1`] = `
 
 exports[`RadioGroup > renders with ui correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -1701,7 +1701,7 @@ exports[`RadioGroup > renders with ui correctly 1`] = `
 
 exports[`RadioGroup > renders with valueKey correctly 1`] = `
 "<div id="v-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0:Option 1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="Option 1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>

--- a/test/components/__snapshots__/RadioGroup.spec.ts.snap
+++ b/test/components/__snapshots__/RadioGroup.spec.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`RadioGroup > renders with ariaLabel correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" aria-label="Aria label" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -44,7 +44,7 @@ exports[`RadioGroup > renders with ariaLabel correctly 1`] = `
 
 exports[`RadioGroup > renders with as correctly 1`] = `
 "<section id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -86,7 +86,7 @@ exports[`RadioGroup > renders with as correctly 1`] = `
 
 exports[`RadioGroup > renders with class correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="absolute" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -128,7 +128,7 @@ exports[`RadioGroup > renders with class correctly 1`] = `
 
 exports[`RadioGroup > renders with defaultValue correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -168,7 +168,7 @@ exports[`RadioGroup > renders with defaultValue correctly 1`] = `
 
 exports[`RadioGroup > renders with description correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -210,7 +210,7 @@ exports[`RadioGroup > renders with description correctly 1`] = `
 
 exports[`RadioGroup > renders with description slot correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -252,7 +252,7 @@ exports[`RadioGroup > renders with description slot correctly 1`] = `
 
 exports[`RadioGroup > renders with descriptionKey correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -294,7 +294,7 @@ exports[`RadioGroup > renders with descriptionKey correctly 1`] = `
 
 exports[`RadioGroup > renders with disabled correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="-1" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" data-disabled="" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm opacity-75">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="false" disabled="" data-state="unchecked" data-disabled="" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 cursor-not-allowed outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -336,7 +336,7 @@ exports[`RadioGroup > renders with disabled correctly 1`] = `
 
 exports[`RadioGroup > renders with highlight indicator hidden correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if--><label data-slot="item" class="flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors text-sm p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10 not-has-disabled:border-primary not-has-disabled:has-data-[state=checked]:border-primary">
       <div data-slot="container" class="flex items-center h-auto"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset overflow-hidden focus-visible:outline-none sr-only size-4 ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
         <!--v-if-->
@@ -376,7 +376,7 @@ exports[`RadioGroup > renders with highlight indicator hidden correctly 1`] = `
 
 exports[`RadioGroup > renders with horizontal variant card correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="horizontal" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="horizontal" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-row gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-row gap-y-1">
     <!--v-if--><label data-slot="item" class="flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row text-sm hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="horizontal" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden focus-visible:outline-none size-4" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
         <!--v-if-->
@@ -416,7 +416,7 @@ exports[`RadioGroup > renders with horizontal variant card correctly 1`] = `
 
 exports[`RadioGroup > renders with horizontal variant list correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="horizontal" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="horizontal" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-row gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-row gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="horizontal" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -496,7 +496,7 @@ exports[`RadioGroup > renders with horizontal variant table correctly 1`] = `
 
 exports[`RadioGroup > renders with icon card correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if--><label data-slot="item" class="flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors text-sm hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-auto"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden focus-visible:outline-none sr-only size-4" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
         <!--v-if-->
@@ -533,7 +533,7 @@ exports[`RadioGroup > renders with icon card correctly 1`] = `
 
 exports[`RadioGroup > renders with icon correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start text-sm outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1]">
       <div data-slot="container" class="flex items-center h-auto"><button id="v-0-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden focus-visible:outline-none sr-only size-4" value="1">
@@ -609,7 +609,7 @@ exports[`RadioGroup > renders with icon table correctly 1`] = `
 
 exports[`RadioGroup > renders with indicator end correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row-reverse text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -649,7 +649,7 @@ exports[`RadioGroup > renders with indicator end correctly 1`] = `
 
 exports[`RadioGroup > renders with indicator hidden correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start text-sm outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1]">
       <div data-slot="container" class="flex items-center h-auto"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden focus-visible:outline-none sr-only size-4" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -689,7 +689,7 @@ exports[`RadioGroup > renders with indicator hidden correctly 1`] = `
 
 exports[`RadioGroup > renders with indicator start correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -729,7 +729,7 @@ exports[`RadioGroup > renders with indicator start correctly 1`] = `
 
 exports[`RadioGroup > renders with items correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -771,7 +771,7 @@ exports[`RadioGroup > renders with items correctly 1`] = `
 
 exports[`RadioGroup > renders with label slot correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -813,7 +813,7 @@ exports[`RadioGroup > renders with label slot correctly 1`] = `
 
 exports[`RadioGroup > renders with labelKey correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -855,7 +855,7 @@ exports[`RadioGroup > renders with labelKey correctly 1`] = `
 
 exports[`RadioGroup > renders with legend slot correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -897,7 +897,7 @@ exports[`RadioGroup > renders with legend slot correctly 1`] = `
 
 exports[`RadioGroup > renders with modelValue correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -937,7 +937,7 @@ exports[`RadioGroup > renders with modelValue correctly 1`] = `
 
 exports[`RadioGroup > renders with neutral variant card correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if--><label data-slot="item" class="flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row text-sm hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-inverted/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-inverted has-focus-visible:z-[1] has-data-[state=checked]:border-inverted/50 has-data-[state=checked]:bg-elevated">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden focus-visible:outline-none size-4" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-inverted after:size-1.5"></span></button>
         <!--v-if-->
@@ -977,7 +977,7 @@ exports[`RadioGroup > renders with neutral variant card correctly 1`] = `
 
 exports[`RadioGroup > renders with neutral variant card highlight correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if--><label data-slot="item" class="flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row text-sm p-3.5 outline-inverted/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-inverted has-focus-visible:z-[1] has-data-[state=checked]:border-inverted/50 has-data-[state=checked]:bg-elevated">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset overflow-hidden focus-visible:outline-none size-4 ring-inverted" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-inverted after:size-1.5"></span></button>
         <!--v-if-->
@@ -1017,7 +1017,7 @@ exports[`RadioGroup > renders with neutral variant card highlight correctly 1`] 
 
 exports[`RadioGroup > renders with neutral variant list correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-inverted/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-inverted" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-inverted after:size-1.5"></span></button>
@@ -1057,7 +1057,7 @@ exports[`RadioGroup > renders with neutral variant list correctly 1`] = `
 
 exports[`RadioGroup > renders with neutral variant list highlight correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset overflow-hidden size-4 outline-inverted/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-inverted ring-inverted" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-inverted after:size-1.5"></span></button>
@@ -1177,7 +1177,7 @@ exports[`RadioGroup > renders with neutral variant table highlight correctly 1`]
 
 exports[`RadioGroup > renders with primary variant card correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if--><label data-slot="item" class="flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row text-sm hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:border-accented p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden focus-visible:outline-none size-4" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
         <!--v-if-->
@@ -1217,7 +1217,7 @@ exports[`RadioGroup > renders with primary variant card correctly 1`] = `
 
 exports[`RadioGroup > renders with primary variant card highlight correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if--><label data-slot="item" class="flex items-start border border-default rounded-lg hover:not-has-disabled:not-has-focus-visible:not-has-data-[state=checked]:bg-elevated/50 transition-colors flex-row text-sm p-3.5 outline-primary/25 has-focus-visible:outline-3 not-has-disabled:has-focus-visible:border-primary has-focus-visible:z-[1] has-data-[state=checked]:border-primary/50 has-data-[state=checked]:bg-primary/10">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset overflow-hidden focus-visible:outline-none size-4 ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
         <!--v-if-->
@@ -1257,7 +1257,7 @@ exports[`RadioGroup > renders with primary variant card highlight correctly 1`] 
 
 exports[`RadioGroup > renders with primary variant list correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -1297,7 +1297,7 @@ exports[`RadioGroup > renders with primary variant list correctly 1`] = `
 
 exports[`RadioGroup > renders with primary variant list highlight correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -1417,7 +1417,7 @@ exports[`RadioGroup > renders with primary variant table highlight correctly 1`]
 
 exports[`RadioGroup > renders with required correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="true">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <legend data-slot="legend" class="mb-1 block font-medium text-default text-sm after:content-['*'] after:ms-0.5 after:text-error">Legend</legend>
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="true" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -1459,7 +1459,7 @@ exports[`RadioGroup > renders with required correctly 1`] = `
 
 exports[`RadioGroup > renders with size lg correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4.5 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -1499,7 +1499,7 @@ exports[`RadioGroup > renders with size lg correctly 1`] = `
 
 exports[`RadioGroup > renders with size md correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>
@@ -1539,7 +1539,7 @@ exports[`RadioGroup > renders with size md correctly 1`] = `
 
 exports[`RadioGroup > renders with size sm correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-0.5">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-0.5">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-xs">
       <div data-slot="container" class="flex items-center h-4"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-3.5 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1"></span></button>
@@ -1579,7 +1579,7 @@ exports[`RadioGroup > renders with size sm correctly 1`] = `
 
 exports[`RadioGroup > renders with size xl correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1.5">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1.5">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-base">
       <div data-slot="container" class="flex items-center h-6"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-5 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-2"></span></button>
@@ -1619,7 +1619,7 @@ exports[`RadioGroup > renders with size xl correctly 1`] = `
 
 exports[`RadioGroup > renders with size xs correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-0.5">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-0.5">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-xs">
       <div data-slot="container" class="flex items-center h-4"><button id="v-0-0:1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-3 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1"></span></button>
@@ -1659,7 +1659,7 @@ exports[`RadioGroup > renders with size xs correctly 1`] = `
 
 exports[`RadioGroup > renders with ui correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:1" role="radio" type="button" aria-checked="false" data-state="unchecked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="1">
@@ -1701,7 +1701,7 @@ exports[`RadioGroup > renders with ui correctly 1`] = `
 
 exports[`RadioGroup > renders with valueKey correctly 1`] = `
 "<div id="v-0-0" data-slot="root" class="relative" tabindex="0" data-orientation="vertical" dir="ltr" style="outline-color: none; outline-style: none; outline-width: initial;" role="radiogroup" aria-orientation="vertical" aria-required="false">
-  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-col gap-y-1">
+  <fieldset data-slot="fieldset" class="flex gap-x-2 flex-wrap flex-col gap-y-1">
     <!--v-if-->
     <div data-slot="item" class="flex items-start flex-row text-sm">
       <div data-slot="container" class="flex items-center h-5"><button id="v-0-0:Option 1" role="radio" type="button" aria-checked="true" data-state="checked" required="false" data-reka-collection-item="" tabindex="-1" data-orientation="vertical" data-active="" data-slot="base" class="rounded-full ring ring-inset ring-accented overflow-hidden size-4 outline-primary/25 focus-visible:outline-solid focus-visible:outline-3 focus-visible:ring-primary" value="Option 1"><span data-state="checked" data-slot="indicator" class="flex items-center justify-center size-full after:bg-default after:rounded-full bg-primary after:size-1.5"></span></button>

--- a/test/nuxt/.nuxtrc
+++ b/test/nuxt/.nuxtrc
@@ -1,1 +1,1 @@
-setups.@nuxt/test-utils="4.1.0"
+setups.@nuxt/test-utils="4.2.0"


### PR DESCRIPTION
### 🔗 Linked issue

Closes #6912

### ❓ Type of change

Not sure if it should be considered a bug fix or a breaking change.

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [x] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This PR adds `.flex-wrap` to the fieldset element of both `CheckboxGroup` and `RadioGroup`. This improves how the children checkboxes and radios are rendered in narrow containers.

Without wrapping, the root element currently ends up overflowing its container.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
