### PR TITLE
docs: fix raw markdown served to agents

### DIFF
--- a/docs/app/pages/docs/[...slug].vue
+++ b/docs/app/pages/docs/[...slug].vue
@@ -1,5 +1,4 @@
 <script setup lang="ts">
-import { joinURL } from 'ufo'
 import { kebabCase } from 'scule'
 import type { ContentNavigationItem } from '@nuxt/content'
 
@@ -77,8 +76,6 @@ useSeoMeta({
 const path = computed(() => route.path.replace(/\/$/, ''))
 
 if (import.meta.server) {
-  prerenderRoutes([joinURL('/raw', `${path.value}.md`)])
-
   if (route.path.startsWith('/docs/components/')) {
     defineOgImage('Component.takumi', {
       title: page.value.title,

--- a/docs/app/pages/index.vue
+++ b/docs/app/pages/index.vue
@@ -10,8 +10,6 @@ const { url } = useSiteConfig()
 const appConfig = useAppConfig()
 
 if (import.meta.server) {
-  prerenderRoutes(['/raw/index.md'])
-
   useSchemaOrg([
     defineSoftwareApp({
       name: 'Nuxt UI',

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -214,8 +214,9 @@ export default defineNuxtConfig({
         '/',
         '/docs/getting-started',
         '/openapi.json',
-        // Also prerendered through `prerenderRoutes()` in `app/pages/index.vue`;
-        // listed here so the guarantee does not hang off a page component.
+        // Also registered by `nuxt-agent-discovery` for the `/` route in
+        // `agentDiscovery.routes`; listed here so the guarantee does not hang off
+        // the module config.
         '/raw/index.md',
         '/api/countries.json',
         '/api/phone-codes.json',

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -445,13 +445,19 @@ export default defineNuxtConfig({
       title: 'Components',
       contentCollection: 'docs',
       contentFilters: [
-        { field: 'path', operator: 'LIKE', value: '/docs/components/%' }
+        { field: 'path', operator: 'LIKE', value: '/docs/components%' }
       ]
     }, {
       title: 'Composables',
       contentCollection: 'docs',
       contentFilters: [
         { field: 'path', operator: 'LIKE', value: '/docs/composables/%' }
+      ]
+    }, {
+      title: 'Typography',
+      contentCollection: 'docs',
+      contentFilters: [
+        { field: 'path', operator: 'LIKE', value: '/docs/typography%' }
       ]
     }],
     notes: [

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -214,10 +214,6 @@ export default defineNuxtConfig({
         '/',
         '/docs/getting-started',
         '/openapi.json',
-        // Also registered by `nuxt-agent-discovery` for the `/` route in
-        // `agentDiscovery.routes`; listed here so the guarantee does not hang off
-        // the module config.
-        '/raw/index.md',
         '/api/countries.json',
         '/api/phone-codes.json',
         '/api/locales.json',

--- a/docs/nuxt.config.ts
+++ b/docs/nuxt.config.ts
@@ -451,7 +451,7 @@ export default defineNuxtConfig({
       title: 'Composables',
       contentCollection: 'docs',
       contentFilters: [
-        { field: 'path', operator: 'LIKE', value: '/docs/composables/%' }
+        { field: 'path', operator: 'LIKE', value: '/docs/composables%' }
       ]
     }, {
       title: 'Typography',

--- a/docs/package.json
+++ b/docs/package.json
@@ -45,7 +45,7 @@
     "minimark": "^0.2.0",
     "motion-v": "^2.4.0",
     "nuxt": "^4.5.2",
-    "nuxt-agent-discovery": "^0.3.0",
+    "nuxt-agent-discovery": "^0.4.0",
     "nuxt-component-meta": "^0.18.0",
     "nuxt-llms": "^0.2.0",
     "nuxt-og-image": "^6.7.8",

--- a/docs/package.json
+++ b/docs/package.json
@@ -45,7 +45,7 @@
     "minimark": "^0.2.0",
     "motion-v": "^2.4.0",
     "nuxt": "^4.5.2",
-    "nuxt-agent-discovery": "^0.1.1",
+    "nuxt-agent-discovery": "^0.3.0",
     "nuxt-component-meta": "^0.18.0",
     "nuxt-llms": "^0.2.0",
     "nuxt-og-image": "^6.7.8",

--- a/docs/server/utils/markdown.ts
+++ b/docs/server/utils/markdown.ts
@@ -1,4 +1,4 @@
-import { SITE_URL } from './site'
+import { textContent } from 'minimark'
 
 /**
  * Markdown builders for what `minimark/stringify` cannot express in its
@@ -6,62 +6,61 @@ import { SITE_URL } from './site'
  * comes out as HTML, and its `pre` handler always opens a three-backtick
  * fence, which code carrying fences of its own breaks out of. Both return a
  * string to drop into the tree as a paragraph, which the stringifier passes
- * through untouched.
+ * through untouched. Links stay as written: `nuxt-agent-discovery` absolutizes
+ * the stringified document afterwards, table rows included.
  */
 
-type Node = string | [string, Record<string, any>, ...Node[]]
-
-function textContent(node: Node): string {
-  if (typeof node === 'string') return node
-  return node.slice(2).map(child => textContent(child as Node)).join('')
-}
-
-// The tree is absolutized by `nuxt-agent-discovery` after the hook, which a
-// pre-rendered string escapes, so links are resolved here the same way.
-function absolutize(url: unknown): string {
-  const value = String(url ?? '')
-  return value.startsWith('/') && !value.startsWith('//') ? `${SITE_URL}${value}` : value
+/**
+ * A backtick run that cannot be closed early by the text: one longer than
+ * any run of `minimum` or more backticks inside it, and at least `minimum`.
+ */
+function backticks(text: string, minimum: number): string {
+  const runs = Array.from(text.matchAll(new RegExp(`\`{${minimum},}`, 'g')), match => match[0].length)
+  return '`'.repeat(Math.max(minimum - 1, ...runs) + 1)
 }
 
 /** Renders the inline nodes a table cell can hold to markdown. */
-export function inlineMarkdown(node: Node): string {
+function inlineMarkdown(node: any): string {
   if (typeof node === 'string') return node
   const [tag, attrs = {}, ...children] = node
-  const inner = () => children.map(child => inlineMarkdown(child as Node)).join('')
+  const inner = () => children.map(inlineMarkdown).join('')
 
   switch (tag) {
-    case 'code': return `\`${textContent(node)}\``
-    case 'a': return `[${inner()}](${absolutize(attrs.href)})`
+    case 'code': {
+      const text = textContent(node)
+      const fence = backticks(text, 1)
+      // A space keeps a leading or trailing backtick apart from the fence.
+      return /^`|`$/.test(text) ? `${fence} ${text} ${fence}` : `${fence}${text}${fence}`
+    }
+    case 'a': return `[${inner()}](${attrs.href})`
     case 'strong':
     case 'b': return `**${inner()}**`
     case 'em':
     case 'i': return `*${inner()}*`
     case 'del': return `~~${inner()}~~`
-    case 'img': return `![${attrs.alt || ''}](${absolutize(attrs.src)})`
-    case 'br': return ' '
+    case 'img': return `![${attrs.alt || ''}](${attrs.src})`
+    // The one line break a pipe cell can hold.
+    case 'br': return '<br>'
     default: return inner()
   }
 }
 
-function cell(node: Node): string {
-  const content = typeof node === 'string' ? node : node.slice(2).map(child => inlineMarkdown(child as Node)).join('')
-  return content.replace(/\s+/g, ' ').replace(/\|/g, '\\|').trim()
+function cell(node: any): string {
+  return inlineMarkdown(node).replace(/\s+/g, ' ').replace(/\|/g, '\\|').trim()
 }
 
 /** A `table` node as a GFM pipe table, the first row serving as header. */
-export function pipeTable(table: Node): string {
+export function pipeTable(table: any[]): string {
   const rows: string[][] = []
-  const collect = (nodes: Node[]) => {
-    for (const node of nodes) {
-      if (!Array.isArray(node)) continue
-      if (node[0] === 'tr') {
-        rows.push(node.slice(2).filter(child => Array.isArray(child)).map(child => cell(child as Node)))
-      } else {
-        collect(node.slice(2) as Node[])
+  for (const section of table.slice(2)) {
+    if (!Array.isArray(section)) continue
+    // Rows sit under `thead` and `tbody`; a bare `tr` is tolerated too.
+    for (const row of section[0] === 'tr' ? [section] : section.slice(2)) {
+      if (Array.isArray(row) && row[0] === 'tr') {
+        rows.push(row.slice(2).filter(child => Array.isArray(child)).map(cell))
       }
     }
   }
-  collect(typeof table === 'string' ? [] : table.slice(2) as Node[])
 
   const [header, ...body] = rows
   if (!header?.length) return ''
@@ -72,9 +71,8 @@ export function pipeTable(table: Node): string {
   return [line(header), line(header.map(() => '---')), ...body.map(line)].join('\n')
 }
 
-/** A fenced code block whose fence is longer than any backtick run inside. */
+/** A fenced code block whose fence is longer than any fence-like run inside. */
 export function fencedBlock(code: string, language = '', filename?: string, meta?: string): string {
-  const longest = Math.max(2, ...Array.from(code.matchAll(/`{3,}/g), match => match[0].length))
-  const fence = '`'.repeat(longest + 1)
+  const fence = backticks(code, 3)
   return `${fence}${language}${filename ? ` [${filename}]` : ''}${meta || ''}\n${code.trim()}\n${fence}`
 }

--- a/docs/server/utils/markdown.ts
+++ b/docs/server/utils/markdown.ts
@@ -19,26 +19,38 @@ function backticks(text: string, minimum: number): string {
   return '`'.repeat(Math.max(minimum - 1, ...runs) + 1)
 }
 
+// GFM reads `\|` as a pipe anywhere in a cell, code spans included, while
+// every other backslash inside a code span stays literal. So plain text gets
+// both characters escaped and a code span only its pipes, joined rather than
+// replaced so a literal backslash is never doubled there.
+function escapeText(text: string): string {
+  return text.replace(/[\\|]/g, '\\$&')
+}
+
+function escapePipes(text: string): string {
+  return text.split('|').join('\\|')
+}
+
 /** Renders the inline nodes a table cell can hold to markdown. */
 function inlineMarkdown(node: any): string {
-  if (typeof node === 'string') return node
+  if (typeof node === 'string') return escapeText(node)
   const [tag, attrs = {}, ...children] = node
   const inner = () => children.map(inlineMarkdown).join('')
 
   switch (tag) {
     case 'code': {
-      const text = textContent(node)
+      const text = escapePipes(textContent(node))
       const fence = backticks(text, 1)
       // A space keeps a leading or trailing backtick apart from the fence.
       return /^`|`$/.test(text) ? `${fence} ${text} ${fence}` : `${fence}${text}${fence}`
     }
-    case 'a': return `[${inner()}](${attrs.href})`
+    case 'a': return `[${inner()}](${escapePipes(String(attrs.href ?? ''))})`
     case 'strong':
     case 'b': return `**${inner()}**`
     case 'em':
     case 'i': return `*${inner()}*`
     case 'del': return `~~${inner()}~~`
-    case 'img': return `![${attrs.alt || ''}](${attrs.src})`
+    case 'img': return `![${escapeText(String(attrs.alt ?? ''))}](${escapePipes(String(attrs.src ?? ''))})`
     // The one line break a pipe cell can hold.
     case 'br': return '<br>'
     default: return inner()
@@ -46,7 +58,7 @@ function inlineMarkdown(node: any): string {
 }
 
 function cell(node: any): string {
-  return inlineMarkdown(node).replace(/\s+/g, ' ').replace(/\|/g, '\\|').trim()
+  return inlineMarkdown(node).replace(/\s+/g, ' ').trim()
 }
 
 /** A `table` node as a GFM pipe table, the first row serving as header. */

--- a/docs/server/utils/markdown.ts
+++ b/docs/server/utils/markdown.ts
@@ -1,0 +1,80 @@
+import { SITE_URL } from './site'
+
+/**
+ * Markdown builders for what `minimark/stringify` cannot express in its
+ * `markdown/html` format: it has no pipe-table handler, so a `table` node
+ * comes out as HTML, and its `pre` handler always opens a three-backtick
+ * fence, which code carrying fences of its own breaks out of. Both return a
+ * string to drop into the tree as a paragraph, which the stringifier passes
+ * through untouched.
+ */
+
+type Node = string | [string, Record<string, any>, ...Node[]]
+
+function textContent(node: Node): string {
+  if (typeof node === 'string') return node
+  return node.slice(2).map(child => textContent(child as Node)).join('')
+}
+
+// The tree is absolutized by `nuxt-agent-discovery` after the hook, which a
+// pre-rendered string escapes, so links are resolved here the same way.
+function absolutize(url: unknown): string {
+  const value = String(url ?? '')
+  return value.startsWith('/') && !value.startsWith('//') ? `${SITE_URL}${value}` : value
+}
+
+/** Renders the inline nodes a table cell can hold to markdown. */
+export function inlineMarkdown(node: Node): string {
+  if (typeof node === 'string') return node
+  const [tag, attrs = {}, ...children] = node
+  const inner = () => children.map(child => inlineMarkdown(child as Node)).join('')
+
+  switch (tag) {
+    case 'code': return `\`${textContent(node)}\``
+    case 'a': return `[${inner()}](${absolutize(attrs.href)})`
+    case 'strong':
+    case 'b': return `**${inner()}**`
+    case 'em':
+    case 'i': return `*${inner()}*`
+    case 'del': return `~~${inner()}~~`
+    case 'img': return `![${attrs.alt || ''}](${absolutize(attrs.src)})`
+    case 'br': return ' '
+    default: return inner()
+  }
+}
+
+function cell(node: Node): string {
+  const content = typeof node === 'string' ? node : node.slice(2).map(child => inlineMarkdown(child as Node)).join('')
+  return content.replace(/\s+/g, ' ').replace(/\|/g, '\\|').trim()
+}
+
+/** A `table` node as a GFM pipe table, the first row serving as header. */
+export function pipeTable(table: Node): string {
+  const rows: string[][] = []
+  const collect = (nodes: Node[]) => {
+    for (const node of nodes) {
+      if (!Array.isArray(node)) continue
+      if (node[0] === 'tr') {
+        rows.push(node.slice(2).filter(child => Array.isArray(child)).map(child => cell(child as Node)))
+      } else {
+        collect(node.slice(2) as Node[])
+      }
+    }
+  }
+  collect(typeof table === 'string' ? [] : table.slice(2) as Node[])
+
+  const [header, ...body] = rows
+  if (!header?.length) return ''
+
+  const width = header.length
+  const line = (cells: string[]) => `| ${Array.from({ length: width }, (_, i) => cells[i] ?? '').join(' | ')} |`
+
+  return [line(header), line(header.map(() => '---')), ...body.map(line)].join('\n')
+}
+
+/** A fenced code block whose fence is longer than any backtick run inside. */
+export function fencedBlock(code: string, language = '', filename?: string, meta?: string): string {
+  const longest = Math.max(2, ...Array.from(code.matchAll(/`{3,}/g), match => match[0].length))
+  const fence = '`'.repeat(longest + 1)
+  return `${fence}${language}${filename ? ` [${filename}]` : ''}${meta || ''}\n${code.trim()}\n${fence}`
+}

--- a/docs/server/utils/transformMDC.ts
+++ b/docs/server/utils/transformMDC.ts
@@ -6,6 +6,7 @@ import { queryCollection } from '@nuxt/content/server'
 import * as theme from '../../.nuxt/ui'
 import meta from '#nuxt-component-meta'
 import { compactProps, getDefaultVariants, hasLinkPassthrough, partitionLinkProps } from './componentMeta'
+import { fencedBlock, pipeTable } from './markdown'
 // @ts-expect-error - no types available
 import { getComponentExample } from '#component-example/nitro'
 
@@ -125,6 +126,38 @@ function replaceNodeWithPre(node: any[], language: string, code: string, filenam
   node[0] = 'pre'
   node[1] = { language, code }
   if (filename) node[1].filename = filename
+}
+
+// A paragraph holding ready-made markdown: the stringifier writes a string
+// child as is, so this is how a block it has no handler for gets through.
+function replaceNodeWithMarkdown(node: any[], markdown: string) {
+  node[0] = 'p'
+  node[1] = {}
+  node[2] = markdown
+  node.length = 3
+}
+
+// A preview without a `#code` slot is a component demo written in MDC, so
+// the closest thing to its source is the tree read back as a template.
+function templateSnippet(nodes: any[]): string {
+  return nodes.map((child) => {
+    if (typeof child === 'string') return child
+    if (!Array.isArray(child)) return ''
+
+    const [tag, attrs = {}, ...content] = child
+    const attributes = Object.entries(attrs)
+      .filter(([key, value]) => key !== 'style' && value !== '' && value !== undefined && value !== null)
+      .map(([key, value]) => {
+        if (key === 'className') return `class="${(Array.isArray(value) ? value : [value]).join(' ')}"`
+        if (typeof value === 'string') return `${key}="${value}"`
+        if (typeof value === 'object') return `:${key}="${stringifyValue(value, '\'')}"`
+        return `:${key}="${value}"`
+      })
+    const open = `<${tag}${attributes.length ? ` ${attributes.join(' ')}` : ''}`
+    const inner = templateSnippet(content).trim()
+
+    return inner ? `${open}>\n  ${inner.split('\n').join('\n  ')}\n</${tag}>` : `${open} />`
+  }).filter(Boolean).join('\n')
 }
 
 function visitAndReplace(doc: Document, type: string, handler: (node: any[]) => void) {
@@ -678,7 +711,9 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
 
     const allChildren: any[] = []
     if (title) {
-      allChildren.push(['p', {}, ['strong', {}, title]])
+      // `strong` stringifies to its text alone, so the link has to wrap it.
+      const heading = ['strong', {}, title]
+      allChildren.push(['p', {}, attrs.to ? ['a', { href: attrs.to }, heading] : heading])
     }
     allChildren.push(...collectBlockChildren(content))
 
@@ -742,6 +777,12 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
     }
   }
 
+  // minimark has no pipe-table handler and writes every table as HTML, so the
+  // rows are rendered here, each cell reduced to inline markdown.
+  visitAndReplace(doc, 'table', (node) => {
+    replaceNodeWithMarkdown(node, pipeTable(node as any))
+  })
+
   // Remove wrapper elements by extracting children content
   const wrapperTypes = ['card-group', 'accordion', 'steps', 'code-group', 'code-collapse', 'tabs', 'div']
   for (const wrapperType of wrapperTypes) {
@@ -797,42 +838,21 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
     })
   }
 
-  // Transform code-preview to extract the Vue code as a code block
+  // Transform code-preview: the `#code` slot holds the literal source, which
+  // is what an agent wants, and the rendered preview is dropped. Without a
+  // code slot the preview itself is the demo, read back as a template.
   visitAndReplace(doc, 'code-preview', (node) => {
     const children = node.slice(2)
+    const codeSlot = children.find(child => Array.isArray(child) && child[0] === 'template' && child[1]?.['v-slot:code'] !== undefined)
 
-    const extractVueCode = (nodes: any[]): string => {
-      return nodes.map((child: any) => {
-        if (typeof child === 'string') return child
-        if (Array.isArray(child)) {
-          const tag = child[0]
-          const attrs = child[1] || {}
-          const content = child.slice(2)
-          // Build the opening tag
-          let tagStr = `<${tag}`
-          for (const [key, val] of Object.entries(attrs)) {
-            if (key.startsWith(':') || key.startsWith('v-')) {
-              tagStr += ` ${key}=${val}`
-            } else if (typeof val === 'string') {
-              tagStr += ` ${key}=${val}`
-            }
-          }
-          const innerContent = extractVueCode(content)
-          if (innerContent.trim()) {
-            tagStr += `>\n${innerContent}</${tag}>`
-          } else {
-            tagStr += ' />'
-          }
-          return tagStr
-        }
-        return ''
-      }).join('\n')
+    if (codeSlot) {
+      replaceWithChildren(node, codeSlot.slice(2))
+      return
     }
 
-    const vueCode = extractVueCode(children).trim()
-    node[0] = 'pre'
-    node[1] = { language: 'vue', code: `<template>\n  ${vueCode.split('\n').join('\n  ')}\n</template>` }
-    node.length = 2
+    const preview = children.filter(child => !(Array.isArray(child) && child[0] === 'template'))
+    const snippet = templateSnippet(preview)
+    replaceNodeWithPre(node, 'vue', `<template>\n  ${snippet.split('\n').join('\n  ')}\n</template>`)
   })
 
   // Transform icons-theme and icons-theme-select to placeholder
@@ -873,6 +893,57 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
       node[1] = {}
       node[2] = label
       node.length = 3
+    }
+  })
+
+  // Inline components with no markdown of their own. A kbd becomes inline
+  // code with a readable label (minimark writes inline HTML on its own lines,
+  // so `<kbd>` is not an option), a styled span is unwrapped to its text, and
+  // a decorative icon or an interactive widget is dropped.
+  const kbdLabels: Record<string, string> = {
+    meta: 'Meta',
+    ctrl: 'Ctrl',
+    alt: 'Alt',
+    option: 'Option',
+    shift: 'Shift',
+    enter: 'Enter',
+    escape: 'Esc',
+    backspace: 'Backspace',
+    tab: 'Tab',
+    space: 'Space',
+    arrowup: '↑',
+    arrowdown: '↓',
+    arrowleft: '←',
+    arrowright: '→'
+  }
+  visitAndReplace(doc, 'kbd', (node) => {
+    const value = String(node[1]?.value ?? '')
+    node[0] = 'code'
+    node[1] = {}
+    node[2] = kbdLabels[value.toLowerCase()] ?? value
+    node.length = 3
+  })
+
+  visitAndReplace(doc, 'span', (node) => {
+    node[0] = '__flatten'
+    node[1] = {}
+  })
+
+  for (const dropped of ['icon', 'prose-icon', 'u-color-mode-select']) {
+    visitAndReplace(doc, dropped, (node) => {
+      node[0] = '__flatten'
+      node[1] = {}
+      node.length = 2
+    })
+  }
+
+  // minimark always opens a three-backtick fence, which code holding fences
+  // of its own (the typography pages documenting code blocks) breaks out of.
+  visitAndReplace(doc, 'pre', (node) => {
+    const attrs = node[1] || {}
+    const code = String(attrs.code ?? '')
+    if (code.includes('```')) {
+      replaceNodeWithMarkdown(node, fencedBlock(code, attrs.language, attrs.filename, attrs.meta))
     }
   })
 

--- a/docs/server/utils/transformMDC.ts
+++ b/docs/server/utils/transformMDC.ts
@@ -2,6 +2,7 @@ import type { H3Event } from 'h3'
 import json5 from 'json5'
 import { camelCase, kebabCase } from 'scule'
 import { visit } from '@nuxt/content/runtime'
+import { textContent } from 'minimark'
 import { queryCollection } from '@nuxt/content/server'
 import * as theme from '../../.nuxt/ui'
 import meta from '#nuxt-component-meta'
@@ -71,6 +72,38 @@ const CAST_TEMPLATES: Record<string, (raw: any) => string> = {
   }
 }
 
+// Readable labels for the keys `useKbd` renders as glyphs or per platform.
+// Anything else (a letter, a digit, `/`) is its own label.
+const KBD_LABELS: Record<string, string> = {
+  meta: 'Meta',
+  cmd: 'Cmd',
+  command: 'Cmd',
+  ctrl: 'Ctrl',
+  control: 'Ctrl',
+  alt: 'Alt',
+  option: 'Option',
+  win: 'Win',
+  shift: 'Shift',
+  enter: 'Enter',
+  escape: 'Esc',
+  backspace: 'Backspace',
+  delete: 'Delete',
+  tab: 'Tab',
+  space: 'Space',
+  capslock: 'CapsLock',
+  pageup: 'PageUp',
+  pagedown: 'PageDown',
+  home: 'Home',
+  end: 'End',
+  arrowup: '↑',
+  arrowdown: '↓',
+  arrowleft: '←',
+  arrowright: '→'
+}
+
+// Inline components with nothing to say in markdown.
+const DROPPED_INLINE = new Set(['icon', 'prose-icon', 'u-color-mode-select'])
+
 const CAST_IMPORTS: Record<string, { name: string, from: string }> = {
   'DateValue': { name: 'CalendarDate', from: '@internationalized/date' },
   'DateValue[]': { name: 'CalendarDate', from: '@internationalized/date' },
@@ -126,6 +159,34 @@ function replaceNodeWithPre(node: any[], language: string, code: string, filenam
   node[0] = 'pre'
   node[1] = { language, code }
   if (filename) node[1].filename = filename
+  // The stringifier reads `code`, so the slot content the node held is dead
+  // weight every later pass would otherwise keep walking.
+  node.length = 2
+}
+
+// A Vue attribute for a template snippet. Bound props arrive as `:key` with
+// a JSON string value, which is re-emitted as a single-quoted object literal
+// so the double quotes of the attribute survive.
+function templateAttribute(key: string, value: unknown): string {
+  const quote = (text: string) => `"${text.replace(/"/g, '&quot;')}"`
+
+  if (key === 'className') {
+    return `class=${quote((Array.isArray(value) ? value : [value]).join(' '))}`
+  }
+  if (typeof value === 'string') {
+    if (key.startsWith(':')) {
+      try {
+        return `${key}=${quote(stringifyValue(json5.parse(value), '\''))}`
+      } catch {
+        // Not JSON: a bound expression, emitted as written.
+      }
+    }
+    return `${key}=${quote(value)}`
+  }
+  if (typeof value === 'object') {
+    return `:${key}=${quote(stringifyValue(value, '\''))}`
+  }
+  return `:${key}="${value}"`
 }
 
 // A paragraph holding ready-made markdown: the stringifier writes a string
@@ -147,12 +208,7 @@ function templateSnippet(nodes: any[]): string {
     const [tag, attrs = {}, ...content] = child
     const attributes = Object.entries(attrs)
       .filter(([key, value]) => key !== 'style' && value !== '' && value !== undefined && value !== null)
-      .map(([key, value]) => {
-        if (key === 'className') return `class="${(Array.isArray(value) ? value : [value]).join(' ')}"`
-        if (typeof value === 'string') return `${key}="${value}"`
-        if (typeof value === 'object') return `:${key}="${stringifyValue(value, '\'')}"`
-        return `:${key}="${value}"`
-      })
+      .map(([key, value]) => templateAttribute(key, value))
     const open = `<${tag}${attributes.length ? ` ${attributes.join(' ')}` : ''}`
     const inner = templateSnippet(content).trim()
 
@@ -202,9 +258,11 @@ function replaceWithChildren(node: any[], newChildren: any[]) {
   }
 }
 
-function flattenMarkers(node: any): void {
+// `start` is 2 for a `[tag, attrs, ...children]` node and 0 for the root
+// children array, whose first two entries are blocks like any other.
+function flattenMarkers(node: any, start = 2): void {
   if (!Array.isArray(node)) return
-  let i = 2
+  let i = start
   while (i < node.length) {
     const child = node[i]
     if (Array.isArray(child) && (child[0] === '__flatten' || child[0] === 'div')) {
@@ -630,6 +688,25 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
     node.length = 7
   })
 
+  // Transform code-preview: the `#code` slot holds the literal source, which
+  // is what an agent wants, and the rendered preview is dropped. Without a
+  // code slot the preview itself is the demo, read back as a template. Runs
+  // before the wrappers are unwrapped, since a preview inside `::tabs` would
+  // otherwise be dissolved into its parts and its rendered heading kept.
+  visitAndReplace(doc, 'code-preview', (node) => {
+    const children = node.slice(2)
+    const codeSlot = children.find(child => Array.isArray(child) && child[0] === 'template' && child[1]?.['v-slot:code'] !== undefined)
+
+    if (codeSlot) {
+      replaceWithChildren(node, codeSlot.slice(2))
+      return
+    }
+
+    const preview = children.filter(child => !(Array.isArray(child) && child[0] === 'template'))
+    const snippet = templateSnippet(preview)
+    replaceNodeWithPre(node, 'vue', `<template>\n  ${snippet.split('\n').join('\n  ')}\n</template>`)
+  })
+
   // Transform callout components (tip, note, warning, caution, callout) to blockquotes
   const calloutTypes = ['tip', 'note', 'warning', 'caution', 'callout']
   const calloutLabels: Record<string, string> = {
@@ -777,12 +854,6 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
     }
   }
 
-  // minimark has no pipe-table handler and writes every table as HTML, so the
-  // rows are rendered here, each cell reduced to inline markdown.
-  visitAndReplace(doc, 'table', (node) => {
-    replaceNodeWithMarkdown(node, pipeTable(node as any))
-  })
-
   // Remove wrapper elements by extracting children content
   const wrapperTypes = ['card-group', 'accordion', 'steps', 'code-group', 'code-collapse', 'tabs', 'div']
   for (const wrapperType of wrapperTypes) {
@@ -838,23 +909,6 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
     })
   }
 
-  // Transform code-preview: the `#code` slot holds the literal source, which
-  // is what an agent wants, and the rendered preview is dropped. Without a
-  // code slot the preview itself is the demo, read back as a template.
-  visitAndReplace(doc, 'code-preview', (node) => {
-    const children = node.slice(2)
-    const codeSlot = children.find(child => Array.isArray(child) && child[0] === 'template' && child[1]?.['v-slot:code'] !== undefined)
-
-    if (codeSlot) {
-      replaceWithChildren(node, codeSlot.slice(2))
-      return
-    }
-
-    const preview = children.filter(child => !(Array.isArray(child) && child[0] === 'template'))
-    const snippet = templateSnippet(preview)
-    replaceNodeWithPre(node, 'vue', `<template>\n  ${snippet.split('\n').join('\n  ')}\n</template>`)
-  })
-
   // Transform icons-theme and icons-theme-select to placeholder
   visitAndReplace(doc, 'icons-theme', (node) => {
     node[0] = 'p'
@@ -900,27 +954,12 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
   // code with a readable label (minimark writes inline HTML on its own lines,
   // so `<kbd>` is not an option), a styled span is unwrapped to its text, and
   // a decorative icon or an interactive widget is dropped.
-  const kbdLabels: Record<string, string> = {
-    meta: 'Meta',
-    ctrl: 'Ctrl',
-    alt: 'Alt',
-    option: 'Option',
-    shift: 'Shift',
-    enter: 'Enter',
-    escape: 'Esc',
-    backspace: 'Backspace',
-    tab: 'Tab',
-    space: 'Space',
-    arrowup: '↑',
-    arrowdown: '↓',
-    arrowleft: '←',
-    arrowright: '→'
-  }
   visitAndReplace(doc, 'kbd', (node) => {
-    const value = String(node[1]?.value ?? '')
+    // `:kbd{value="K"}` carries its key as an attribute, `<kbd>K</kbd>` as text.
+    const value = String(node[1]?.value ?? textContent(node as any))
     node[0] = 'code'
     node[1] = {}
-    node[2] = kbdLabels[value.toLowerCase()] ?? value
+    node[2] = KBD_LABELS[value.toLowerCase()] ?? value
     node.length = 3
   })
 
@@ -929,13 +968,21 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
     node[1] = {}
   })
 
-  for (const dropped of ['icon', 'prose-icon', 'u-color-mode-select']) {
-    visitAndReplace(doc, dropped, (node) => {
+  visit(doc.body, (node) => {
+    if (Array.isArray(node) && DROPPED_INLINE.has(node[0])) {
       node[0] = '__flatten'
       node[1] = {}
       node.length = 2
-    })
-  }
+    }
+    return true
+  }, node => node)
+
+  // minimark has no pipe-table handler and writes every table as HTML, so the
+  // rows are rendered here, each cell reduced to inline markdown. Last of the
+  // inline passes, so a kbd or icon inside a cell has already been reduced.
+  visitAndReplace(doc, 'table', (node) => {
+    replaceNodeWithMarkdown(node, pipeTable(node))
+  })
 
   // minimark always opens a three-backtick fence, which code holding fences
   // of its own (the typography pages documenting code blocks) breaks out of.
@@ -949,9 +996,9 @@ export async function transformMDC(event: H3Event, doc: Document): Promise<Docum
 
   // Flatten __flatten markers by splicing their children into parents
   if (Array.isArray(doc.body)) {
-    flattenMarkers(doc.body)
+    flattenMarkers(doc.body, 0)
   } else if (doc.body?.value && Array.isArray(doc.body.value)) {
-    flattenMarkers(doc.body.value)
+    flattenMarkers(doc.body.value, 0)
   }
 
   return doc

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,8 +429,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(5c792d2c2a669ceedb3253d439575f90)
       nuxt-agent-discovery:
-        specifier: ^0.3.0
-        version: 0.3.0(32a1e1d3c93ae0568bb8fb3ad3ce53f4)
+        specifier: ^0.4.0
+        version: 0.4.0(32a1e1d3c93ae0568bb8fb3ad3ce53f4)
       nuxt-component-meta:
         specifier: ^0.18.0
         version: 0.18.0(@oxc-project/types@0.146.0)(esbuild@0.28.0)(magicast@0.5.4)(rolldown@1.2.5)(rollup@4.60.4)(vite@8.2.2(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
@@ -6875,8 +6875,8 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  nuxt-agent-discovery@0.3.0:
-    resolution: {integrity: sha512-H4rRJj7arra4zr0N244WQ7PJPq6rZcuKTadl/rxbASAsNa1bs8CpQne84dWicpe1NAI7jY6JxsgYxM5s5pwP6g==}
+  nuxt-agent-discovery@0.4.0:
+    resolution: {integrity: sha512-vIeIkWacnI1qDQc+5lynpPiNBbbykluIXHmL76iTmuWY5xn/wLU1L6Rr+X7OfsID4GoCZ2zx8mQ/ZQ1MFBHULw==}
     peerDependencies:
       '@nuxt/content': ^3.0.0
       '@nuxtjs/mcp-toolkit': '>=0.19.0'
@@ -16533,7 +16533,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt-agent-discovery@0.3.0(32a1e1d3c93ae0568bb8fb3ad3ce53f4):
+  nuxt-agent-discovery@0.4.0(32a1e1d3c93ae0568bb8fb3ad3ce53f4):
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.5)(rollup@4.60.4)(vite@8.2.2(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0)))
       defu: 6.1.7

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -429,8 +429,8 @@ importers:
         specifier: ^4.5.2
         version: 4.5.2(5c792d2c2a669ceedb3253d439575f90)
       nuxt-agent-discovery:
-        specifier: ^0.1.1
-        version: 0.1.1(32a1e1d3c93ae0568bb8fb3ad3ce53f4)
+        specifier: ^0.3.0
+        version: 0.3.0(32a1e1d3c93ae0568bb8fb3ad3ce53f4)
       nuxt-component-meta:
         specifier: ^0.18.0
         version: 0.18.0(@oxc-project/types@0.146.0)(esbuild@0.28.0)(magicast@0.5.4)(rolldown@1.2.5)(rollup@4.60.4)(vite@8.2.2(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0))
@@ -6875,8 +6875,8 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  nuxt-agent-discovery@0.1.1:
-    resolution: {integrity: sha512-ms9KZ4RyqNOKBKh4kEE1AszfG91XCWDnb07RmtRadMwEQwk1PMWo97CT3QQQa28y/eJPYHigWnGsfWJ0mbgUCg==}
+  nuxt-agent-discovery@0.3.0:
+    resolution: {integrity: sha512-H4rRJj7arra4zr0N244WQ7PJPq6rZcuKTadl/rxbASAsNa1bs8CpQne84dWicpe1NAI7jY6JxsgYxM5s5pwP6g==}
     peerDependencies:
       '@nuxt/content': ^3.0.0
       '@nuxtjs/mcp-toolkit': '>=0.19.0'
@@ -16533,7 +16533,7 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nuxt-agent-discovery@0.1.1(32a1e1d3c93ae0568bb8fb3ad3ce53f4):
+  nuxt-agent-discovery@0.3.0(32a1e1d3c93ae0568bb8fb3ad3ce53f4):
     dependencies:
       '@nuxt/kit': 4.5.2(magic-string@1.2.3)(magicast@0.5.4)(oxc-parser@0.143.0)(rolldown@1.2.5)(unplugin@3.3.0(esbuild@0.28.0)(rolldown@1.2.5)(rollup@4.60.4)(vite@8.2.2(@types/node@25.9.0)(esbuild@0.28.0)(jiti@2.7.0)(terser@5.47.1)(yaml@2.9.0)))
       defu: 6.1.7

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -42,3 +42,6 @@ allowBuilds:
   esbuild: false
   unrs-resolver: false
   vue-demi: false
+
+minimumReleaseAgeExclude:
+  - 'nuxt-agent-discovery@0.3.0'

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -44,4 +44,4 @@ allowBuilds:
   vue-demi: false
 
 minimumReleaseAgeExclude:
-  - 'nuxt-agent-discovery@0.3.0'
+  - 'nuxt-agent-discovery@0.4.0'


### PR DESCRIPTION
### 🔗 Linked issue

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [x] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Bumps `nuxt-agent-discovery` from 0.1.1 to 0.4.0, drops the prerender hints the docs were adding by hand, and fixes what a check of the preview deployment turned up in the markdown we serve to agents.

**Prerender.** Since 0.3.0 every prerendered page hands Nitro's crawler its own raw twin through `x-nitro-prerender` (benjamincanac/nuxt-agent-discovery#23), so the `prerenderRoutes()` calls in `app/pages/index.vue` and `app/pages/docs/[...slug].vue` are redundant. The explicit `/raw/index.md` entry in `nitro.prerender.routes` goes too, the module has registered it for the exact `/` route since 0.1.1. Twins the raw route cannot answer as markdown (a section redirecting to its first document) are now skipped instead of failing the build (#24). 0.3.0 also stops emitting the `x-nitro-prerender` header in dev and no longer doubles the canonical `Link` pair on raw responses served through the Vercel route table.

0.4.0 then moves that canonical pair out of the leading Vercel route table into a trailing `hit` phase, so a missing twin's 404 no longer advertises a canonical for a page that does not exist, and teaches `extractSections` to ignore `##` lines inside a fenced block, which is what cut the MCP `get-documentation-page` sections short on the typography pages. Its other feature, locale roots as homepages, is a no-op here since the docs run no i18n.

**Raw markdown.** Four things were wrong on production already, none caused by the bump, all in our own `agent-discovery:document` hook or config:

- `::code-preview` was serialised from the rendered tree, so 47 pages carried Shiki `className=` spans inside a `vue` fence and `/docs/typography` had the MDC it teaches shredded one token per line. The `#code` slot holds the literal source, so that is what the hook emits now. Previews without a code slot (the page section demos) are read back as a template snippet with quoted attributes.
- `minimark/stringify` has no pipe-table handler and writes every `table` node as HTML, which is why the Expose tables of 28 pages came out as `<table>` markup. The hook now renders tables itself, cells reduced to inline markdown, with `|` escaped.
- A `pre` holding fences of its own (the typography pages documenting code blocks) broke out of the stringifier's three-backtick fence. Those are written with a fence longer than any backtick run inside.
- `::card` dropped its `to` link, so the ten template cards on the Nuxt installation page had no URL. The title is a link now.
- Inline components with no markdown of their own leaked as HTML: `:kbd` on 61 spots came out as `<kbd value="K" className="ms-px">`, `[text]{class=...}` spans and `:icon` likewise. A kbd is inline code with a readable label now (`Meta`, `Shift`, `↑`), spans are unwrapped to their text, and icons and the inline color mode select are dropped.
- `llms.txt` never listed the 22 typography pages nor `/docs/components`: there was no Typography section and the Components filter required a trailing slash.

A review pass over the preview then fixed what the first round left: bound props in the demo snippets were emitted as JSON inside double quotes, a `<kbd>` written as HTML lost its key, a flattened block among the first two of a page leaked as `<__flatten>`, and a `::code-preview` inside `::tabs` was dissolved before its handler ran so its rendered heading escaped as a real one. Tables now keep `<br>` and are rendered after the inline passes.

`minimumReleaseAgeExclude` carries the fresh release the way #6883 did for 0.1.1, to be dropped by the next deps sweep.

Two leftovers stay for a follow-up, both already on production: callouts render their `to` as a plain `See: /docs/...` line so nothing absolutizes it, and two typography sources open `::tabs` with fewer colons than the `:::code-preview` inside it, which hangs the code slot on the wrong node.

Verified against a docs build of this branch: all 183 documentation pages still have their `/raw/docs/**.md` twin, plus `/raw/index.md` and `/sitemap.md`. No raw document and no `llms-full.txt` section carries a `<table>` or a `className=` any more, the typography fences come through as literal MDC, the installation cards link to their templates, and `llms.txt` links 189 raw twins where it linked 166. The only twins no longer written at build are the section paths that redirect to their first document, which answer their 302 at request time.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
