### PR TITLE
docs(theme): note layer merging breaks function slot overrides

### DIFF
--- a/docs/content/docs/1.getting-started/5.theme/3.components.md
+++ b/docs/content/docs/1.getting-started/5.theme/3.components.md
@@ -358,6 +358,13 @@ export default defineConfig({
 
 ::framework-only
 #nuxt
+:::warning
+Set a slot to a function in one place only. Nuxt merges the `app.config.ts` of every [layer](https://nuxt.com/docs/getting-started/layers) with `defuFn`, which calls your function with whatever value the key already has lower down and keeps only the result. Nuxt UI then reads a plain string, so its classes are merged onto the defaults instead of replacing them.
+:::
+::
+
+::framework-only
+#nuxt
 :::tip{to="/docs/getting-started/installation/nuxt#themeunstyled"}
 To remove the default classes from all components at once, use the `theme.unstyled` option in your `nuxt.config.ts`.
 :::


### PR DESCRIPTION
### 🔗 Linked issue

Related to #6928

### ❓ Type of change

- [x] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Nuxt merges the `app.config.ts` of every layer with `defuFn`. When a slot is set to a function and the same key already has a value lower down, another layer or `appConfig` in `nuxt.config`, `defuFn` calls that function during the merge and stores what it returns, so `app.config.ui.<component>.slots.<slot>` is already a plain string by the time Nuxt UI reads it. A string means merge, which is why the defaults come back instead of being replaced. With a single definition there is nothing under the function, it survives the merge untouched and the replace behaviour works as documented.

Nothing is left for Nuxt UI to detect once the merge has run, so this adds a warning next to the function form with the one thing that does work: keep the function in a single place. The issue stays open because the behaviour itself is unchanged. A marker object instead of a bare function (something like `replace('...')`) would go through the normal deep merge and survive any number of layers, so that would fix it properly, but it is an API addition. Happy to send that if you want it.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [x] I have updated the documentation accordingly.
