### PR TITLE
fix(Form): clear only the targeted field inside a nested form

### DIFF
--- a/src/runtime/components/Form.vue
+++ b/src/runtime/components/Form.vue
@@ -439,7 +439,9 @@ const api = {
     // Clear from nested forms and collect remaining errors
     const nestedErrors: FormError[] = []
     for (const form of nestedForms.value.values()) {
-      if (matchesTarget(name, form.name)) form.api.clear()
+      // A RegExp is written against the parent's prefixed names, so it cannot be
+      // re-tested inside the nested form and clears it whole.
+      if (matchesTarget(name, form.name)) form.api.clear(name instanceof RegExp ? undefined : getNestedTarget(name, form.name || ''))
       nestedErrors.push(...getFormErrors(form as any))
     }
 

--- a/test/components/Form.spec.ts
+++ b/test/components/Form.spec.ts
@@ -551,6 +551,22 @@ describe('Form', () => {
       ])
     })
 
+    it('clear with a nested path keeps the other errors of the same nested form', async () => {
+      const nestedWrapper: any = await renderForm({ fixture: 'FormNestedFields' })
+      const nestedForm = nestedWrapper.setupState.form.value
+
+      await nestedForm.submit()
+      expect(nestedForm.errors).toMatchObject([
+        { id: 'first', name: 'nested.first' },
+        { id: 'second', name: 'nested.second' }
+      ])
+
+      nestedForm.clear('nested.first')
+      expect(nestedForm.errors).toMatchObject([
+        { id: 'second', name: 'nested.second' }
+      ])
+    })
+
     it('clear works on nested form name', async () => {
       await form.submit()
       form.clear('nested')

--- a/test/components/fixtures/FormNestedFields.vue
+++ b/test/components/fixtures/FormNestedFields.vue
@@ -1,0 +1,28 @@
+<script setup lang="ts">
+import { z } from 'zod'
+import { reactive, useTemplateRef } from 'vue'
+
+const state = reactive<any>({
+  nested: { }
+})
+
+const nestedSchema = z.object({
+  first: z.string().min(1),
+  second: z.string().min(1)
+})
+
+const form = useTemplateRef('form')
+</script>
+
+<template>
+  <UForm ref="form" :state="state">
+    <UForm name="nested" :schema="nestedSchema" nested>
+      <UFormField id="firstField" name="first">
+        <UInput id="first" v-model="state.nested.first" />
+      </UFormField>
+      <UFormField id="secondField" name="second">
+        <UInput id="second" v-model="state.nested.second" />
+      </UFormField>
+    </UForm>
+  </UForm>
+</template>


### PR DESCRIPTION
### 🔗 Linked issue

<!-- none -->

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

`form.clear(path)` is documented as "Clears form errors associated with a specific path", but when the path points into a nested form it wipes every error of that nested form instead of the one field.

Minimal reproduction:

```vue
<UForm ref="form" :state="state">
  <UForm name="nested" :schema="nestedSchema" nested>
    <UFormField name="first"><UInput v-model="state.nested.first" /></UFormField>
    <UFormField name="second"><UInput v-model="state.nested.second" /></UFormField>
  </UForm>
</UForm>
```

```ts
await form.submit()
// form.errors -> [{ name: 'nested.first' }, { name: 'nested.second' }]

form.clear('nested.first')
// form.errors -> []            (expected [{ name: 'nested.second' }])
```

Root cause: in `Form.vue`, `clear()` decides which nested forms are concerned with `matchesTarget(name, form.name)` but then delegates with `form.api.clear()` and no argument, so the child clears everything. `setErrors()` sitting right above it already translates the target with `getNestedTarget(name, form.name)` before delegating; `clear()` just never did. The defect is in this repo, not in reka-ui: `UForm` is a plain Vue component with no reka primitive involved.

A `RegExp` target keeps its current behaviour. It is written against the parent's prefixed names (`nested.first`), so it cannot be re-tested inside the child where the same error is named `first`; when it matches the nested form's own path the whole child is cleared, as before.

The test asserts that after `form.clear('nested.first')` the errors array still contains `nested.second`. Reverting the one-line change turns it red with `expected [] to match object [ { id: 'second', name: 'nested.second' } ]`. The three existing `clear` tests for nested forms (root path, nested path, nested form name, regex) are unchanged and still pass.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
