### PR TITLE
fix(components): fall back to `md` for custom sizes in virtualizer

### DIFF
--- a/src/runtime/components/Tree.vue
+++ b/src/runtime/components/Tree.vue
@@ -190,7 +190,7 @@ const flattenedPaddingFormula = computed(() => {
     lg: { base: 3, perLevel: 7 }, // px-3, ms-5.5 + ps-1.5
     xl: { base: 3, perLevel: 7.5 } // px-3, ms-6 + ps-1.5
   }
-  const config = sizeConfig[props.size || 'md']
+  const config = sizeConfig[props.size as keyof typeof sizeConfig] ?? sizeConfig.md
   return (level: number) => `calc(var(--spacing) * ${(level - 1) * config.perLevel + config.base})`
 })
 

--- a/src/runtime/utils/virtualizer.ts
+++ b/src/runtime/utils/virtualizer.ts
@@ -8,7 +8,7 @@ function itemHasDescription(item: any, descriptionKey: string): boolean {
   return value !== undefined && value !== null && value !== ''
 }
 
-function getSize(size: string, hasDescription: boolean): number {
+function getSize(size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | (string & {}), hasDescription: boolean): number {
   const sizes = hasDescription
     ? {
         xs: 44,
@@ -31,7 +31,7 @@ function getSize(size: string, hasDescription: boolean): number {
 /**
  * Get estimate size for virtualizers that checks each item individually
  */
-export function getEstimateSize(items: any[], size: string, descriptionKey?: string, hasDescriptionSlot?: boolean): (index: number) => number {
+export function getEstimateSize(items: any[], size: 'xs' | 'sm' | 'md' | 'lg' | 'xl' | (string & {}), descriptionKey?: string, hasDescriptionSlot?: boolean): (index: number) => number {
   const sizeWithDescription = getSize(size, true)
   const sizeWithoutDescription = getSize(size, false)
 

--- a/src/runtime/utils/virtualizer.ts
+++ b/src/runtime/utils/virtualizer.ts
@@ -8,30 +8,30 @@ function itemHasDescription(item: any, descriptionKey: string): boolean {
   return value !== undefined && value !== null && value !== ''
 }
 
-function getSize(size: 'xs' | 'sm' | 'md' | 'lg' | 'xl', hasDescription: boolean): number {
-  if (hasDescription) {
-    return ({
-      xs: 44,
-      sm: 48,
-      md: 52,
-      lg: 56,
-      xl: 60
-    })[size]
-  }
+function getSize(size: string, hasDescription: boolean): number {
+  const sizes = hasDescription
+    ? {
+        xs: 44,
+        sm: 48,
+        md: 52,
+        lg: 56,
+        xl: 60
+      }
+    : {
+        xs: 24,
+        sm: 28,
+        md: 32,
+        lg: 36,
+        xl: 40
+      }
 
-  return ({
-    xs: 24,
-    sm: 28,
-    md: 32,
-    lg: 36,
-    xl: 40
-  })[size]
+  return sizes[size as keyof typeof sizes] ?? sizes.md
 }
 
 /**
  * Get estimate size for virtualizers that checks each item individually
  */
-export function getEstimateSize(items: any[], size: 'xs' | 'sm' | 'md' | 'lg' | 'xl', descriptionKey?: string, hasDescriptionSlot?: boolean): (index: number) => number {
+export function getEstimateSize(items: any[], size: string, descriptionKey?: string, hasDescriptionSlot?: boolean): (index: number) => number {
   const sizeWithDescription = getSize(size, true)
   const sizeWithoutDescription = getSize(size, false)
 

--- a/test/components/Tree.spec.ts
+++ b/test/components/Tree.spec.ts
@@ -73,6 +73,17 @@ describe('Tree', () => {
     ['with dynamic slot', { props, slots: { app: () => 'dynamic slot' } }]
   ])
 
+  it('does not throw when flattened with a custom theme size', async () => {
+    const wrapper = await mountSuspended(Tree, {
+      props: {
+        items: [{ label: 'app', defaultExpanded: true, children: items }],
+        nested: false,
+        size: 'xxs' as any
+      }
+    })
+    expect(wrapper.exists()).toBe(true)
+  })
+
   it('passes accessibility tests', async () => {
     const wrapper = await mountSuspended(Tree, {
       props: {

--- a/test/utils/virtualizer.spec.ts
+++ b/test/utils/virtualizer.spec.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { getEstimateSize } from '../../src/runtime/utils/virtualizer'
+
+describe('getEstimateSize', () => {
+  it('returns the size matching the theme size', () => {
+    expect(getEstimateSize([{ label: 'foo' }], 'xs')(0)).toBe(24)
+    expect(getEstimateSize([{ label: 'foo' }], 'xl')(0)).toBe(40)
+  })
+
+  it('falls back to the `md` size for a custom theme size', () => {
+    expect(getEstimateSize([{ label: 'foo' }], 'xxs')(0)).toBe(32)
+  })
+
+  it('falls back to the `md` size for a custom theme size with a description', () => {
+    const items = [{ label: 'foo', description: 'bar' }]
+
+    expect(getEstimateSize(items, 'xxs', 'description')(0)).toBe(52)
+    expect(getEstimateSize(items, 'xxs', undefined, true)(0)).toBe(52)
+  })
+
+  it('uses the larger size only for items that have a description', () => {
+    const items = [{ label: 'foo', description: 'bar' }, { label: 'baz' }]
+    const estimateSize = getEstimateSize(items, 'md', 'description')
+
+    expect(estimateSize(0)).toBe(52)
+    expect(estimateSize(1)).toBe(32)
+  })
+})

--- a/test/utils/virtualizer.spec.ts
+++ b/test/utils/virtualizer.spec.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from 'vitest'
 import { getEstimateSize } from '../../src/runtime/utils/virtualizer'
 
 describe('getEstimateSize', () => {
-  it('returns the size matching the theme size', () => {
+  it('returns the height for each built-in size', () => {
     expect(getEstimateSize([{ label: 'foo' }], 'xs')(0)).toBe(24)
     expect(getEstimateSize([{ label: 'foo' }], 'xl')(0)).toBe(40)
   })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #6916

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`getEstimateSize` maps the `size` prop to a pixel height through a closed record of the five built-in sizes, with nothing behind it. Adding a size variant in `app.config.ts` is a supported way to extend a theme, so `size` can legitimately be a value that record doesn't have, and then `getSize` hands `undefined` to the virtualizer. `@tanstack/virtual-core` keeps measurements in a `Float64Array`, so every item size and every accumulated offset turns into `NaN`, and reka-ui writes `height: NaNpx` and `translateY(NaNpx)` into the styles. The browser drops both declarations, the items stack on top of each other, and the menu looks empty. Nothing is logged, and the missing height on the virtualizer element makes it read like a CSS problem.

The lookup now falls back to the `md` height. An estimate that is off by a few pixels only shifts the scroll geometry slightly and corrects itself once reka measures the real rows, which is a much better outcome than the component rendering nothing.

`SelectMenu`, `InputMenu`, `Listbox` and `Tree` all pass their own `size` through here and were all affected. `CommandPalette` passes a literal `md` and was never hit.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
