### PR TITLE
fix(Link): wait for `onNuxtReady` before observing visibility

### DIFF
--- a/src/runtime/components/Link.vue
+++ b/src/runtime/components/Link.vue
@@ -125,7 +125,7 @@ import { useForwardProps, Slot } from 'reka-ui'
 import { defu } from 'defu'
 import { hasProtocol } from 'ufo'
 import { reactiveOmit } from '@vueuse/core'
-import { useRoute, useAppConfig, useNuxtApp } from '#imports'
+import { useRoute, useAppConfig, useNuxtApp, onNuxtReady } from '#imports'
 import { mergeClasses } from '../utils'
 import { tv } from '../utils/tv'
 import { isPartiallyEqual } from '../utils/link'
@@ -297,6 +297,7 @@ function getPrefetchListeners({ prefetch, shouldPrefetch }: NuxtLinkDefaultSlotP
 
 let idleId: ReturnType<typeof requestIdleCallback>
 let unobserve: (() => void) | null = null
+let unmounted = false
 
 onMounted(() => {
   if (!prefetchApi?.shouldPrefetch?.('visibility')) {
@@ -312,16 +313,26 @@ onMounted(() => {
     return
   }
 
-  idleId = requestIdleCallback(() => {
-    unobserve = observeIntersection(el, () => {
-      unobserve?.()
-      unobserve = null
-      onPrefetch()
+  // Like NuxtLink, wait for hydration: the payload plugin only registers its
+  // `link:prefetch` listener `onNuxtReady`, and `prefetch` marks the link as
+  // prefetched even when nobody listens.
+  onNuxtReady(() => {
+    if (unmounted) {
+      return
+    }
+
+    idleId = requestIdleCallback(() => {
+      unobserve = observeIntersection(el, () => {
+        unobserve?.()
+        unobserve = null
+        onPrefetch()
+      })
     })
   })
 })
 
 onBeforeUnmount(() => {
+  unmounted = true
   cancelIdleCallback(idleId)
   unobserve?.()
   unobserve = null


### PR DESCRIPTION
### 🔗 Linked issue

Follow-up to #6921

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Before Nuxt 4.5, `NuxtLink` observed `custom` links itself and only started the visibility observer inside `onNuxtReady`. #6921 rebuilt that observer in `ULink` but scheduled it straight from `onMounted`, so `ULink` started prefetching earlier than a plain `NuxtLink`.

This matters for two reasons:

- the `nuxt:payload` plugin registers its `link:prefetch` listener inside `onNuxtReady`, and `prefetch()` marks the link as prefetched before calling the hook. If a plugin ordered before `nuxt:payload` returns a promise from `app:suspense:resolve`, an early visible link can fire before the listener exists and never loads its payload.
- Nuxt gates prefetching on `onNuxtReady` on purpose so payload and chunk requests don't compete with hydration.

`ULink` now mirrors `NuxtLink` again: `onMounted` → `onNuxtReady` → `requestIdleCallback` → observe, with a guard so a link unmounted before hydration resolves never starts an observer.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
