### PR TITLE
fix(SelectMenu): open menu on arrow keys

### DIFF
--- a/src/runtime/components/SelectMenu.vue
+++ b/src/runtime/components/SelectMenu.vue
@@ -491,6 +491,19 @@ function onUpdateOpen(value: boolean) {
   }
 }
 
+// `ComboboxTrigger` only toggles on click, unlike `ComboboxInput` which opens on arrow keys.
+// Since the trigger is the focusable element here, replicate the same behavior.
+function onTriggerKeydown(e: KeyboardEvent) {
+  if (isOpen.value) {
+    return
+  }
+
+  const trigger = e.currentTarget as HTMLElement
+
+  e.preventDefault()
+  trigger.click()
+}
+
 function onCreate(e: Event) {
   e.preventDefault()
   e.stopPropagation()
@@ -649,6 +662,8 @@ defineExpose({
         :class="ui.base({ class: [props.ui?.base, props.class] })"
         tabindex="0"
         v-bind="{ ...$attrs, ...ariaAttrs }"
+        @keydown.down="onTriggerKeydown"
+        @keydown.up="onTriggerKeydown"
       >
         <span v-if="isLeading || !!props.avatar || !!slots.leading" data-slot="leading" :class="ui.leading({ class: props.ui?.leading })">
           <slot name="leading" :model-value="(modelValue as ApplyModifiers<GetModelValue<T, VK, M, ExcludeItem>, Mod>)" :open="open" :ui="ui">

--- a/test/components/SelectMenu.spec.ts
+++ b/test/components/SelectMenu.spec.ts
@@ -173,6 +173,32 @@ describe('SelectMenu', () => {
     })
   })
 
+  describe('keyboard', () => {
+    test.each(['ArrowDown', 'ArrowUp'])('opens the menu on %s', async (key) => {
+      const wrapper = mount(SelectMenu, { attachTo: document.body, props: { portal: false, items } })
+
+      await wrapper.find('[data-slot="base"]').trigger('keydown', { key })
+      await flushPromises()
+
+      expect(wrapper.emitted('update:open')).toMatchObject([[true]])
+
+      wrapper.unmount()
+    })
+
+    test('does not toggle the menu on ArrowDown when already open', async () => {
+      const wrapper = mount(SelectMenu, { attachTo: document.body, props: { portal: false, items } })
+      const root = wrapper.findComponent({ name: 'ComboboxRoot' })
+
+      await root.vm.$emit('update:open', true)
+      await wrapper.find('[data-slot="base"]').trigger('keydown', { key: 'ArrowDown' })
+      await flushPromises()
+
+      expect(wrapper.emitted('update:open')).toMatchObject([[true]])
+
+      wrapper.unmount()
+    })
+  })
+
   describe('search input', () => {
     test('focuses the search input when the menu opens by default', async () => {
       const wrapper = mount(SelectMenu, { attachTo: document.body, props: { open: true, portal: false, items } })


### PR DESCRIPTION
### 🔗 Linked issue

Resolves #5082

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation or readme)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Pressing `ArrowDown` or `ArrowUp` on a focused `SelectMenu` did nothing, while `Select` opens on both.

The arrow key handling in reka-ui lives in `ComboboxInput`, which is why it works in reka-ui's own demo and in `InputMenu`. `SelectMenu` renders the search input inside the content, so the focusable element is `ComboboxTrigger`, and that one only toggles on click.

Added a `keydown` handler on the trigger that clicks it when the menu is closed, so it still goes through reka-ui's `onOpenChange` and keeps working when `open` is controlled.

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
